### PR TITLE
Add OpenTelemetry wiring across all hosts

### DIFF
--- a/src/NosCore.Core/NosCore.Core.csproj
+++ b/src/NosCore.Core/NosCore.Core.csproj
@@ -35,6 +35,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageReference Include="NosCore.Dao" Version="4.0.3" />
     <PackageReference Include="NosCore.Networking" Version="7.0.0" />
     <PackageReference Include="NosCore.PathFinder" Version="2.1.0" />

--- a/src/NosCore.Core/Observability/NosCoreTelemetry.cs
+++ b/src/NosCore.Core/Observability/NosCoreTelemetry.cs
@@ -1,0 +1,57 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace NosCore.Core.Observability
+{
+    public static class NosCoreTelemetry
+    {
+        public const string ActivitySourceName = "NosCore";
+        public const string MeterName = "NosCore";
+
+        public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+        public static readonly Meter Meter = new(MeterName);
+
+        // Configured via standard OTEL env vars: OTEL_SERVICE_NAME,
+        // OTEL_RESOURCE_ATTRIBUTES, OTEL_EXPORTER_OTLP_ENDPOINT,
+        // OTEL_EXPORTER_OTLP_PROTOCOL.
+        public static IServiceCollection AddNosCoreTelemetry(this IServiceCollection services, string defaultServiceName, bool includeAspNetCore = false)
+        {
+            services.AddOpenTelemetry()
+                .ConfigureResource(rb => rb.AddService(defaultServiceName))
+                .WithTracing(t =>
+                {
+                    t.AddSource(ActivitySourceName);
+                    t.AddHttpClientInstrumentation();
+                    t.AddEntityFrameworkCoreInstrumentation();
+                    if (includeAspNetCore)
+                    {
+                        t.AddAspNetCoreInstrumentation();
+                    }
+                    t.AddOtlpExporter();
+                })
+                .WithMetrics(m =>
+                {
+                    m.AddMeter(MeterName);
+                    m.AddRuntimeInstrumentation();
+                    m.AddHttpClientInstrumentation();
+                    if (includeAspNetCore)
+                    {
+                        m.AddAspNetCoreInstrumentation();
+                    }
+                    m.AddOtlpExporter();
+                });
+
+            return services;
+        }
+    }
+}

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -21,6 +21,7 @@ using NodaTime;
 using NosCore.Core;
 using NosCore.Core.Configuration;
 using NosCore.Core.Encryption;
+using NosCore.Core.Observability;
 using NosCore.Core.Services.IdService;
 using NosCore.Dao;
 using NosCore.Dao.Interfaces;
@@ -199,6 +200,7 @@ namespace NosCore.LoginServer
                     InitializeConfiguration(args, services);
                     services.AddI18NLogs();
                     services.AddLogging(builder => builder.AddFilter("Microsoft", LogLevel.Warning));
+                    services.AddNosCoreTelemetry("NosCore.LoginServer");
 
                     services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
                     services.Configure<ConsoleLifetimeOptions>(o => o.SuppressStatusMessages = true);

--- a/src/NosCore.MasterServer/Startup.cs
+++ b/src/NosCore.MasterServer/Startup.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using NosCore.Core;
 using NosCore.Core.Encryption;
+using NosCore.Core.Observability;
 using NosCore.Core.Services.IdService;
 using NosCore.Dao;
 using NosCore.Dao.Interfaces;
@@ -214,6 +215,7 @@ namespace NosCore.MasterServer
 
             services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
             services.AddLogging(builder => builder.AddFilter("Microsoft", LogLevel.Warning));
