### PR TITLE
Add ECS components, bundles, systems, and extensions

### DIFF
--- a/src/NosCore.GameObject/Ecs/Components/AppearanceComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/AppearanceComponent.cs
@@ -1,0 +1,12 @@
+using NosCore.Packets.Enumerations;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct AppearanceComponent(
+    GenderType Gender,
+    HairStyleType HairStyle,
+    HairColorType HairColor,
+    CharacterClassType Class,
+    byte Face,
+    byte Size);

--- a/src/NosCore.GameObject/Ecs/Components/CombatComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/CombatComponent.cs
@@ -1,0 +1,24 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct CombatComponent(
+    int HitRate,
+    int CriticalChance,
+    int CriticalRate,
+    int MinHit,
+    int MaxHit,
+    int MinDistance,
+    int MaxDistance,
+    int DistanceCriticalChance,
+    int DistanceCriticalRate,
+    int DistanceRate,
+    int FireResistance,
+    int WaterResistance,
+    int LightResistance,
+    int DarkResistance,
+    int Defence,
+    int DefenceRate,
+    int DistanceDefence,
+    int DistanceDefenceRate,
+    int MagicDefence,
+    int Element,
+    int ElementRate);

--- a/src/NosCore.GameObject/Ecs/Components/EffectComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/EffectComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct EffectComponent(short Effect, short EffectDelay);

--- a/src/NosCore.GameObject/Ecs/Components/EntityIdentityComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/EntityIdentityComponent.cs
@@ -1,0 +1,5 @@
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct EntityIdentityComponent(long VisualId, VisualType VisualType, long CharacterId);

--- a/src/NosCore.GameObject/Ecs/Components/ExperienceComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/ExperienceComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct ExperienceComponent(byte Level, long LevelXp, byte JobLevel, long JobLevelXp, byte HeroLevel, long HeroLevelXp);

--- a/src/NosCore.GameObject/Ecs/Components/GoldComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/GoldComponent.cs
@@ -1,0 +1,9 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct GoldComponent(long Gold);

--- a/src/NosCore.GameObject/Ecs/Components/HealthComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/HealthComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct HealthComponent(int Hp, int MaxHp, bool IsAlive);

--- a/src/NosCore.GameObject/Ecs/Components/ManaComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/ManaComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct ManaComponent(int Mp, int MaxMp);

--- a/src/NosCore.GameObject/Ecs/Components/MapItemDataComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/MapItemDataComponent.cs
@@ -1,0 +1,7 @@
+using System;
+using NodaTime;
+using NosCore.GameObject.Services.ItemGenerationService.Item;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct MapItemDataComponent(short VNum, short Amount, long? OwnerId, Instant DroppedAt, Guid ItemInstanceId, IItemInstance? ItemInstance);

--- a/src/NosCore.GameObject/Ecs/Components/NameComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/NameComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct NameComponent(string Name);

--- a/src/NosCore.GameObject/Ecs/Components/NpcDataComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/NpcDataComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct NpcDataComponent(short VNum, short Race, byte Level, byte HeroLevel, byte Speed, byte Size);

--- a/src/NosCore.GameObject/Ecs/Components/NpcMovementComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/NpcMovementComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct NpcMovementComponent(short FirstX, short FirstY, bool IsMoving, bool IsHostile);

--- a/src/NosCore.GameObject/Ecs/Components/NpcStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/NpcStateComponent.cs
@@ -1,0 +1,24 @@
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.ComponentEntities.Interfaces;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.MapInstanceGenerationService;
+using NosCore.GameObject.Services.ShopService;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using System.Threading;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct NpcStateComponent(
+    NpcMonsterDto NpcMonster,
+    MapInstance MapInstance,
+    SemaphoreSlim HitSemaphore,
+    ConcurrentDictionary<IAliveEntity, int> HitList,
+    Shop? Shop,
+    IDisposable? Life,
+    Dictionary<Type, Subject<RequestData>> Requests,
+    short? Dialog,
+    bool IsDisabled
+);

--- a/src/NosCore.GameObject/Ecs/Components/PlayerComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct PlayerComponent(long AccountId, long CharacterId, bool IsGm, int ServerId);

--- a/src/NosCore.GameObject/Ecs/Components/PlayerFlagsComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerFlagsComponent.cs
@@ -1,0 +1,22 @@
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct PlayerFlagsComponent(
+    bool ExchangeBlocked,
+    bool FriendRequestBlocked,
+    bool WhisperBlocked,
+    bool GroupRequestBlocked,
+    bool HeroChatBlocked,
+    bool FamilyRequestBlocked,
+    bool EmoticonsBlocked,
+    bool QuickGetUp,
+    bool HpBlocked,
+    bool MinilandInviteBlocked,
+    bool MouseAimLock,
+    AuthorityType Authority,
+    bool UseSp,
+    bool IsVehicled,
+    bool Invisible,
+    bool IsSitting,
+    bool Camouflage);

--- a/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
@@ -1,0 +1,60 @@
+using NodaTime;
+using NosCore.Algorithm.DignityService;
+using NosCore.Algorithm.ReputationService;
+using NosCore.Core.I18N;
+using NosCore.Data.Dto;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.ComponentEntities.Interfaces;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.BattleService;
+using NosCore.GameObject.Services.BroadcastService;
+using NosCore.GameObject.Services.GroupService;
+using NosCore.GameObject.Services.InventoryService;
+using NosCore.GameObject.Services.ItemGenerationService;
+using NosCore.GameObject.Services.MapInstanceGenerationService;
+using NosCore.GameObject.Services.QuestService;
+using NosCore.GameObject.Services.ShopService;
+using NosCore.Networking;
+using NosCore.Shared.I18N;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using System.Threading;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct PlayerStateComponent(
+    CharacterDto CharacterDto,
+    AccountDto Account,
+    IInventoryService InventoryService,
+    IItemGenerationService ItemProvider,
+    MapInstance MapInstance,
+    Group? Group,
+    Shop? Shop,
+    ScriptDto? Script,
+    ConcurrentDictionary<short, CharacterSkill> Skills,
+    ConcurrentDictionary<Guid, CharacterQuest> Quests,
+    List<QuicklistEntryDto> QuicklistEntries,
+    List<StaticBonusDto> StaticBonusList,
+    List<TitleDto> Titles,
+    ConcurrentDictionary<long, long> GroupRequestCharacterIds,
+    Dictionary<Type, Subject<RequestData>> Requests,
+    bool IsChangingMapInstance,
+    bool IsDisconnecting,
+    bool InShop,
+    bool InExchange,
+    bool CanFight,
+    Instant LastPortal,
+    Instant LastSp,
+    Instant? LastGroupRequest,
+    short SpCooldown,
+    byte VehicleSpeed,
+    SemaphoreSlim HitSemaphore,
+    IChannel? Channel,
+    IPacketSender? Sender,
+    IReputationService ReputationService,
+    IDignityService DignityService,
+    IGameLanguageLocalizer GameLanguageLocalizer,
+    ConcurrentDictionary<IAliveEntity, int> HitList
+);

--- a/src/NosCore.GameObject/Ecs/Components/PositionComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PositionComponent.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct PositionComponent(short PositionX, short PositionY, byte Direction, Guid MapInstanceId);

--- a/src/NosCore.GameObject/Ecs/Components/ReputationComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/ReputationComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct ReputationComponent(long Reputation, short Dignity, short Compliment);

--- a/src/NosCore.GameObject/Ecs/Components/SpComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/SpComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct SpComponent(int SpCooldown, int SpPoint, int SpAdditionPoint);

--- a/src/NosCore.GameObject/Ecs/Components/SpawnComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/SpawnComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct SpawnComponent(short FirstX, short FirstY, bool IsMoving, bool IsHostile);

--- a/src/NosCore.GameObject/Ecs/Components/SpeedComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/SpeedComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct SpeedComponent(byte Speed);

--- a/src/NosCore.GameObject/Ecs/Components/TimingComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/TimingComponent.cs
@@ -1,0 +1,5 @@
+using NodaTime;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct TimingComponent(Instant LastMove, Instant LastAttack);

--- a/src/NosCore.GameObject/Ecs/Components/VisualComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/VisualComponent.cs
@@ -1,0 +1,3 @@
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct VisualComponent(short Morph, byte MorphUpgrade, short MorphDesign, byte MorphBonus, bool NoAttack, bool NoMove, bool IsSitting);

--- a/src/NosCore.GameObject/Ecs/Extensions/MapItemBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/MapItemBundleExtensions.cs
@@ -1,0 +1,45 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.Packets.ServerPackets.Entities;
+using NosCore.Packets.ServerPackets.Visibility;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Extensions;
+
+public static class MapItemBundleExtensions
+{
+    public static InPacket GenerateIn(this MapItemComponentBundle item)
+    {
+        return new InPacket
+        {
+            VisualType = VisualType.Object,
+            VisualId = item.VisualId,
+            VNum = item.VNum.ToString(),
+            PositionX = item.PositionX,
+            PositionY = item.PositionY,
+            InItemSubPacket = new InItemSubPacket
+            {
+                Amount = item.Amount,
+                IsQuestRelative = false,
+                Owner = item.OwnerId ?? 0
+            }
+        };
+    }
+
+    public static DropPacket GenerateDrop(this MapItemComponentBundle item)
+    {
+        return new DropPacket
+        {
+            VNum = item.VNum,
+            VisualId = item.VisualId,
+            PositionX = item.PositionX,
+            PositionY = item.PositionY,
+            Amount = item.Amount,
+            OwnerId = item.OwnerId
+        };
+    }
+}

