### PR TITLE
Fixed wrong initial Player Character Size

### DIFF
--- a/src/NosCore.GameObject/Character.cs
+++ b/src/NosCore.GameObject/Character.cs
@@ -156,7 +156,7 @@ namespace NosCore.GameObject
 
         public byte Direction { get; set; }
 
-        public byte Size { get; set; } = 10;
+        public byte Size { get; set; } = 100;
 
         public short PositionX { get; set; }
 


### PR DESCRIPTION
Adjusted the default `Size` value in the `Character.cs` class from 10 to 100 to fix the issue of the player spawning too small.