### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -504,3 +504,6 @@ Log.txt
 *.orig
 
 /postgres
+
+# Claude Code
+.claude/


### PR DESCRIPTION
Keeps Claude Code's local workspace metadata (`.claude/settings.local.json`) out of the repo.