--- a/src/NosCore.GameObject/Ecs/Extensions/MonsterBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/MonsterBundleExtensions.cs
@@ -1,0 +1,76 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.Packets.Enumerations;
+using NosCore.Packets.ServerPackets.Entities;
+using NosCore.Packets.ServerPackets.Movement;
+using NosCore.Packets.ServerPackets.Player;
+using NosCore.Packets.ServerPackets.Visibility;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Extensions;
+
+public static class MonsterBundleExtensions
+{
+    public static InPacket GenerateIn(this MonsterComponentBundle monster)
+    {
+        return new InPacket
+        {
+            VisualType = VisualType.Monster,
+            VisualId = monster.VisualId,
+            VNum = monster.VNum.ToString(),
+            PositionX = monster.PositionX,
+            PositionY = monster.PositionY,
+            Direction = monster.Direction,
+            InNonPlayerSubPacket = new InNonPlayerSubPacket
+            {
+                Dialog = 0,
+                InAliveSubPacket = new InAliveSubPacket
+                {
+                    Hp = monster.MaxHp > 0 ? (int)(monster.Hp / (float)monster.MaxHp * 100) : 100,
+                    Mp = monster.MaxMp > 0 ? (int)(monster.Mp / (float)monster.MaxMp * 100) : 100
+                },
+                IsSitting = monster.IsSitting,
+                SpawnEffect = SpawnEffectType.NoEffect,
+                Unknow1 = 2
+            }
+        };
+    }
+
+    public static CondPacket GenerateCond(this MonsterComponentBundle monster)
+    {
+        return new CondPacket
+        {
+            VisualType = VisualType.Monster,
+            VisualId = monster.VisualId,
+            NoAttack = monster.NoAttack,
+            NoMove = monster.NoMove,
+            Speed = monster.Speed
+        };
+    }
+
+    public static MovePacket GenerateMove(this MonsterComponentBundle monster, short? mapX = null, short? mapY = null)
+    {
+        return new MovePacket
+        {
+            VisualType = VisualType.Monster,
+            VisualEntityId = monster.VisualId,
+            MapX = mapX ?? monster.PositionX,
+            MapY = mapY ?? monster.PositionY,
+            Speed = monster.Speed
+        };
+    }
+
+    public static CharScPacket GenerateCharSc(this MonsterComponentBundle monster)
+    {
+        return new CharScPacket
+        {
+            VisualType = VisualType.Monster,
+            VisualId = monster.VisualId,
+            Size = monster.Size
+        };
+    }
+}

--- a/src/NosCore.GameObject/Ecs/Extensions/NpcBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/NpcBundleExtensions.cs
@@ -1,0 +1,76 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.Packets.Enumerations;
+using NosCore.Packets.ServerPackets.Entities;
+using NosCore.Packets.ServerPackets.Movement;
+using NosCore.Packets.ServerPackets.Player;
+using NosCore.Packets.ServerPackets.Visibility;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Extensions;
+
+public static class NpcBundleExtensions
+{
+    public static InPacket GenerateIn(this NpcComponentBundle npc, short? dialog = null)
+    {
+        return new InPacket
+        {
+            VisualType = VisualType.Npc,
+            VisualId = npc.VisualId,
+            VNum = npc.VNum.ToString(),
+            PositionX = npc.PositionX,
+            PositionY = npc.PositionY,
+            Direction = npc.Direction,
+            InNonPlayerSubPacket = new InNonPlayerSubPacket
+            {
+                Dialog = dialog ?? 0,
+                InAliveSubPacket = new InAliveSubPacket
+                {
+                    Hp = npc.MaxHp > 0 ? (int)(npc.Hp / (float)npc.MaxHp * 100) : 100,
+                    Mp = npc.MaxMp > 0 ? (int)(npc.Mp / (float)npc.MaxMp * 100) : 100
+                },
+                IsSitting = npc.IsSitting,
+                SpawnEffect = SpawnEffectType.NoEffect,
+                Unknow1 = 2
+            }
+        };
+    }
+
+    public static CondPacket GenerateCond(this NpcComponentBundle npc)
+    {
+        return new CondPacket
+        {
+            VisualType = VisualType.Npc,
+            VisualId = npc.VisualId,
+            NoAttack = npc.NoAttack,
+            NoMove = npc.NoMove,
+            Speed = npc.Speed
+        };
+    }
+
+    public static MovePacket GenerateMove(this NpcComponentBundle npc, short? mapX = null, short? mapY = null)
+    {
+        return new MovePacket
+        {
+            VisualType = VisualType.Npc,
+            VisualEntityId = npc.VisualId,
+            MapX = mapX ?? npc.PositionX,
+            MapY = mapY ?? npc.PositionY,
+            Speed = npc.Speed
+        };
+    }
+
+    public static CharScPacket GenerateCharSc(this NpcComponentBundle npc)
+    {
+        return new CharScPacket
+        {
+            VisualType = VisualType.Npc,
+            VisualId = npc.VisualId,
+            Size = npc.Size
+        };
+    }
+}

