### PR TITLE
Fix codeql issues (install .NET 9.0)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 9.0.x
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:


### PR DESCRIPTION
Fix issue with codeql workflow.
.NET version is incorrect.NET 9 is supported by CodeQL. However, it is not pre-installed on the GitHub Actions. (Installed version is 8.x)

This PR adds extra step where correct .NET is installed

read more: https://github.com/github/codeql-action/issues/2821