### PR TITLE
Add ECS source generator + Arch package + ComponentBundleAttribute

### DIFF
--- a/NosCore.sln
+++ b/NosCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.2.11408.102 d18.0
+VisualStudioVersion = 18.2.11408.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NosCore.LoginServer", "src\NosCore.LoginServer\NosCore.LoginServer.csproj", "{40663D90-0B3E-48A7-800E-CB5E1BED27B6}"
 EndProject
@@ -44,6 +44,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NosCore.WebApi", "src\NosCore.WebApi\NosCore.WebApi.csproj", "{4A4D1876-74CC-46B7-BB93-B3E0E4D25AE5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NosCore.Parser.Tests", "test\NosCore.Parser.Tests\NosCore.Parser.Tests.csproj", "{4E68313F-69F8-4125-B87E-665D6F7DFD5D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NosCore.EcsGenerator", "tools\NosCore.EcsGenerator\NosCore.EcsGenerator.csproj", "{78731E48-C6CA-4614-B617-65B55A85CAE0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -271,6 +275,18 @@ Global
 		{4E68313F-69F8-4125-B87E-665D6F7DFD5D}.Release|x64.Build.0 = Release|Any CPU
 		{4E68313F-69F8-4125-B87E-665D6F7DFD5D}.Release|x86.ActiveCfg = Release|Any CPU
 		{4E68313F-69F8-4125-B87E-665D6F7DFD5D}.Release|x86.Build.0 = Release|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Debug|x64.Build.0 = Debug|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Debug|x86.Build.0 = Debug|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x64.ActiveCfg = Release|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x64.Build.0 = Release|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x86.ActiveCfg = Release|Any CPU
+		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -294,6 +310,7 @@ Global
 		{3F7C2822-BF7B-4BC9-8AA3-3ED2E2F0351C} = {975CF226-2297-4B1B-88C6-5783C5359D18}
 		{4A4D1876-74CC-46B7-BB93-B3E0E4D25AE5} = {D4E0F6CD-9F21-4140-AC42-CD021D98B980}
 		{4E68313F-69F8-4125-B87E-665D6F7DFD5D} = {EFA0F8A7-CBF2-4542-82A9-931BB0111FED}
+		{78731E48-C6CA-4614-B617-65B55A85CAE0} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B673C11-52EF-455B-BFC6-8CFEBC340972}

--- a/src/NosCore.GameObject/Ecs/Attributes/ComponentBundleAttribute.cs
+++ b/src/NosCore.GameObject/Ecs/Attributes/ComponentBundleAttribute.cs
@@ -1,0 +1,21 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+
+namespace NosCore.GameObject.Ecs.Attributes
+{
+    [AttributeUsage(AttributeTargets.Struct)]
+    public sealed class ComponentBundleAttribute : Attribute
+    {
+        public Type[] Components { get; }
+
+        public ComponentBundleAttribute(params Type[] components)
+        {
+            Components = components;
+        }
+    }
+}

--- a/src/NosCore.GameObject/NosCore.GameObject.csproj
+++ b/src/NosCore.GameObject/NosCore.GameObject.csproj
@@ -6,6 +6,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -17,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arch" Version="2.1.0-beta" />
     <PackageReference Include="NosCore.Algorithm" Version="2.0.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="WolverineFx" Version="5.31.1" />
@@ -31,5 +33,11 @@
   <ItemGroup>
     <ProjectReference Include="..\NosCore.Core\NosCore.Core.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\NosCore.EcsGenerator\NosCore.EcsGenerator.csproj"
+        OutputItemType="Analyzer"
+        ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
 </Project>

--- a/tools/NosCore.EcsGenerator/ComponentBundleGenerator.cs
+++ b/tools/NosCore.EcsGenerator/ComponentBundleGenerator.cs
@@ -1,0 +1,331 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace NosCore.EcsGenerator;
+
+[Generator]
+public class ComponentBundleGenerator : IIncrementalGenerator
+{
+    private const string ComponentBundleAttributeName = "NosCore.GameObject.Ecs.Attributes.ComponentBundleAttribute";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var bundleDeclarations = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (s, _) => IsPartialStruct(s),
+                transform: static (ctx, _) => GetBundleInfo(ctx))
+            .Where(static m => m is not null);
+
+        var compilationAndBundles = context.CompilationProvider.Combine(bundleDeclarations.Collect());
+
+        context.RegisterSourceOutput(compilationAndBundles,
+            static (spc, source) => Execute(source.Left, source.Right!, spc));
+    }
+
+    private static bool IsPartialStruct(SyntaxNode node)
+    {
+        return node is StructDeclarationSyntax sds &&
+               sds.Modifiers.Any(SyntaxKind.PartialKeyword);
+    }
+
+    private static BundleInfo? GetBundleInfo(GeneratorSyntaxContext context)
+    {
+        var structDeclaration = (StructDeclarationSyntax)context.Node;
+        var symbol = context.SemanticModel.GetDeclaredSymbol(structDeclaration);
+
+        if (symbol is null)
+            return null;
+
+        var bundleAttr = symbol.GetAttributes()
+            .FirstOrDefault(ad => ad.AttributeClass?.ToDisplayString() == ComponentBundleAttributeName);
+
+        if (bundleAttr is null)
+            return null;
+
+        var includedComponents = new List<IncludedComponent>();
+
+        // Get component types from attribute constructor arguments
+        foreach (var arg in bundleAttr.ConstructorArguments)
+        {
+            if (arg.Kind == TypedConstantKind.Array)
+            {
+                foreach (var typeArg in arg.Values)
+                {
+                    if (typeArg.Value is INamedTypeSymbol componentSymbol)
+                    {
+                        var component = CreateIncludedComponent(componentSymbol);
+                        if (component != null)
+                            includedComponents.Add(component);
+                    }
+                }
+            }
+        }
+
+        if (includedComponents.Count == 0)
+            return null;
+
+        return new BundleInfo(
+            symbol.ContainingNamespace.ToDisplayString(),
+            symbol.Name,
+            includedComponents);
+    }
+
+    private static IncludedComponent? CreateIncludedComponent(INamedTypeSymbol componentSymbol)
+    {
+        var properties = new List<ComponentProperty>();
+        var typeNamespaces = new HashSet<string>();
+
+        foreach (var member in componentSymbol.GetMembers())
+        {
+            if (member is IPropertySymbol prop && prop.DeclaredAccessibility == Accessibility.Public)
+            {
+                var defaultValue = GetDefaultValue(prop.Type);
+                properties.Add(new ComponentProperty(
+                    prop.Name,
+                    prop.Type.ToDisplayString(),
+                    !prop.IsReadOnly,
+                    defaultValue));
+
+                CollectNamespaces(prop.Type, typeNamespaces);
+            }
+        }
+
+        var componentName = componentSymbol.Name;
+        var shortName = componentName.EndsWith("Component")
+            ? componentName.Substring(0, componentName.Length - "Component".Length)
+            : componentName;
+
+        var fieldName = "_" + char.ToLowerInvariant(shortName[0]) + shortName.Substring(1);
+
+        return new IncludedComponent(
+            componentSymbol.ContainingNamespace.ToDisplayString(),
+            componentName,
+            shortName,
+            fieldName,
+            properties,
+            typeNamespaces);
+    }
+
+    private static void CollectNamespaces(ITypeSymbol type, HashSet<string> namespaces)
+    {
+        if (type is INamedTypeSymbol namedType)
+        {
+            var ns = namedType.ContainingNamespace?.ToDisplayString();
+            if (!string.IsNullOrEmpty(ns) && ns != "System" && !ns!.StartsWith("System."))
+            {
+                namespaces.Add(ns);
+            }
+
+            foreach (var typeArg in namedType.TypeArguments)
+            {
+                CollectNamespaces(typeArg, namespaces);
+            }
+        }
+        else if (type is IArrayTypeSymbol arrayType)
+        {
+            CollectNamespaces(arrayType.ElementType, namespaces);
+        }
+    }
+
+    private static void Execute(Compilation compilation, ImmutableArray<BundleInfo?> bundles, SourceProductionContext context)
+    {
+        if (bundles.IsDefaultOrEmpty)
+            return;
+
+        var bundleDict = new Dictionary<string, BundleInfo>();
+        foreach (var b in bundles)
+        {
+            if (b is null) continue;
+            var key = $"{b.Namespace}.{b.Name}";
+            if (!bundleDict.ContainsKey(key))
+            {
+                bundleDict[key] = b;
+            }
+        }
+
+        foreach (var bundle in bundleDict.Values)
+        {
+            var source = GenerateBundlePartial(bundle);
+            context.AddSource($"{bundle.Name}.g.cs", SourceText.From(source, Encoding.UTF8));
+        }
+    }
+
+    private static string GenerateBundlePartial(BundleInfo bundle)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("#pragma warning disable CS0282 // Field ordering in partial struct");
+        sb.AppendLine();
+        sb.AppendLine("using Arch.Core;");
+        sb.AppendLine("using NosCore.GameObject.Ecs;");
+
+        var namespaces = bundle.Components
+            .Select(c => c.Namespace)
+            .Concat(bundle.Components.SelectMany(c => c.TypeNamespaces))
+            .Distinct()
+            .Where(ns => ns != bundle.Namespace && ns != "Arch.Core" && ns != "NosCore.GameObject.Ecs")
+            .OrderBy(ns => ns);
+
+        foreach (var ns in namespaces)
+        {
+            sb.AppendLine($"using {ns};");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"namespace {bundle.Namespace};");
+        sb.AppendLine();
+        sb.AppendLine($"public partial struct {bundle.Name}");
+        sb.AppendLine("{");
+
+        // Generate Entity and World as readonly fields
+        sb.AppendLine("    public readonly Entity Entity;");
+        sb.AppendLine("    public readonly MapWorld World;");
+        sb.AppendLine();
+
+        // Generate constructor
+        sb.AppendLine($"    public {bundle.Name}(Entity entity, MapWorld world)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        Entity = entity;");
+        sb.AppendLine("        World = world;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Find duplicate property names across all components
+        var propertyOccurrences = new Dictionary<string, int>();
+        foreach (var component in bundle.Components)
+        {
+            foreach (var prop in component.Properties)
+            {
+                if (!propertyOccurrences.ContainsKey(prop.Name))
+                    propertyOccurrences[prop.Name] = 0;
+                propertyOccurrences[prop.Name]++;
+            }
+        }
+        var duplicateProperties = new HashSet<string>(
+            propertyOccurrences.Where(kv => kv.Value > 1).Select(kv => kv.Key));
+
+        // Generate implicit conversion operators
+        sb.AppendLine("    // Implicit conversion operators");
+        foreach (var component in bundle.Components)
+        {
+            sb.AppendLine($"    public static implicit operator {component.Name}({bundle.Name} bundle) => bundle.World.TryGetComponent<{component.Name}>(bundle.Entity) ?? default;");
+        }
+        sb.AppendLine();
+
+        // Generate properties using casts
+        foreach (var component in bundle.Components)
+        {
+            sb.AppendLine($"    // From {component.Name}");
+
+            foreach (var prop in component.Properties)
+            {
+                var memberName = duplicateProperties.Contains(prop.Name)
+                    ? $"{component.ShortName}{prop.Name}"
+                    : prop.Name;
+
+                if (prop.HasSetter)
+                {
+                    sb.AppendLine($"    public {prop.Type} {memberName}");
+                    sb.AppendLine("    {");
+                    sb.AppendLine($"        get => (({component.Name})this).{prop.Name};");
+                    sb.AppendLine($"        set => World.SetComponent(Entity, (({component.Name})this) with {{ {prop.Name} = value }});");
+                    sb.AppendLine("    }");
+                }
+                else
+                {
+                    sb.AppendLine($"    public {prop.Type} {memberName} => (({component.Name})this).{prop.Name};");
+                }
+            }
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private class BundleInfo
+    {
+        public string Namespace { get; }
+        public string Name { get; }
+        public List<IncludedComponent> Components { get; }
+
+        public BundleInfo(string @namespace, string name, List<IncludedComponent> components)
+        {
+            Namespace = @namespace;
+            Name = name;
+            Components = components;
+        }
+    }
+
+    private class IncludedComponent
+    {
+        public string Namespace { get; }
+        public string Name { get; }
+        public string ShortName { get; }
+        public string FieldName { get; }
+        public List<ComponentProperty> Properties { get; }
+        public HashSet<string> TypeNamespaces { get; }
+
+        public IncludedComponent(string @namespace, string name, string shortName, string fieldName, List<ComponentProperty> properties, HashSet<string> typeNamespaces)
+        {
+            Namespace = @namespace;
+            Name = name;
+            ShortName = shortName;
+            FieldName = fieldName;
+            Properties = properties;
+            TypeNamespaces = typeNamespaces;
+        }
+    }
+
+    private static string GetDefaultValue(ITypeSymbol type)
+    {
+        return type.SpecialType switch
+        {
+            SpecialType.System_Boolean => "false",
+            SpecialType.System_Byte => "0",
+            SpecialType.System_SByte => "0",
+            SpecialType.System_Int16 => "0",
+            SpecialType.System_UInt16 => "0",
+            SpecialType.System_Int32 => "0",
+            SpecialType.System_UInt32 => "0",
+            SpecialType.System_Int64 => "0",
+            SpecialType.System_UInt64 => "0",
+            SpecialType.System_Single => "0f",
+            SpecialType.System_Double => "0d",
+            SpecialType.System_String => "string.Empty",
+            _ => type.IsValueType
+                ? type.NullableAnnotation == NullableAnnotation.Annotated ? "null" : "default"
+                : "null!"
+        };
+    }
+
+    private class ComponentProperty
+    {
+        public string Name { get; }
+        public string Type { get; }
+        public bool HasSetter { get; }
+        public string DefaultValue { get; }
+
+        public ComponentProperty(string name, string type, bool hasSetter, string defaultValue)
+        {
+            Name = name;
+            Type = type;
+            HasSetter = hasSetter;
+            DefaultValue = defaultValue;
+        }
+    }
+}

--- a/tools/NosCore.EcsGenerator/NosCore.EcsGenerator.csproj
+++ b/tools/NosCore.EcsGenerator/NosCore.EcsGenerator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Foundation for the upcoming ECS-based entity model. This PR is **self-contained but inert**: no bundle types use `[ComponentBundle]` yet, so the generator emits no code. Component structs, bundles, and the `World`/system wiring that actually consume this follow in the next PR.

## What changes
- **New** `tools/NosCore.EcsGenerator/` — Roslyn incremental source generator.
  - Scans for partial structs annotated with `[ComponentBundle(typeof(A), typeof(B), ...)]` and emits component accessors + set helpers.
  - Pinned to `Microsoft.CodeAnalysis.CSharp 4.8.0` for source-generator host compatibility (same approach as the existing `NosCore.DtoGenerator`).
- **New** `src/NosCore.GameObject/Ecs/Attributes/ComponentBundleAttribute.cs` — `[AttributeUsage(AttributeTargets.Struct)]`, `params Type[]` components.
- **Modifies** `src/NosCore.GameObject/NosCore.GameObject.csproj`:
  - Adds `Arch` (2.1.0-beta) ECS package.
  - Wires the generator as an `Analyzer` `ProjectReference` (`OutputItemType="Analyzer"` + `ReferenceOutputAssembly="false"`).
  - Sets `EmitCompilerGeneratedFiles=true` so emitted sources land on disk for inspection.
- Adds the new generator project to `NosCore.sln`.

## Context
Third slice of #2058. Extracted from commit `c2ddc9d2` (`generator`), reworked:
- Swapped `VersionOverride=` (central package management) back to `Version=` since master isn't on central package management yet.
- Fixed a CS8602 nullable dereference warning in the generator source (`ns!.StartsWith(...)` after null-guard).

## Test plan
- [x] Solution builds clean (`dotnet build NosCore.sln`) — 0 warnings, 0 errors
- [x] Full test suite: **829 passed / 0 failed**
- [x] Generator loads and runs (build finishes with the analyzer step — it just has nothing to generate until the next PR adds `[ComponentBundle]`-annotated types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)