--- a/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
@@ -1,0 +1,989 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using Microsoft.Extensions.Options;
+using NosCore.Algorithm.ExperienceService;
+using NosCore.Algorithm.HeroExperienceService;
+using NosCore.Data.Enumerations.I18N;
+using NosCore.Algorithm.JobExperienceService;
+using NosCore.Core.Configuration;
+using NosCore.Data.Dto;
+using NosCore.Data.Enumerations;
+using NosCore.GameObject.ComponentEntities.Extensions;
+using NosCore.GameObject.InterChannelCommunication.Hubs.BlacklistHub;
+using NosCore.GameObject.InterChannelCommunication.Hubs.ChannelHub;
+using NosCore.GameObject.InterChannelCommunication.Hubs.FriendHub;
+using NosCore.GameObject.InterChannelCommunication.Hubs.PubSub;
+using NosCore.GameObject.InterChannelCommunication.Messages;
+using NosCore.GameObject.Networking;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.BroadcastService;
+using NosCore.GameObject.Services.GroupService;
+using NosCore.GameObject.Services.InventoryService;
+using NosCore.GameObject.Services.ItemGenerationService.Item;
+using NosCore.Networking;
+using NosCore.Networking.SessionGroup;
+using NosCore.Networking.SessionGroup.ChannelMatcher;
+using NosCore.Packets.ClientPackets.Inventory;
+using NosCore.Packets.Enumerations;
+using NosCore.Packets.Interfaces;
+using NosCore.Packets.ServerPackets.Chats;
+using NosCore.Packets.ServerPackets.Inventory;
+using NosCore.Packets.ServerPackets.MiniMap;
+using NosCore.Packets.ServerPackets.Miniland;
+using NosCore.Packets.ServerPackets.Player;
+using NosCore.Packets.ServerPackets.Entities;
+using NosCore.Packets.ServerPackets.Relations;
+using NosCore.Packets.ServerPackets.Specialists;
+using NosCore.Packets.ServerPackets.Visibility;
+using NosCore.Packets.ServerPackets.UI;
+using NosCore.Packets.ServerPackets.Shop;
+using NosCore.Packets.ServerPackets.Groups;
+using NosCore.Packets.ServerPackets.Movement;
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Shared.Enumerations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NosCore.GameObject.Ecs.Extensions;
+
+public static class PlayerBundleExtensions
+{
+    public static Task SendPacketAsync(this PlayerComponentBundle player, IPacket? packet)
+    {
+        return player.Sender?.SendPacketAsync(packet) ?? Task.CompletedTask;
+    }
+
+    public static Task SendPacketsAsync(this PlayerComponentBundle player, IEnumerable<IPacket?> packets)
+    {
+        return player.Sender?.SendPacketsAsync(packets) ?? Task.CompletedTask;
+    }
+
+    public static async Task RestAsync(this PlayerComponentBundle player)
+    {
+        player.IsSitting = !player.IsSitting;
+        await player.MapInstance.SendPacketAsync(player.GenerateRest());
+    }
+
+    public static TalkPacket GenerateTalk(this PlayerComponentBundle player, string message)
+    {
+        return new TalkPacket
+        {
+            CharacterId = player.VisualId,
+            Message = message
+        };
+    }
+
+    public static SpeakPacket GenerateSpk(this PlayerComponentBundle player, SpeakPacket speakPacket)
+    {
+        return new SpeakPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            SpeakType = speakPacket.SpeakType,
+            Message = speakPacket.Message,
+            EntityName = player.Name
+        };
+    }
+
+    public static SayPacket GenerateSay(this PlayerComponentBundle player, SayPacket sayPacket)
+    {
+        return new SayPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            Type = sayPacket.Type,
+            Message = sayPacket.Message
+        };
+    }
+
+    public static async Task<FinitPacket> GenerateFinitAsync(this PlayerComponentBundle player, IFriendHub friendHub, IChannelHub channelHub, IPubSubHub pubSubHub)
+    {
+        var friends = await friendHub.GetFriendsAsync(player.CharacterId);
+        var friendSubPackets = new List<FinitSubPacket?>();
+
+        foreach (var relation in friends)
+        {
+            var isOnline = (await pubSubHub.GetSubscribersAsync())
+                .Any(s => s.ConnectedCharacter?.Id == relation.CharacterId);
+
+            friendSubPackets.Add(new FinitSubPacket
+            {
+                CharacterId = relation.CharacterId,
+                RelationType = relation.RelationType,
+                IsOnline = isOnline,
+                CharacterName = relation.CharacterName
+            });
+        }
+
+        return new FinitPacket
+        {
+            SubPackets = friendSubPackets
+        };
+    }
+
+    public static async Task<BlinitPacket> GenerateBlinitAsync(this PlayerComponentBundle player, IBlacklistHub blacklistHub)
+    {
+        var subpackets = new List<BlinitSubPacket?>();
+        var blacklist = await blacklistHub.GetBlacklistedAsync(player.CharacterId);
+        foreach (var b in blacklist)
+        {
+            subpackets.Add(new BlinitSubPacket
+            {
+                RelatedCharacterId = b.CharacterId,
+                CharacterName = b.CharacterName
+            });
+        }
+        return new BlinitPacket { SubPackets = subpackets };
+    }
+
+    public static async Task SetReputationAsync(this PlayerComponentBundle player, long reputation)
+    {
+        player.Reputation = reputation;
+        await player.SendPacketAsync(player.GenerateFd());
+        await player.SendPacketAsync(player.GenerateSay(
+            player.GetMessageFromKey(LanguageKey.REPUTATION_CHANGED),
+            SayColorType.Red));
+        await player.MapInstance.SendPacketAsync(player.GenerateIn(""));
+    }
+
+    public static async Task SetLevelAsync(this PlayerComponentBundle player, byte level,
+        IExperienceService experienceService, IJobExperienceService jobExperienceService,
+        IHeroExperienceService heroExperienceService, ISessionRegistry sessionRegistry)
+    {
+        player.Level = level;
+        player.LevelXp = 0;
+        player.Hp = player.MaxHp;
+        player.Mp = player.MaxMp;
+
+        await player.SendPacketAsync(player.GenerateStat());
+        await player.SendPacketAsync(player.GenerateStatInfo());
+        await player.SendPacketAsync(player.GenerateLev(experienceService, jobExperienceService, heroExperienceService));
+
+        var visualId = player.VisualId;
+        var authority = player.Authority;
+        var supportPrefix = authority == AuthorityType.Moderator
+            ? player.GetMessageFromKey(LanguageKey.SUPPORT) : string.Empty;
+        var inPacket = player.GenerateIn(supportPrefix);
+        var eff6 = player.GenerateEff(6);
+        var eff198 = player.GenerateEff(198);
+
+        var mapInstance = player.MapInstance;
+        var mapSessions = sessionRegistry.GetCharacters(s => s.MapInstance == mapInstance).ToList();
+        await Task.WhenAll(mapSessions.Select(async s =>
+        {
+            if (s.VisualId != visualId)
+            {
+                await s.SendPacketAsync(inPacket);
+            }
+            await s.SendPacketAsync(eff6);
+            await s.SendPacketAsync(eff198);
+        }));
+
+        var group = player.Group;
+        if (group != null)
+        {
+            foreach (var member in group.Keys)
+            {
+                if (member.Item1 != VisualType.Player)
+                {
+                    continue;
+                }
+
+                if (sessionRegistry.GetCharacter(s => s.VisualId == member.Item2) is { } groupMember)
+                {
+                    await groupMember.SendPacketAsync(group.GeneratePinit());
+                }
+            }
+            await player.SendPacketAsync(group.GeneratePinit());
+        }
+
+        await player.SendPacketAsync(new MsgiPacket
+        {
+            Type = MessageType.Default,
+            Message = Game18NConstString.LevelIncreased
+        });
+    }
+
+    public static InPacket GenerateIn(this PlayerComponentBundle player, string prefix)
+    {
+        return new InPacket
+        {
+            VisualType = VisualType.Player,
+            Name = prefix + player.Name,
+            VisualId = player.VisualId,
+            PositionX = player.PositionX,
+            PositionY = player.PositionY,
+            Direction = player.Direction,
+            InCharacterSubPacket = new InCharacterSubPacket
+            {
+                Authority = player.Authority,
+                Gender = player.Gender,
+                HairStyle = player.HairStyle,
+                HairColor = player.HairColor,
+                Class = player.Class,
+                Equipment = player.GetEquipmentSubPacket(),
+                InAliveSubPacket = new InAliveSubPacket
+                {
+                    Hp = player.MaxHp > 0 ? (int)(player.Hp / (float)player.MaxHp * 100) : 100,
+                    Mp = player.MaxMp > 0 ? (int)(player.Mp / (float)player.MaxMp * 100) : 100
+                },
+                IsSitting = player.IsSitting,
+                GroupId = player.Group?.GroupId ?? -1,
+                Fairy = 0,
+                FairyElement = 0,
+                Unknown = 0,
+                Morph = 0,
+                Unknown2 = 0,
+                Unknown3 = 0,
+                WeaponUpgradeRareSubPacket = player.GetWeaponUpgradeRareSubPacket(),
+                ArmorUpgradeRareSubPacket = player.GetArmorUpgradeRareSubPacket(),
+                FamilySubPacket = new FamilySubPacket(),
+                FamilyName = null,
+                ReputIco = (byte)(GetDignityIcon(player.Dignity) == 0 ? GetReputationIcon(player.Reputation) : -GetDignityIcon(player.Dignity)),
+                Invisible = player.Invisible,
+                MorphUpgrade = player.MorphUpgrade,
+                Faction = 0,
+                MorphUpgrade2 = (byte)player.MorphDesign,
+                Level = player.Level,
+                FamilyLevel = 0,
+                FamilyIcons = new List<bool> { false, false, false },
+                ArenaWinner = false,
+                Compliment = (short)player.Compliment,
+                Size = player.Size,
+                HeroLevel = player.HeroLevel
+            }
+        };
+    }
+
+    public static InEquipmentSubPacket GetEquipmentSubPacket(this PlayerComponentBundle player)
+    {
+        var inventory = player.InventoryService;
+        return new InEquipmentSubPacket
+        {
+            Armor = inventory.LoadBySlotAndType((short)EquipmentType.Armor, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            CostumeHat = inventory.LoadBySlotAndType((short)EquipmentType.CostumeHat, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            CostumeSuit = inventory.LoadBySlotAndType((short)EquipmentType.CostumeSuit, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            Fairy = inventory.LoadBySlotAndType((short)EquipmentType.Fairy, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            Hat = inventory.LoadBySlotAndType((short)EquipmentType.Hat, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            MainWeapon = inventory.LoadBySlotAndType((short)EquipmentType.MainWeapon, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            Mask = inventory.LoadBySlotAndType((short)EquipmentType.Mask, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            SecondaryWeapon = inventory.LoadBySlotAndType((short)EquipmentType.SecondaryWeapon, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            WeaponSkin = inventory.LoadBySlotAndType((short)EquipmentType.WeaponSkin, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum,
+            WingSkin = inventory.LoadBySlotAndType((short)EquipmentType.WingSkin, NoscorePocketType.Wear)?.ItemInstance?.ItemVNum
+        };
+    }
+
+    public static UpgradeRareSubPacket GetWeaponUpgradeRareSubPacket(this PlayerComponentBundle player)
+    {
+        var weapon = player.InventoryService.LoadBySlotAndType((short)EquipmentType.MainWeapon, NoscorePocketType.Wear);
+        return new UpgradeRareSubPacket
+        {
+            Upgrade = weapon?.ItemInstance?.Upgrade ?? 0,
+            Rare = (sbyte)(weapon?.ItemInstance?.Rare ?? 0)
+        };
+    }
+
+    public static UpgradeRareSubPacket GetArmorUpgradeRareSubPacket(this PlayerComponentBundle player)
+    {
+        var armor = player.InventoryService.LoadBySlotAndType((short)EquipmentType.Armor, NoscorePocketType.Wear);
+        return new UpgradeRareSubPacket
+        {
+            Upgrade = armor?.ItemInstance?.Upgrade ?? 0,
+            Rare = (sbyte)(armor?.ItemInstance?.Rare ?? 0)
+        };
+    }
+
+    public static StatPacket GenerateStat(this PlayerComponentBundle player)
+    {
+        return new StatPacket
+        {
+            Hp = player.Hp,
+            HpMaximum = player.MaxHp,
+            Mp = player.Mp,
+            MpMaximum = player.MaxMp,
+            Unknown = 0,
+            Option = 0
+        };
+    }
+
+    public static GoldPacket GenerateGold(this PlayerComponentBundle player)
+    {
+        return new GoldPacket { Gold = player.Gold };
+    }
+
+    public static LevPacket GenerateLev(this PlayerComponentBundle player,
+        IExperienceService experienceService,
+        IJobExperienceService jobExperienceService,
+        IHeroExperienceService heroExperienceService)
+    {
+        return new LevPacket
+        {
+            Level = player.Level,
+            LevelXp = player.LevelXp,
+            JobLevel = player.JobLevel,
+            JobLevelXp = player.JobLevelXp,
+            XpLoad = experienceService.GetExperience(player.Level),
+            JobXpLoad = jobExperienceService.GetJobExperience(player.Class, player.JobLevel),
+            Reputation = player.Reputation,
+            SkillCp = 0,
+            HeroXp = player.HeroLevelXp,
+            HeroLevel = player.HeroLevel,
+            HeroXpLoad = player.HeroLevel == 0 ? 0 : heroExperienceService.GetHeroExperience(player.HeroLevel)
+        };
+    }
+
+    public static FdPacket GenerateFd(this PlayerComponentBundle player)
+    {
+        return new FdPacket
+        {
+            Reput = player.Reputation,
+            ReputIcon = (int)GetReputationIcon(player.Reputation),
+            Dignity = player.Dignity,
+            DignityIcon = (int)GetDignityIcon(player.Dignity)
+        };
+    }
+
+    public static AtPacket GenerateAt(this PlayerComponentBundle player, short mapId, int music = 0)
+    {
+        return new AtPacket
+        {
+            CharacterId = player.VisualId,
+            MapId = mapId,
+            PositionX = player.PositionX,
+            PositionY = player.PositionY,
+            Direction = player.Direction,
+            Unknown1 = 0,
+            Music = music,
+            Unknown2 = 0,
+            Unknown3 = -1
+        };
+    }
+
+    public static CInfoPacket GenerateCInfo(this PlayerComponentBundle player)
+    {
+        return new CInfoPacket
+        {
+            Name = player.Name,
+            Unknown1 = null,
+            GroupId = -1,
+            FamilyId = -1,
+            FamilyName = null,
+            CharacterId = player.VisualId,
+            Authority = player.Authority,
+            Gender = player.Gender,
+            HairStyle = player.HairStyle,
+            HairColor = player.HairColor,
+            Class = player.Class,
+            Icon = (byte)(GetDignityIcon(player.Dignity) == 0 ? GetReputationIcon(player.Reputation) : -GetDignityIcon(player.Dignity)),
+            Compliment = (short)player.Compliment,
+            Morph = player.Morph,
+            Invisible = player.Invisible,
+            FamilyLevel = 0,
+            MorphUpgrade = player.MorphUpgrade,
+            ArenaWinner = false
+        };
+    }
+
+    public static CondPacket GenerateCond(this PlayerComponentBundle player)
+    {
+        return new CondPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            NoAttack = player.NoAttack,
+            NoMove = player.NoMove,
+            Speed = player.Speed
+        };
+    }
+
+    public static CModePacket GenerateCMode(this PlayerComponentBundle player)
+    {
+        return new CModePacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            Morph = player.Morph,
+            MorphUpgrade = player.MorphUpgrade,
+            MorphDesign = player.MorphDesign,
+            MorphBonus = player.MorphBonus,
+            Size = player.Size
+        };
+    }
+
+    public static OutPacket GenerateOut(this PlayerComponentBundle player)
+    {
+        return new OutPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId
+        };
+    }
+
+    public static RestPacket GenerateRest(this PlayerComponentBundle player)
+    {
+        return new RestPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            IsSitting = player.IsSitting
+        };
+    }
+
+    private static int GetReputationIcon(long reputation)
+    {
+        return reputation switch
+        {
+            >= 5000001 => 28,
+            >= 2500001 => 27,
+            >= 500001 => 26,
+            >= 250001 => 25,
+            >= 100001 => 24,
+            >= 50001 => 23,
+            >= 10001 => 22,
+            >= 5001 => 21,
+            >= 2501 => 20,
+            >= 501 => 19,
+            >= 251 => 18,
+            >= 1 => 17,
+            _ => 16
+        };
+    }
+
+    private static int GetDignityIcon(int dignity)
+    {
+        return dignity switch
+        {
+            < -1000 => 1,
+            <= -800 => 2,
+            <= -600 => 3,
+            <= -400 => 4,
+            <= -200 => 5,
+            <= -100 => 6,
+            _ => 7
+        };
+    }
+
+    public static EffectPacket GenerateEff(this PlayerComponentBundle player, int effectId)
+    {
+        return new EffectPacket
+        {
+            EffectType = VisualType.Player,
+            VisualEntityId = player.VisualId,
+            Id = effectId
+        };
+    }
+
+    public static SayPacket GenerateSay(this PlayerComponentBundle player, string message, SayColorType type)
+    {
+        return new SayPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            Type = type,
+            Message = message
+        };
+    }
+
+    public static UseItemPacket GenerateUseItem(this PlayerComponentBundle player, PocketType type, short slot, byte mode, byte parameter)
+    {
+        return new UseItemPacket
+        {
+            VisualId = player.VisualId,
+            VisualType = VisualType.Player,
+            Type = type,
+            Slot = slot,
+            Mode = mode,
+            Parameter = parameter
+        };
+    }
+
+    public static EqPacket GenerateEq(this PlayerComponentBundle player)
+    {
+        return new EqPacket
+        {
+            VisualId = player.VisualId,
+            Visibility = (byte)(player.Authority < AuthorityType.GameMaster ? 0 : 2),
+            Gender = player.Gender,
+            HairStyle = player.HairStyle,
+            Haircolor = player.HairColor,
+            ClassType = player.Class,
+            EqSubPacket = player.GetEquipmentSubPacket(),
+            WeaponUpgradeRarePacket = player.GetWeaponUpgradeRareSubPacket(),
+            ArmorUpgradeRarePacket = player.GetArmorUpgradeRareSubPacket(),
+            Size = player.Size
+        };
+    }
+
+    public static EquipPacket GenerateEquipment(this PlayerComponentBundle player)
+    {
+        var inventory = player.InventoryService;
+
+        EquipmentSubPacket? GenerateEquipmentSubPacket(EquipmentType eqType)
+        {
+            var eq = inventory.LoadBySlotAndType((short)eqType, NoscorePocketType.Wear);
+            if (eq == null)
+            {
+                return null;
+            }
+
+            return new EquipmentSubPacket
+            {
+                EquipmentType = eqType,
+                VNum = eq.ItemInstance.ItemVNum,
+                Rare = eq.ItemInstance.Rare,
+                Upgrade = (eq.ItemInstance.Item.IsColored ? eq.ItemInstance?.Design
+                    : eq.ItemInstance.Upgrade) ?? 0,
+                Unknown = 0
+            };
+        }
+
+        return new EquipPacket
+        {
+            WeaponUpgradeRareSubPacket = player.GetWeaponUpgradeRareSubPacket(),
+            ArmorUpgradeRareSubPacket = player.GetArmorUpgradeRareSubPacket(),
+            Armor = GenerateEquipmentSubPacket(EquipmentType.Armor),
+            WeaponSkin = GenerateEquipmentSubPacket(EquipmentType.WeaponSkin),
+            SecondaryWeapon = GenerateEquipmentSubPacket(EquipmentType.SecondaryWeapon),
+            Sp = GenerateEquipmentSubPacket(EquipmentType.Sp),
+            Amulet = GenerateEquipmentSubPacket(EquipmentType.Amulet),
+            Boots = GenerateEquipmentSubPacket(EquipmentType.Boots),
+            CostumeHat = GenerateEquipmentSubPacket(EquipmentType.CostumeHat),
+            CostumeSuit = GenerateEquipmentSubPacket(EquipmentType.CostumeSuit),
+            Fairy = GenerateEquipmentSubPacket(EquipmentType.Fairy),
+            Gloves = GenerateEquipmentSubPacket(EquipmentType.Gloves),
+            Hat = GenerateEquipmentSubPacket(EquipmentType.Hat),
+            MainWeapon = GenerateEquipmentSubPacket(EquipmentType.MainWeapon),
+            Mask = GenerateEquipmentSubPacket(EquipmentType.Mask),
+            Necklace = GenerateEquipmentSubPacket(EquipmentType.Necklace),
+            Ring = GenerateEquipmentSubPacket(EquipmentType.Ring),
+            Bracelet = GenerateEquipmentSubPacket(EquipmentType.Bracelet),
+            WingSkin = GenerateEquipmentSubPacket(EquipmentType.WingSkin)
+        };
+    }
+
+    public static SpPacket GenerateSpPoint(this PlayerComponentBundle player, IOptions<WorldConfiguration> worldConfiguration)
+    {
+        return new SpPacket
+        {
+            AdditionalPoint = player.SpAdditionPoint,
+            MaxAdditionalPoint = worldConfiguration.Value.MaxAdditionalSpPoints,
+            SpPoint = player.SpPoint,
+            MaxSpPoint = worldConfiguration.Value.MaxSpPoints
+        };
+    }
+
+    public static TitleInfoPacket GenerateTitInfo(this PlayerComponentBundle player)
+    {
+        var visibleTitle = player.Titles.FirstOrDefault(s => s.Visible)?.TitleType;
+        var effectiveTitle = player.Titles.FirstOrDefault(s => s.Active)?.TitleType;
+        return new TitleInfoPacket
+        {
+            VisualId = player.VisualId,
+            EffectiveTitle = effectiveTitle ?? 0,
+            VisualType = VisualType.Player,
+            VisibleTitle = visibleTitle ?? 0
+        };
+    }
+
+    public static PairyPacket GeneratePairy(this PlayerComponentBundle player, WearableInstance? fairy)
+    {
+        var isBuffed = false;
+        return new PairyPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            FairyMoveType = fairy == null ? 0 : 4,
+            Element = fairy?.Item?.Element ?? 0,
+            ElementRate = fairy?.ElementRate + fairy?.Item?.ElementRate ?? 0,
+            Morph = fairy?.Item?.Morph ?? 0 + (isBuffed ? 5 : 0)
+        };
+    }
+
+    public static TitlePacket GenerateTitle(this PlayerComponentBundle player)
+    {
+        var data = player.Titles.Select(s => new TitleSubPacket
+        {
+            TitleId = (short)(s.TitleType - 9300),
+            TitleStatus = (byte)((s.Visible ? 2 : 0) + (s.Active ? 4 : 0) + 1)
+        }).ToList() as List<TitleSubPacket?>;
+        return new TitlePacket
+        {
+            Data = data.Any() ? data : null
+        };
+    }
+
+    public static IconPacket GenerateIcon(this PlayerComponentBundle player, byte iconType, short iconParameter)
+    {
+        return new IconPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            IconParameter = iconParameter,
+            IconType = iconType
+        };
+    }
+
+    public static ServerGetPacket GenerateGet(this PlayerComponentBundle player, long itemId)
+    {
+        return new ServerGetPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            ItemId = itemId
+        };
+    }
+
+    public static MlobjlstPacket GenerateMlobjlst(this PlayerComponentBundle player)
+    {
+        var mlobj = new List<MlobjlstSubPacket?>();
+        foreach (var item in player.InventoryService.Where(s => s.Value.Type == NoscorePocketType.Miniland)
+            .OrderBy(s => s.Value.Slot).Select(s => s.Value))
+        {
+            var used = player.MapInstance.MapDesignObjects.ContainsKey(item.Id);
+            var mp = used ? player.MapInstance.MapDesignObjects[item.Id] : null;
+
+            mlobj.Add(new MlobjlstSubPacket
+            {
+                InUse = used,
+                Slot = item.Slot,
+                MlObjSubPacket = new MlobjSubPacket
+                {
+                    MapX = used ? mp!.MapX : (short)0,
+                    MapY = used ? mp!.MapY : (short)0,
+                    Width = item.ItemInstance.Item.Width != 0 ? item.ItemInstance.Item.Width : (byte)1,
+                    Height = item.ItemInstance.Item.Height != 0 ? item.ItemInstance.Item.Height : (byte)1,
+                    DurabilityPoint = used ? item.ItemInstance.DurabilityPoint : 0,
+                    Unknown = 100,
+                    Unknown2 = false,
+                    IsWarehouse = item.ItemInstance.Item.IsWarehouse
+                }
+            });
+        }
+
+        return new MlobjlstPacket
+        {
+            MlobjlstSubPacket = mlobj
+        };
+    }
+
+    public static SayItemPacket GenerateSayItem(this PlayerComponentBundle player, string message, InventoryItemInstance item)
+    {
+        var isNormalItem = item.Type != NoscorePocketType.Equipment && item.Type != NoscorePocketType.Specialist;
+        return new SayItemPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            OratorSlot = 17,
+            Message = message,
+            IconInfo = isNormalItem ? new IconInfoPacket
+            {
+                IconId = item.ItemInstance.ItemVNum
+            } : null,
+            EquipmentInfo = isNormalItem ? null : new EInfoPacket(),
+            SlInfo = item.Type != NoscorePocketType.Specialist ? null : new SlInfoPacket()
+        };
+    }
+
+    public static StPacket GenerateStatInfo(this PlayerComponentBundle player)
+    {
+        return new StPacket
+        {
+            Type = VisualType.Player,
+            VisualId = player.VisualId,
+            Level = player.Level,
+            HeroLvl = player.HeroLevel,
+            HpPercentage = (int)(player.Hp / (float)player.MaxHp * 100),
+            MpPercentage = (int)(player.Mp / (float)player.MaxMp * 100),
+            CurrentHp = player.Hp,
+            CurrentMp = player.Mp,
+            BuffIds = null
+        };
+    }
+
+    public static PflagPacket GeneratePFlag(this PlayerComponentBundle player)
+    {
+        return new PflagPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            Flag = player.Shop?.ShopId ?? 0
+        };
+    }
+
+    public static ShopPacket GenerateShop(this PlayerComponentBundle player, RegionType language)
+    {
+        return new ShopPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            ShopId = player.Shop?.ShopId ?? 0,
+            MenuType = player.Shop?.MenuType ?? 0,
+            ShopType = player.Shop?.ShopType,
+            Name = player.Shop?.Name[language]
+        };
+    }
+
+    public static DirPacket GenerateChangeDir(this PlayerComponentBundle player)
+    {
+        return new DirPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            Direction = player.Direction
+        };
+    }
+
+    public static MovePacket GenerateMove(this PlayerComponentBundle player)
+    {
+        return player.GenerateMove(null, null);
+    }
+
+    public static MovePacket GenerateMove(this PlayerComponentBundle player, short? mapX, short? mapY)
+    {
+        return new MovePacket
+        {
+            VisualEntityId = player.VisualId,
+            MapX = mapX ?? player.PositionX,
+            MapY = mapY ?? player.PositionY,
+            Speed = player.Speed,
+            VisualType = VisualType.Player
+        };
+    }
+
+    public static PidxSubPacket GenerateSubPidx(this PlayerComponentBundle player)
+    {
+        return player.GenerateSubPidx(false);
+    }
+
+    public static PidxSubPacket GenerateSubPidx(this PlayerComponentBundle player, bool isMemberOfGroup)
+    {
+        return new PidxSubPacket
+        {
+            IsGrouped = isMemberOfGroup,
+            VisualId = player.VisualId
+        };
+    }
+
+    public static PinitSubPacket GenerateSubPinit(this PlayerComponentBundle player, int groupPosition)
+    {
+        return new PinitSubPacket
+        {
+            VisualType = VisualType.Player,
+            VisualId = player.VisualId,
+            GroupPosition = groupPosition,
+            Level = player.Level,
+            Name = player.Name,
+            Gender = player.Gender,
+            Race = 0,
+            Morph = player.Morph,
+            HeroLevel = player.HeroLevel
+        };
+    }
+
+    public static void LoadExpensions(this PlayerComponentBundle player)
+    {
+        var backpack = player.StaticBonusList.Any(s => s.StaticBonusType == StaticBonusType.BackPack);
+        var backpackticket = player.StaticBonusList.Any(s => s.StaticBonusType == StaticBonusType.InventoryTicketUpgrade);
+        var expension = (byte)((backpack ? 12 : 0) + (backpackticket ? 60 : 0));
+
+        player.InventoryService.Expensions[NoscorePocketType.Main] += expension;
+        player.InventoryService.Expensions[NoscorePocketType.Equipment] += expension;
+        player.InventoryService.Expensions[NoscorePocketType.Etc] += expension;
+    }
+
+    public static ExtsPacket GenerateExts(this PlayerComponentBundle player, IOptions<WorldConfiguration> conf)
+    {
+        return new ExtsPacket
+        {
+            EquipmentExtension = (byte)(player.InventoryService.Expensions[NoscorePocketType.Equipment] + conf.Value.BackpackSize),
+            MainExtension = (byte)(player.InventoryService.Expensions[NoscorePocketType.Main] + conf.Value.BackpackSize),
+            EtcExtension = (byte)(player.InventoryService.Expensions[NoscorePocketType.Etc] + conf.Value.BackpackSize)
+        };
+    }
+
+    public static void AddSpPoints(this PlayerComponentBundle player, int spPointToAdd, IOptions<WorldConfiguration> worldConfiguration)
+    {
+        var newValue = player.SpPoint + spPointToAdd;
+        player.SpPoint = newValue > worldConfiguration.Value.MaxSpPoints
+            ? worldConfiguration.Value.MaxSpPoints : newValue;
+    }
+
+    public static void AddAdditionalSpPoints(this PlayerComponentBundle player, int spPointToAdd, IOptions<WorldConfiguration> worldConfiguration)
+    {
+        var newValue = player.SpAdditionPoint + spPointToAdd;
+        player.SpAdditionPoint = newValue > worldConfiguration.Value.MaxAdditionalSpPoints
+            ? worldConfiguration.Value.MaxAdditionalSpPoints : newValue;
+    }
+
+    public static void RemoveGold(this PlayerComponentBundle player, long gold)
+    {
+        player.Gold -= gold;
+    }
+
+    public static TitPacket GenerateTit(this PlayerComponentBundle player)
+    {
+        return new TitPacket
+        {
+            ClassType = (Game18NConstString)Enum.Parse(typeof(Game18NConstString), player.Class.ToString()),
+            Name = player.Name
+        };
+    }
+}
+
+public static class ClientSessionMailExtensions
+{
+    public static async Task GenerateMailAsync(this ClientSession session, IEnumerable<MailData> mails)
+    {
+        var playerName = session.Character.Name;
+        foreach (var mail in mails)
+        {
+            if (!mail.MailDto.IsSenderCopy && (mail.ReceiverName == playerName))
+            {
+                if (mail.ItemInstance != null)
+                {
+                    await session.SendPacketAsync(mail.GeneratePost(0)!);
+                }
+                else
+                {
+                    await session.SendPacketAsync(mail.GeneratePost(1)!);
+                }
+            }
+            else
+            {
+                if (mail.ItemInstance != null)
+                {
+                    await session.SendPacketAsync(mail.GeneratePost(3)!);
+                }
+                else
+                {
+                    await session.SendPacketAsync(mail.GeneratePost(2)!);
+                }
+            }
+        }
+    }
+
+    public static async Task ChangeClassAsync(this ClientSession session, CharacterClassType classType,
+        IOptions<WorldConfiguration> worldConfiguration,
+        IExperienceService experienceService, IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService)
+    {
+        var character = session.Character;
+        var inventoryService = character.InventoryService;
+        var characterId = character.CharacterId;
+        var mapInstance = character.MapInstance;
+        var itemProvider = character.ItemProvider;
+        var group = character.Group;
+
+        if (inventoryService.Any(s => s.Value.Type == NoscorePocketType.Wear))
+        {
+            await session.SendPacketAsync(new SayiPacket
+            {
+                VisualType = VisualType.Player,
+                VisualId = characterId,
+                Type = SayColorType.Yellow,
+                Message = Game18NConstString.RemoveEquipment
+            });
+            return;
+        }
+
+        character = session.Character;
+        character.JobLevel = 1;
+        character.JobLevelXp = 0;
+        await session.SendPacketAsync(new NpInfoPacket());
+        await session.SendPacketAsync(new PclearPacket());
+
+        if (classType == CharacterClassType.Adventurer)
+        {
+            character = session.Character;
+            var currentHairStyle = character.HairStyle;
+            character.HairStyle = currentHairStyle > HairStyleType.HairStyleB ? 0 : currentHairStyle;
+        }
+
+        character = session.Character;
+        character.Class = classType;
+        character.Hp = character.MaxHp;
+        character.Mp = character.MaxMp;
+
+        var itemsToAdd = new List<BasicEquipment>();
+        foreach (var (key, _) in worldConfiguration.Value.BasicEquipments)
+        {
+            switch (key)
+            {
+                case nameof(CharacterClassType.Adventurer) when classType == CharacterClassType.Adventurer:
+                case nameof(CharacterClassType.Archer) when classType == CharacterClassType.Archer:
+                case nameof(CharacterClassType.Mage) when classType == CharacterClassType.Mage:
+                case nameof(CharacterClassType.MartialArtist) when classType == CharacterClassType.MartialArtist:
+                case nameof(CharacterClassType.Swordsman) when classType == CharacterClassType.Swordsman:
+                    itemsToAdd.AddRange(worldConfiguration.Value.BasicEquipments[key]);
+                    break;
+            }
+        }
+
+        foreach (var itemToAdd in itemsToAdd)
+        {
+            var inv = inventoryService.AddItemToPocket(
+                InventoryItemInstance.Create(itemProvider.Create(itemToAdd.VNum, itemToAdd.Amount), characterId),
+                itemToAdd.NoscorePocketType);
+            if (inv != null)
+            {
+                await session.SendPacketsAsync(
+                    inv.Select(invItem => invItem.GeneratePocketChange((PocketType)invItem.Type, invItem.Slot)));
+            }
+        }
+
+        character = session.Character;
+        var titPacket = character.GenerateTit();
+        var statPacket = character.GenerateStat();
+        var eqPacket = character.GenerateEq();
+        var effPacket8 = character.GenerateEff(8);
+        var condPacket = character.GenerateCond();
+        var levPacket = character.GenerateLev(experienceService, jobExperienceService, heroExperienceService);
+        var cmodePacket = character.GenerateCMode();
+        var msgiPacket = new MsgiPacket
+        {
+            Type = MessageType.Default,
+            Message = Game18NConstString.ClassChanged
+        };
+
+        await session.SendPacketAsync(titPacket);
+        await session.SendPacketAsync(statPacket);
+        await mapInstance.SendPacketAsync(eqPacket);
+        await mapInstance.SendPacketAsync(effPacket8);
+        await session.SendPacketAsync(condPacket);
+        await session.SendPacketAsync(levPacket);
+        await session.SendPacketAsync(cmodePacket);
+        await session.SendPacketAsync(msgiPacket);
+
+        character = session.Character;
+        character.QuicklistEntries = new List<QuicklistEntryDto>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CharacterId = characterId,
+                QuickListIndex = 0,
+                Slot = 9,
+                Type = 1,
+                IconType = 3,
+                IconVNum = 1
+            }
+        };
+
+        character = session.Character;
+        var channelId = session.Channel!.Id;
+        var inPacket = character.GenerateIn("");
+        var pidxPacket = group!.GeneratePidx(character);
+        var effPacket6 = character.GenerateEff(6);
+        var effPacket198 = character.GenerateEff(198);
+
+        await mapInstance.SendPacketAsync(inPacket, new EveryoneBut(channelId));
+        await mapInstance.SendPacketAsync(pidxPacket);
+        await mapInstance.SendPacketAsync(effPacket6);
+        await mapInstance.SendPacketAsync(effPacket198);
+    }
+}