+            services.AddNosCoreTelemetry("NosCore.MasterServer", includeAspNetCore: true);
             services.AddAuthentication(config => config.DefaultScheme = JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();
 
             services.AddSignalR(options =>

--- a/src/NosCore.WebApi/WebApiBootstrap.cs
+++ b/src/NosCore.WebApi/WebApiBootstrap.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using NosCore.Core.Configuration;
 using NosCore.Core.Encryption;
+using NosCore.Core.Observability;
 using NosCore.Dao;
 using NosCore.Dao.Interfaces;
 using NosCore.Data.Dto;
@@ -36,6 +37,7 @@ namespace NosCore.WebApi
             var builder = WebApplication.CreateBuilder(args);
             builder.Services.AddControllers();
             builder.Services.AddRazorPages();
+            builder.Services.AddNosCoreTelemetry("NosCore.WebApi", includeAspNetCore: true);
             var loginConfiguration = new ApiConfiguration();
             var conf = ConfiguratorBuilder.InitializeConfiguration(args, new[] { "logger.yml", "api.yml" });
             conf.Bind(loginConfiguration);

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -25,6 +25,7 @@ using NosCore.Core;
 using NosCore.Core.Configuration;
 using NosCore.Core.Encryption;
 using NosCore.Core.I18N;
+using NosCore.Core.Observability;
 using NosCore.Core.Services.IdService;
 using NosCore.Dao;
 using NosCore.Dao.Interfaces;
@@ -367,6 +368,7 @@ namespace NosCore.WorldServer
                     InitializeConfiguration(args, services);
 
                     services.AddLogging(builder => builder.AddFilter("Microsoft", LogLevel.Warning));
+                    services.AddNosCoreTelemetry("NosCore.WorldServer");
 
                     services.AddI18NLogs();
                     services.AddTransient(typeof(IGameLanguageLocalizer), typeof(GameLanguageLocalizer));

--- a/test/NosCore.PacketHandlers.Tests/Login/NoS0575PacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Login/NoS0575PacketHandlerTests.cs
@@ -48,7 +48,7 @@ namespace NosCore.PacketHandlers.Tests.Login
         [TestInitialize]
         public async Task SetupAsync()
         {
-            Password = new Sha512Hasher().Hash("test");
+            Password = new Sha512Hasher().Hash("test").ToUpperInvariant();
             await TestHelpers.ResetAsync();
             Session = await TestHelpers.Instance.GenerateSessionAsync();
             AuthHttpClient = new Mock<IAuthHub>();
@@ -229,7 +229,7 @@ namespace NosCore.PacketHandlers.Tests.Login
             var encryption = new Sha512Hasher();
             await NoS0575PacketHandler.ExecuteAsync(new NoS0575Packet
             {
-                Password = encryption.Hash("test1"),
+                Password = encryption.Hash("test1").ToUpperInvariant(),
                 Username = Session.Account.Name
             }, Session);
         }


### PR DESCRIPTION
## Summary
- Introduces `AddNosCoreTelemetry()` helper in `NosCore.Core.Observability`.
- Wires it into `LoginServer`, `WorldServer`, `MasterServer`, and `WebApi` so all four hosts emit OTLP traces + metrics (HTTP client, EF Core, runtime — plus ASP.NET Core on `MasterServer`/`WebApi`) under their own `service.name`.
- Configured via standard OTEL env vars: `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`.
- **Drive-by test fix**: `NoS0575PacketHandlerSpecs` — `LoginService` uppercases `acc.Password` before comparing to the client-sent token (matching real NosTale client behavior), but the tests were sending the raw `Sha512Hasher` output (lowercase). 5 tests exercising the post-password-check path were always getting `AccountOrPasswordWrong`. Fix: `.ToUpperInvariant()` the hashed password in the test setup. Unblocks CI on master and on this branch.

## Context
First slice of #2058. This PR is self-contained and stands alone — no dependency on subsequent ECS migration work.

Extracted from #2058 commits `22bcfb84` (initial OTel scaffolding) and `6c68d3ce` (restore call on Login/WebApi), reworked to land all four wirings together on top of `master`. Uses explicit package versions rather than central package management (which is a separate upcoming PR).

## Test plan
- [x] Solution builds clean (`dotnet build NosCore.sln`)
- [x] Full test suite: **829 passed / 0 failed** (up from 824 passing with 5 pre-existing login failures on master)
- [ ] Smoke test: start each host with `OTEL_EXPORTER_OTLP_ENDPOINT` pointing at a local collector, verify traces appear
- [ ] Smoke test: start each host without OTEL env vars, verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)