--- a/src/NosCore.GameObject/Ecs/MapItemComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/MapItemComponentBundle.cs
@@ -1,0 +1,13 @@
+using NosCore.GameObject.Ecs.Attributes;
+using NosCore.GameObject.Ecs.Components;
+
+namespace NosCore.GameObject.Ecs;
+
+[ComponentBundle(
+    typeof(EntityIdentityComponent),
+    typeof(PositionComponent),
+    typeof(MapItemDataComponent)
+)]
+public partial struct MapItemComponentBundle
+{
+}

--- a/src/NosCore.GameObject/Ecs/MapWorld.cs
+++ b/src/NosCore.GameObject/Ecs/MapWorld.cs
@@ -1,0 +1,234 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using System.Threading;
+using Arch.Core;
+using NodaTime;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Components;
+using NosCore.GameObject.ComponentEntities.Interfaces;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.ItemGenerationService.Item;
+using NosCore.GameObject.Services.MapInstanceGenerationService;
+using NosCore.GameObject.Services.NRunService;
+using NosCore.GameObject.Services.ShopService;
+using NosCore.Packets.Enumerations;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs;
+
+public class MapWorld : IDisposable
+{
+    public World World { get; }
+
+    public MapWorld()
+    {
+        World = World.Create();
+    }
+
+    public T? TryGetComponent<T>(Entity entity) where T : struct
+    {
+        if (World.Has<T>(entity))
+        {
+            return World.Get<T>(entity);
+        }
+        return null;
+    }
+
+    public void SetComponent<T>(Entity entity, T component) where T : struct
+    {
+        World.Set(entity, component);
+    }
+
+    public bool HasComponent<T>(Entity entity) where T : struct
+    {
+        return World.Has<T>(entity);
+    }
+
+    public void AddComponent<T>(Entity entity, T component) where T : struct
+    {
+        World.Add(entity, component);
+    }
+
+    public void RemoveComponent<T>(Entity entity) where T : struct
+    {
+        World.Remove<T>(entity);
+    }
+
+    public Entity CreateMonster(
+        int monsterId,
+        NpcMonsterDto npcMonster,
+        MapInstance mapInstance,
+        short positionX,
+        short positionY,
+        byte direction,
+        short firstX,
+        short firstY,
+        bool isMoving,
+        bool isHostile,
+        bool isDisabled)
+    {
+        var now = SystemClock.Instance.GetCurrentInstant();
+        var entity = World.Create(
+            new EntityIdentityComponent(monsterId, VisualType.Monster, 0),
+            new HealthComponent(npcMonster.MaxHp, npcMonster.MaxHp, true),
+            new ManaComponent(npcMonster.MaxMp, npcMonster.MaxMp),
+            new PositionComponent(positionX, positionY, direction, mapInstance.MapInstanceId),
+            new VisualComponent(0, 0, 0, 0, false, false, false),
+            new NpcDataComponent(npcMonster.NpcMonsterVNum, npcMonster.Race, npcMonster.Level, npcMonster.HeroLevel, npcMonster.Speed, npcMonster.BasicArea),
+            new SpawnComponent(firstX, firstY, isMoving, isHostile),
+            new EffectComponent(0, 0),
+            new TimingComponent(now, now),
+            new NpcStateComponent(npcMonster, mapInstance, new SemaphoreSlim(1, 1), new ConcurrentDictionary<IAliveEntity, int>(), null, null, new Dictionary<Type, Subject<RequestData>>(), null, isDisabled)
+        );
+        return entity;
+    }
+
+    public Entity CreateNpc(
+        int npcId,
+        NpcMonsterDto npcMonster,
+        MapInstance mapInstance,
+        short positionX,
+        short positionY,
+        byte direction,
+        short firstX,
+        short firstY,
+        bool isMoving,
+        bool isDisabled,
+        short? dialog,
+        short effect,
+        short effectDelay,
+        Shop? shop)
+    {
+        var now = SystemClock.Instance.GetCurrentInstant();
+        var entity = World.Create(
+            new EntityIdentityComponent(npcId, VisualType.Npc, 0),
+            new HealthComponent(npcMonster.MaxHp, npcMonster.MaxHp, true),
+            new ManaComponent(npcMonster.MaxMp, npcMonster.MaxMp),
+            new PositionComponent(positionX, positionY, direction, mapInstance.MapInstanceId),
+            new VisualComponent(0, 0, 0, 0, false, false, false),
+            new NpcDataComponent(npcMonster.NpcMonsterVNum, npcMonster.Race, npcMonster.Level, 0, npcMonster.Speed, npcMonster.BasicArea),
+            new SpawnComponent(firstX, firstY, isMoving, false),
+            new EffectComponent(effect, effectDelay),
+            new TimingComponent(now, now),
+            new NpcStateComponent(npcMonster, mapInstance, new SemaphoreSlim(1, 1), new ConcurrentDictionary<IAliveEntity, int>(), shop, null, new Dictionary<Type, Subject<RequestData>> { [typeof(INrunEventHandler)] = new() }, dialog, isDisabled)
+        );
+        return entity;
+    }
+
+    public Entity CreateMapItem(
+        long visualId,
+        short vNum,
+        short amount,
+        Guid mapInstanceId,
+        short positionX,
+        short positionY,
+        long? ownerId,
+        Instant droppedAt,
+        Guid itemInstanceId,
+        IItemInstance? itemInstance)
+    {
+        var entity = World.Create(
+            new EntityIdentityComponent(visualId, VisualType.Object, 0),
+            new PositionComponent(positionX, positionY, 0, mapInstanceId),
+            new MapItemDataComponent(vNum, amount, ownerId, droppedAt, itemInstanceId, itemInstance)
+        );
+        return entity;
+    }
+
+    public Entity CreatePlayer(
+        int visaulId,
+        long characterId,
+        long accountId,
+        string name,
+        Guid mapInstanceId,
+        short positionX,
+        short positionY,
+        byte direction,
+        int hp,
+        int maxHp,
+        int mp,
+        int maxMp,
+        byte level,
+        long levelXp,
+        byte jobLevel,
+        long jobLevelXp,
+        byte heroLevel,
+        long heroLevelXp,
+        long gold,
+        long reputation,
+        short dignity,
+        short compliment,
+        GenderType gender,
+        HairStyleType hairStyle,
+        HairColorType hairColor,
+        CharacterClassType characterClass,
+        byte face,
+        byte speed,
+        AuthorityType authority,
+        bool isGm,
+        int serverId)
+    {
+        var now = SystemClock.Instance.GetCurrentInstant();
+        var entity = World.Create(
+            new EntityIdentityComponent(visaulId, VisualType.Player, characterId),
+            new HealthComponent(hp, maxHp, true),
+            new ManaComponent(mp, maxMp),
+            new PositionComponent(positionX, positionY, direction, mapInstanceId),
+            new VisualComponent(0, 0, 0, 0, false, false, false),
+            new AppearanceComponent(gender, hairStyle, hairColor, characterClass, face, 100),
+            new ExperienceComponent(level, levelXp, jobLevel, jobLevelXp, heroLevel, heroLevelXp),
+            new GoldComponent(gold),
+            new ReputationComponent(reputation, dignity, compliment),
+            new SpComponent(0, 0, 0),
+            new NameComponent(name),
+            new CombatComponent(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            new PlayerComponent(accountId, characterId, isGm, serverId),
+            new PlayerFlagsComponent(false, false, false, false, false, false, false, false, false, false, false, authority, false, false, false, false, false),
+            new TimingComponent(now, now),
+            new SpeedComponent(speed)
+        );
+        return entity;
+    }
+
+    public Entity ClonePlayer(
+        EntityIdentityComponent identity,
+        HealthComponent health,
+        ManaComponent mana,
+        PositionComponent position,
+        VisualComponent visual,
+        AppearanceComponent appearance,
+        ExperienceComponent experience,
+        GoldComponent gold,
+        ReputationComponent reputation,
+        SpComponent sp,
+        NameComponent name,
+        CombatComponent combat,
+        PlayerComponent player,
+        PlayerFlagsComponent playerFlags,
+        TimingComponent timing,
+        SpeedComponent speed,
+        PlayerStateComponent state)
+    {
+        return World.Create(identity, health, mana, position, visual, appearance, experience, gold,
+            reputation, sp, name, combat, player, playerFlags, timing, speed, state);
+    }
+
+    public void DestroyEntity(Entity entity)
+    {
+        World.Destroy(entity);
+    }
+
+    public void Dispose()
+    {
+        World.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/NosCore.GameObject/Ecs/MonsterComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/MonsterComponentBundle.cs
@@ -1,0 +1,23 @@
+using NosCore.GameObject.Ecs.Attributes;
+using NosCore.GameObject.Ecs.Components;
+using NosCore.GameObject.ComponentEntities.Interfaces;
+
+namespace NosCore.GameObject.Ecs;
+
+[ComponentBundle(
+    typeof(EntityIdentityComponent),
+    typeof(HealthComponent),
+    typeof(ManaComponent),
+    typeof(PositionComponent),
+    typeof(VisualComponent),
+    typeof(NpcDataComponent),
+    typeof(SpawnComponent),
+    typeof(EffectComponent),
+    typeof(TimingComponent),
+    typeof(NpcStateComponent)
+)]
+public readonly partial struct MonsterComponentBundle : INonPlayableEntity
+{
+    public short MapX => FirstX;
+    public short MapY => FirstY;
+}

--- a/src/NosCore.GameObject/Ecs/NpcComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/NpcComponentBundle.cs
@@ -1,0 +1,23 @@
+using NosCore.GameObject.Ecs.Attributes;
+using NosCore.GameObject.Ecs.Components;
+using NosCore.GameObject.ComponentEntities.Interfaces;
+
+namespace NosCore.GameObject.Ecs;
+
+[ComponentBundle(
+    typeof(EntityIdentityComponent),
+    typeof(HealthComponent),
+    typeof(ManaComponent),
+    typeof(PositionComponent),
+    typeof(VisualComponent),
+    typeof(NpcDataComponent),
+    typeof(SpawnComponent),
+    typeof(EffectComponent),
+    typeof(TimingComponent),
+    typeof(NpcStateComponent)
+)]
+public readonly partial struct NpcComponentBundle : INonPlayableEntity, IRequestableEntity
+{
+    public short MapX => FirstX;
+    public short MapY => FirstY;
+}

--- a/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
@@ -1,0 +1,126 @@
+using NosCore.Algorithm.DignityService;
+using NosCore.Algorithm.ReputationService;
+using NosCore.Data.Enumerations.I18N;
+using NosCore.GameObject.ComponentEntities.Interfaces;
+using NosCore.GameObject.Ecs.Attributes;
+using NosCore.GameObject.Ecs.Components;
+using NosCore.Packets.Interfaces;
+using NosCore.Shared.Enumerations;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NosCore.GameObject.Ecs;
+
+[ComponentBundle(
+    typeof(EntityIdentityComponent),
+    typeof(HealthComponent),
+    typeof(ManaComponent),
+    typeof(PositionComponent),
+    typeof(VisualComponent),
+    typeof(AppearanceComponent),
+    typeof(ExperienceComponent),
+    typeof(GoldComponent),
+    typeof(ReputationComponent),
+    typeof(SpComponent),
+    typeof(NameComponent),
+    typeof(CombatComponent),
+    typeof(PlayerComponent),
+    typeof(PlayerFlagsComponent),
+    typeof(TimingComponent),
+    typeof(SpeedComponent),
+    typeof(PlayerStateComponent)
+)]
+public readonly partial struct PlayerComponentBundle : ICharacterEntity
+{
+    public long CharacterId => PlayerCharacterId;
+    public bool InExchangeOrShop => InShop || InExchange;
+
+    public long HeroXp
+    {
+        get => HeroLevelXp;
+        set => HeroLevelXp = value;
+    }
+
+    public long Reput
+    {
+        get => Reputation;
+        set => Reputation = value;
+    }
+
+    public RegionType AccountLanguage => Account.Language;
+
+    // IVisualEntity - VisualId and VisualType are generated
+    public short VNum => 0;
+
+    // IAliveEntity
+    public bool IsSitting
+    {
+        get => VisualIsSitting;
+        set => VisualIsSitting = value;
+    }
+
+    public short Race => (short)Class;
+
+    // INamedEntity - LevelXp is generated
+
+    // ICharacterEntity
+    byte? ICharacterEntity.VehicleSpeed => VehicleSpeed;
+
+    public short SpCooldown
+    {
+        get => PlayerStateSpCooldown;
+        set => PlayerStateSpCooldown = value;
+    }
+
+    public short MapId
+    {
+        get => CharacterDto.MapId;
+        set => CharacterDto.MapId = value;
+    }
+
+    public short MapX
+    {
+        get => CharacterDto.MapX;
+        set => CharacterDto.MapX = value;
+    }
+
+    public short MapY
+    {
+        get => CharacterDto.MapY;
+        set => CharacterDto.MapY = value;
+    }
+
+    public byte Slot => CharacterDto.Slot;
+
+    public Guid? CurrentScriptId => Script?.Id;
+
+    public long BankGold
+    {
+        get => Account.BankMoney;
+        set => Account.BankMoney = value;
+    }
+
+    public string? Prefix => null;
+
+    ReputationType ICharacterEntity.ReputIcon => ReputationService.GetLevelFromReputation(Reputation);
+    DignityType ICharacterEntity.DignityIcon => DignityService.GetLevelFromDignity(Dignity);
+
+    public int ReputIconValue => (int)ReputationService.GetLevelFromReputation(Reputation);
+
+    public Task SendPacketAsync(IPacket? packet)
+    {
+        return Sender?.SendPacketAsync(packet) ?? Task.CompletedTask;
+    }
+
+    public Task SendPacketsAsync(IEnumerable<IPacket?> packets)
+    {
+        return Sender?.SendPacketsAsync(packets) ?? Task.CompletedTask;
+    }
+
+    public string GetMessageFromKey(LanguageKey languageKey)
+    {
+        return GameLanguageLocalizer[languageKey, Account.Language];
+    }
+}

--- a/src/NosCore.GameObject/Ecs/Systems/MovementSystem.cs
+++ b/src/NosCore.GameObject/Ecs/Systems/MovementSystem.cs
@@ -1,0 +1,71 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using Arch.Core;
+using NodaTime;
+using NosCore.GameObject.Ecs.Components;
+using NosCore.PathFinder.Interfaces;
+using NosCore.Shared.Helpers;
+
+namespace NosCore.GameObject.Ecs.Systems;
+
+public class MovementSystem
+{
+    private readonly IClock _clock;
+    private readonly IHeuristic _distanceCalculator;
+    private readonly QueryDescription _movableQuery;
+
+    public MovementSystem(IClock clock, IHeuristic distanceCalculator)
+    {
+        _clock = clock;
+        _distanceCalculator = distanceCalculator;
+        _movableQuery = new QueryDescription()
+            .WithAll<PositionComponent, NpcDataComponent, SpawnComponent, TimingComponent, HealthComponent>();
+    }
+
+    public void Update(MapWorld world, Map.Map map, Action<Entity, MoveData> onMove)
+    {
+        var now = _clock.GetCurrentInstant();
+
+        world.World.Query(in _movableQuery, (Entity entity, ref PositionComponent position, ref NpcDataComponent npcData, ref SpawnComponent spawn, ref TimingComponent timing, ref HealthComponent health) =>
+        {
+            if (!health.IsAlive || !spawn.IsMoving || npcData.Speed <= 0)
+            {
+                return;
+            }
+
+            var timeSinceLastMove = (now - timing.LastMove).TotalMilliseconds;
+            if (timeSinceLastMove <= RandomHelper.Instance.RandomNumber(400, 3200))
+            {
+                return;
+            }
+
+            var mapX = position.PositionX;
+            var mapY = position.PositionY;
+
+            if (!map.GetFreePosition(ref mapX, ref mapY,
+                (byte)RandomHelper.Instance.RandomNumber(0, 3),
+                (byte)RandomHelper.Instance.RandomNumber(0, 3)))
+            {
+                return;
+            }
+
+            var distance = (int)_distanceCalculator.GetDistance(
+                (position.PositionX, position.PositionY),
+                (mapX, mapY));
+
+            var moveDuration = 1000d * distance / (2 * npcData.Speed);
+
+            timing = timing with { LastMove = now.Plus(Duration.FromMilliseconds(moveDuration)) };
+            position = position with { PositionX = mapX, PositionY = mapY };
+
+            onMove(entity, new MoveData(mapX, mapY, npcData.Speed));
+        });
+    }
+}
+
+public readonly record struct MoveData(short MapX, short MapY, byte Speed);

--- a/src/NosCore.GameObject/Ecs/Systems/VisibilitySystem.cs
+++ b/src/NosCore.GameObject/Ecs/Systems/VisibilitySystem.cs
@@ -1,0 +1,86 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Collections.Generic;
+using Arch.Core;
+using NosCore.GameObject.Ecs.Components;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs.Systems;
+
+public class VisibilitySystem
+{
+    private readonly QueryDescription _npcDataQuery;
+    private readonly QueryDescription _itemsQuery;
+    private readonly QueryDescription _positionQuery;
+
+    public VisibilitySystem()
+    {
+        _npcDataQuery = new QueryDescription()
+            .WithAll<EntityIdentityComponent, PositionComponent, HealthComponent, NpcDataComponent, VisualComponent, SpawnComponent>();
+
+        _itemsQuery = new QueryDescription()
+            .WithAll<EntityIdentityComponent, PositionComponent, MapItemDataComponent>();
+
+        _positionQuery = new QueryDescription().WithAll<PositionComponent>();
+    }
+
+    public IEnumerable<Entity> GetMonsterEntities(MapWorld world)
+    {
+        var monsters = new List<Entity>();
+        world.World.Query(in _npcDataQuery, (Entity entity) =>
+        {
+            var identity = world.World.Get<EntityIdentityComponent>(entity);
+            if (identity.VisualType == VisualType.Monster)
+            {
+                monsters.Add(entity);
+            }
+        });
+        return monsters;
+    }
+
+    public IEnumerable<Entity> GetNpcEntities(MapWorld world)
+    {
+        var npcs = new List<Entity>();
+        world.World.Query(in _npcDataQuery, (Entity entity) =>
+        {
+            var identity = world.World.Get<EntityIdentityComponent>(entity);
+            if (identity.VisualType == VisualType.Npc)
+            {
+                npcs.Add(entity);
+            }
+        });
+        return npcs;
+    }
+
+    public IEnumerable<Entity> GetMapItemEntities(MapWorld world)
+    {
+        var items = new List<Entity>();
+        world.World.Query(in _itemsQuery, (Entity entity) =>
+        {
+            items.Add(entity);
+        });
+        return items;
+    }
+
+    public IEnumerable<Entity> GetEntitiesInRange(MapWorld world, short centerX, short centerY, int range)
+    {
+        var entities = new List<Entity>();
+
+        world.World.Query(in _positionQuery, (Entity entity, ref PositionComponent position) =>
+        {
+            var dx = Math.Abs(position.PositionX - centerX);
+            var dy = Math.Abs(position.PositionY - centerY);
+            if (dx <= range && dy <= range)
+            {
+                entities.Add(entity);
+            }
+        });
+
+        return entities;
+    }
+}


### PR DESCRIPTION
## Summary
Adds the Arch-backed ECS data model on top of the source generator merged in #2061. This PR is **pure additive infrastructure** — nothing on master consumes the new types yet. `ISessionRegistry`, `Character`, `MapInstance`, etc. still operate on the legacy `ICharacterEntity` path. The next PRs wire the ECS entities into the session registry and migrate the character lifecycle.

## What changes
- **23 component structs** in `Ecs/Components/*` — a mix of `record struct` POCOs (`HealthComponent`, `ManaComponent`, `PositionComponent`, …) and richer mutable structs for state (`PlayerStateComponent`, `NpcStateComponent`, `PlayerFlagsComponent`, `CombatComponent`, `AppearanceComponent`, …).
- **4 component bundles** — `PlayerComponentBundle` (implements `ICharacterEntity`), `MonsterComponentBundle`, `NpcComponentBundle`, `MapItemComponentBundle`. All annotated with `[ComponentBundle(typeof(...), ...)]` so the generator emits per-component accessors.
- **`Ecs/MapWorld.cs`** — wraps `Arch.Core.World` with typed `Create*` / `TryGetComponent` / `HasComponent` / `SetComponent` helpers and entity factories (`CreateMonster`, `CreateNpc`, `CreateMapItem`, `ClonePlayer`).
- **Systems** — `MovementSystem` + `VisibilitySystem` operate over `PositionComponent` / `VisualComponent` bundles.
- **Bundle extensions** — `PlayerBundleExtensions` (~989 lines covering level-up, stat generation, visibility packets, etc.), `Monster/Npc/MapItemBundleExtensions`.

## Context
Fourth slice of #2058. Stands alone: compiles, passes full test suite, zero runtime behavior change (nothing invokes the new code).

### Reworks vs. the original PR
- Swapped `NosCore.GameObject.Entities.{Interfaces,Extensions}` imports back to the legacy `NosCore.GameObject.ComponentEntities.{Interfaces,Extensions}` namespace. The namespace move is a separate upcoming PR — doing both here would pull ~200 files worth of unrelated churn into this diff.
- One `PlayerBundleExtensions` method referenced a future `ISessionRegistry.TryGetCharacter` overload that doesn't exist on master yet. Replaced with the equivalent `GetCharacter(predicate)` + pattern-match — same behavior, uses the existing registry API. When the registry gets its ECS-aware overloads in a later PR, this can migrate back.

## Test plan
- [x] Solution builds clean (`dotnet build NosCore.sln`) — 0 warnings, 0 errors
- [x] Full test suite: **829 passed / 0 failed**
- [x] Generator emits code for all 4 bundles (visible under `obj/Debug/net10.0/generated/`)
- [ ] Follow-up PRs wire these types into `ISessionRegistry`, `Character`, `MapInstance` — behavior coverage comes with them

🤖 Generated with [Claude Code](https://claude.com/claude-code)