### PR TITLE
Slim PlayerStateComponent: extract Sender/Channel, evict IItemGenerationService

### DIFF
--- a/src/NosCore.GameObject/Ecs/Components/PlayerNetworkComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerNetworkComponent.cs
@@ -1,0 +1,12 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.GameObject.Services.BroadcastService;
+using NosCore.Networking;
+
+namespace NosCore.GameObject.Ecs.Components;
+
+public record struct PlayerNetworkComponent(IPacketSender? Sender, IChannel? Channel);

--- a/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
@@ -10,11 +10,9 @@ using NosCore.GameObject.Services.BattleService;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.GroupService;
 using NosCore.GameObject.Services.InventoryService;
-using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.GameObject.Services.MapInstanceGenerationService;
 using NosCore.GameObject.Services.QuestService;
 using NosCore.GameObject.Services.ShopService;
-using NosCore.Networking;
 using NosCore.Shared.I18N;
 using System;
 using System.Collections.Concurrent;
@@ -28,7 +26,6 @@ public record struct PlayerStateComponent(
     CharacterDto CharacterDto,
     AccountDto Account,
     IInventoryService InventoryService,
-    IItemGenerationService ItemProvider,
     MapInstance MapInstance,
     Group? Group,
     Shop? Shop,
@@ -51,8 +48,6 @@ public record struct PlayerStateComponent(
     short SpCooldown,
     byte VehicleSpeed,
     SemaphoreSlim HitSemaphore,
-    IChannel? Channel,
-    IPacketSender? Sender,
     IReputationService ReputationService,
     IDignityService DignityService,
     IGameLanguageLocalizer GameLanguageLocalizer,

--- a/src/NosCore.GameObject/Ecs/Extensions/CharacterEntityExtension.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/CharacterEntityExtension.cs
@@ -20,6 +20,7 @@ using NosCore.GameObject.Services.BattleService;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.GroupService;
 using NosCore.GameObject.Services.InventoryService;
+using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.GameObject.Services.ItemGenerationService.Item;
 using NosCore.GameObject.Services.ShopService;
 using NosCore.Networking;
@@ -461,7 +462,8 @@ namespace NosCore.GameObject.Ecs.Extensions
         }
 
         public static async Task BuyAsync(this ICharacterEntity characterEntity, Shop shop, short slot, short amount,
-            Microsoft.Extensions.Options.IOptions<NosCore.Core.Configuration.WorldConfiguration> worldConfiguration)
+            Microsoft.Extensions.Options.IOptions<NosCore.Core.Configuration.WorldConfiguration> worldConfiguration,
+            IItemGenerationService itemProvider)
         {
             if (amount <= 0)
             {
@@ -526,7 +528,7 @@ namespace NosCore.GameObject.Ecs.Extensions
             if (shop.OwnerCharacter == null)
             {
                 inv = characterEntity.InventoryService.AddItemToPocket(InventoryItemInstance.Create(
-                    characterEntity.ItemProvider.Create(item.ItemInstance!.ItemVNum, amount), characterEntity.CharacterId));
+                    itemProvider.Create(item.ItemInstance!.ItemVNum, amount), characterEntity.CharacterId));
             }
             else
             {
@@ -548,7 +550,7 @@ namespace NosCore.GameObject.Ecs.Extensions
                 else
                 {
                     inv = characterEntity.InventoryService.AddItemToPocket(InventoryItemInstance.Create(
-                        characterEntity.ItemProvider.Create(item.ItemInstance?.ItemVNum ?? 0, amount), characterEntity.CharacterId));
+                        itemProvider.Create(item.ItemInstance?.ItemVNum ?? 0, amount), characterEntity.CharacterId));
                 }
             }
 

--- a/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
@@ -23,6 +23,7 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.GroupService;
 using NosCore.GameObject.Services.InventoryService;
+using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.GameObject.Services.ItemGenerationService.Item;
 using NosCore.Networking;
 using NosCore.Networking.SessionGroup;
@@ -871,13 +872,13 @@ public static class ClientSessionMailExtensions
 
     public static async Task ChangeClassAsync(this ClientSession session, CharacterClassType classType,
         IOptions<WorldConfiguration> worldConfiguration,
-        IExperienceService experienceService, IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService)
+        IExperienceService experienceService, IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService,
+        IItemGenerationService itemProvider)
     {
         var character = session.Character;
         var inventoryService = character.InventoryService;
         var characterId = character.CharacterId;
         var mapInstance = character.MapInstance;
-        var itemProvider = character.ItemProvider;
         var group = character.Group;
 
         if (inventoryService.Any(s => s.Value.Type == NoscorePocketType.Wear))

--- a/src/NosCore.GameObject/Ecs/Interfaces/ICharacterEntity.cs
+++ b/src/NosCore.GameObject/Ecs/Interfaces/ICharacterEntity.cs
@@ -90,8 +90,6 @@ namespace NosCore.GameObject.Ecs.Interfaces
 
         long CharacterId { get; }
 
-        IItemGenerationService ItemProvider { get; }
-
         long BankGold { get; set; }
 
         string? Prefix { get; }

--- a/src/NosCore.GameObject/Ecs/MapWorld.cs
+++ b/src/NosCore.GameObject/Ecs/MapWorld.cs
@@ -215,10 +215,11 @@ public class MapWorld : IDisposable
         PlayerFlagsComponent playerFlags,
         TimingComponent timing,
         SpeedComponent speed,
-        PlayerStateComponent state)
+        PlayerStateComponent state,
+        PlayerNetworkComponent network)
     {
         return World.Create(identity, health, mana, position, visual, appearance, experience, gold,
-            reputation, sp, name, combat, player, playerFlags, timing, speed, state);
+            reputation, sp, name, combat, player, playerFlags, timing, speed, state, network);
     }
 
     public void DestroyEntity(Entity entity)

--- a/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
@@ -30,7 +30,8 @@ namespace NosCore.GameObject.Ecs;
     typeof(PlayerFlagsComponent),
     typeof(TimingComponent),
     typeof(SpeedComponent),
-    typeof(PlayerStateComponent)
+    typeof(PlayerStateComponent),
+    typeof(PlayerNetworkComponent)
 )]
 public readonly partial struct PlayerComponentBundle : ICharacterEntity
 {

--- a/src/NosCore.GameObject/Services/MapChangeService/MapChangeService.cs
+++ b/src/NosCore.GameObject/Services/MapChangeService/MapChangeService.cs
@@ -118,6 +118,7 @@ namespace NosCore.GameObject.Services.MapChangeService
                 var timing = oldWorld.TryGetComponent<TimingComponent>(oldEntity) ?? default;
                 var speedComp = oldWorld.TryGetComponent<SpeedComponent>(oldEntity) ?? default;
                 var state = oldWorld.TryGetComponent<PlayerStateComponent>(oldEntity) ?? default;
+                var network = oldWorld.TryGetComponent<PlayerNetworkComponent>(oldEntity) ?? default;
 
                 if (session.Channel?.Id != null)
                 {
@@ -153,7 +154,8 @@ namespace NosCore.GameObject.Services.MapChangeService
                     playerFlags,
                     timing,
                     speedComp,
-                    state with { MapInstance = newMapInstance });
+                    state with { MapInstance = newMapInstance },
+                    network);
 
                 session.SetPlayerEntity(playerEntity, newMapInstance.EcsWorld);
                 character = session.Character;

--- a/src/NosCore.GameObject/Services/NRunService/Handlers/ChangeClassHandler.cs
+++ b/src/NosCore.GameObject/Services/NRunService/Handlers/ChangeClassHandler.cs
@@ -13,6 +13,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.GameObject.Ecs.Extensions;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.Packets.ClientPackets.Npcs;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Chats;
@@ -27,7 +28,8 @@ namespace NosCore.GameObject.Services.NRunService.Handlers
 {
     public class ChangeClassEventHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> languageLocalizer,
         IOptions<WorldConfiguration> worldConfiguration, IExperienceService experienceService,
-        IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService)
+        IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService,
+        IItemGenerationService itemProvider)
         : INrunEventHandler
     {
         public bool Condition(Tuple<IAliveEntity, NrunPacket> item)
@@ -80,7 +82,7 @@ namespace NosCore.GameObject.Services.NRunService.Handlers
                 return;
             }
 
-            await requestData.ClientSession.ChangeClassAsync(classType, worldConfiguration, experienceService, jobExperienceService, heroExperienceService);
+            await requestData.ClientSession.ChangeClassAsync(classType, worldConfiguration, experienceService, jobExperienceService, heroExperienceService, itemProvider);
         }
     }
 }

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -156,7 +156,6 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     characterDto,
                     clientSession.Account,
                     inventoryService,
-                    itemProvider,
                     mapInstance,
                     group,
                     null,
@@ -183,8 +182,6 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     0,
                     0,
                     new SemaphoreSlim(1, 1),
-                    clientSession.Channel,
-                    clientSession,
                     reputationService,
                     dignityService,
                     gameLanguageLocalizer,
@@ -192,6 +189,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
                 );
 
                 mapInstance.EcsWorld.AddComponent(playerEntity, playerStateComponent);
+                mapInstance.EcsWorld.AddComponent(playerEntity, new PlayerNetworkComponent(clientSession, clientSession.Channel));
                 clientSession.SetPlayerEntity(playerEntity, mapInstance.EcsWorld);
 
                 var character = clientSession.Character;

--- a/src/NosCore.PacketHandlers/Command/ChangeClassPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Command/ChangeClassPacketHandler.cs
@@ -16,6 +16,7 @@ using NosCore.GameObject.Infastructure;
 using NosCore.GameObject.InterChannelCommunication.Hubs.PubSub;
 using NosCore.GameObject.InterChannelCommunication.Messages;
 using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using System.Linq;
@@ -26,14 +27,15 @@ namespace NosCore.PacketHandlers.Command
 {
     public class ChangeClassPacketHandler(IPubSubHub pubSubHub,
         IOptions<WorldConfiguration> worldConfiguration, IExperienceService experienceService,
-        IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService)
+        IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService,
+        IItemGenerationService itemProvider)
         : PacketHandler<ChangeClassPacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(ChangeClassPacket changeClassPacket, ClientSession session)
         {
             if ((changeClassPacket.Name == session.Character.Name) || string.IsNullOrEmpty(changeClassPacket.Name))
             {
-                await session.ChangeClassAsync(changeClassPacket.ClassType, worldConfiguration, experienceService, jobExperienceService, heroExperienceService);
+                await session.ChangeClassAsync(changeClassPacket.ClassType, worldConfiguration, experienceService, jobExperienceService, heroExperienceService, itemProvider);
                 return;
             }
 

--- a/src/NosCore.PacketHandlers/Shops/BuyPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Shops/BuyPacketHandler.cs
@@ -12,6 +12,7 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Infastructure;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.BroadcastService;
+using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
@@ -21,7 +22,8 @@ using System.Threading.Tasks;
 namespace NosCore.PacketHandlers.Shops
 {
     public class BuyPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
-            ISessionRegistry sessionRegistry, IOptions<WorldConfiguration> worldConfiguration)
+            ISessionRegistry sessionRegistry, IOptions<WorldConfiguration> worldConfiguration,
+            IItemGenerationService itemProvider)
         : PacketHandler<BuyPacket>, IWorldPacketHandler
     {
         public override Task ExecuteAsync(BuyPacket buyPacket, ClientSession clientSession)
@@ -44,7 +46,7 @@ namespace NosCore.PacketHandlers.Shops
 
             if (aliveEntity != null)
             {
-                return clientSession.Character.BuyAsync(aliveEntity.Shop!, buyPacket.Slot, buyPacket.Amount, worldConfiguration);
+                return clientSession.Character.BuyAsync(aliveEntity.Shop!, buyPacket.Slot, buyPacket.Amount, worldConfiguration, itemProvider);
             }
 
             logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);

--- a/test/NosCore.GameObject.Tests/Services/NRunService/Handlers/ChangeClassTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/NRunService/Handlers/ChangeClassTests.cs
@@ -51,7 +51,7 @@ namespace NosCore.GameObject.Tests.Services.NRunService.Handlers
             Item = TestHelpers.Instance.GenerateItemProvider();
             NrRunService = new NrunService(
                 new List<IEventHandler<Tuple<IAliveEntity, NrunPacket>, Tuple<IAliveEntity, NrunPacket>>>
-                    {new ChangeClassEventHandler(Logger, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration, new ExperienceService(), new JobExperienceService(), new HeroExperienceService())});
+                    {new ChangeClassEventHandler(Logger, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration, new ExperienceService(), new JobExperienceService(), new HeroExperienceService(), Item)});
         }
 
         [DataTestMethod]

--- a/test/NosCore.GameObject.Tests/ShopTests.cs
+++ b/test/NosCore.GameObject.Tests/ShopTests.cs
@@ -163,7 +163,7 @@ namespace NosCore.GameObject.Tests
         {
             var itemBuilder = CreateItemBuilder();
             var shop = CreateShop(itemBuilder);
-            await Session.Character.BuyAsync(shop, 1, 99, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 1, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
         }
 
 
@@ -179,7 +179,7 @@ namespace NosCore.GameObject.Tests
                 Amount = 98
             });
             var shop = new Shop { ShopItems = list };
-            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
         }
 
         private async Task AttemptingToBuy_ItemsAsync(int value)
@@ -187,7 +187,7 @@ namespace NosCore.GameObject.Tests
             var itemBuilder = CreateItemBuilder();
             var shop = CreateShop(itemBuilder);
 
-            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
         }
 
         private void ShouldReceiveNotEnoughGoldMessage()
@@ -201,7 +201,7 @@ namespace NosCore.GameObject.Tests
         {
             var itemBuilder = CreateItemBuilder(0, 500000);
             var shop = CreateShop(itemBuilder);
-            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
         }
 
         private void ShouldReceiveReputationError()
@@ -215,7 +215,7 @@ namespace NosCore.GameObject.Tests
         {
             CharacterHasGold(500000);
             ItemBuilder = CreateItemBuilder(1);
-            Session.Character.ItemProvider = ItemBuilder;
+            
             Session.Character.InventoryService.AddItemToPocket(
                 InventoryItemInstance.Create(ItemBuilder.Create(1, 999), Session.Character.CharacterId),
                 NoscorePocketType.Etc, 0);
@@ -230,7 +230,7 @@ namespace NosCore.GameObject.Tests
         private async Task AttemptingToBuyWithFullInventoryAsync()
         {
             var shop = CreateShop(ItemBuilder, -1, 1);
-            await Session.Character.BuyAsync(shop, 0, 999, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 0, 999, TestHelpers.Instance.WorldConfiguration, ItemBuilder);
         }
 
         private void ShouldReceiveNotEnoughSpaceMessage()
@@ -242,7 +242,7 @@ namespace NosCore.GameObject.Tests
         {
             CharacterHasGold(500000);
             ItemBuilder = CreateItemBuilder(1);
-            Session.Character.ItemProvider = ItemBuilder;
+            
             Session.Character.InventoryService.AddItemToPocket(
                 InventoryItemInstance.Create(ItemBuilder.Create(1, 999), Session.Character.CharacterId),
                 NoscorePocketType.Etc, 0);
@@ -257,7 +257,7 @@ namespace NosCore.GameObject.Tests
         private async Task Buying998ItemsAt1GoldEachAsync()
         {
             var shop = CreateShop(ItemBuilder);
-            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration, ItemBuilder);
         }
 
         private void AllInventorySlotsShouldHave_Items(int value)
@@ -274,7 +274,7 @@ namespace NosCore.GameObject.Tests
         {
             Session.Character.Reput = 500000;
             ItemBuilder = CreateItemBuilder(0, 1);
-            Session.Character.ItemProvider = ItemBuilder;
+            
             Session.Character.InventoryService.AddItemToPocket(
                 InventoryItemInstance.Create(ItemBuilder.Create(1, 999), Session.Character.CharacterId),
                 NoscorePocketType.Etc, 0);
@@ -291,7 +291,7 @@ namespace NosCore.GameObject.Tests
             var list = new ConcurrentDictionary<int, ShopItem>();
             list.TryAdd(0, new ShopItem { Slot = 0, ItemInstance = ItemBuilder.Create(1), Type = 0 });
             var shop = new Shop { ShopItems = list };
-            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration);
+            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration, ItemBuilder);
         }
 
         private void ReputationShouldBeDeducted()

--- a/test/NosCore.PacketHandlers.Tests/Command/ChangeClassPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Command/ChangeClassPacketHandlerTests.cs
@@ -46,7 +46,8 @@ namespace NosCore.PacketHandlers.Tests.Command
                 .Returns(Task.FromResult(new List<Subscriber>()));
 
             Handler = new ChangeClassPacketHandler(PubSubHub.Object,
-                TestHelpers.Instance.WorldConfiguration, new ExperienceService(), new JobExperienceService(), new HeroExperienceService());
+                TestHelpers.Instance.WorldConfiguration, new ExperienceService(), new JobExperienceService(), new HeroExperienceService(),
+                TestHelpers.Instance.GenerateItemProvider());
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Shops/BuyPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/BuyPacketHandlerTests.cs
@@ -35,7 +35,8 @@ namespace NosCore.PacketHandlers.Tests.Shops
                 Logger,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.SessionRegistry,
-                TestHelpers.Instance.WorldConfiguration);
+                TestHelpers.Instance.WorldConfiguration,
+                TestHelpers.Instance.GenerateItemProvider());
         }
 
         [TestMethod]

--- a/test/NosCore.Tests.Shared/TestHelpers.cs
+++ b/test/NosCore.Tests.Shared/TestHelpers.cs
@@ -407,7 +407,6 @@ namespace NosCore.Tests.Shared
                 characterDto,
                 acc,
                 inventoryService,
-                new Mock<IItemGenerationService>().Object,
                 mapInstance,
                 group,
                 null,
@@ -434,8 +433,6 @@ namespace NosCore.Tests.Shared
                 0,
                 0,
                 new SemaphoreSlim(1, 1),
-                session.Channel,
-                session,
                 new ReputationService(),
                 new DignityService(),
                 Instance.GameLanguageLocalizer,
@@ -443,6 +440,7 @@ namespace NosCore.Tests.Shared
             );
 
             mapInstance.EcsWorld.AddComponent(playerEntity, playerStateComponent);
+            mapInstance.EcsWorld.AddComponent(playerEntity, new GameObject.Ecs.Components.PlayerNetworkComponent(session, session.Channel));
             session.SetPlayerEntity(playerEntity, mapInstance.EcsWorld);
 
             var character = session.Character;

--- a/tools/NosCore.EcsGenerator/ComponentBundleGenerator.cs
+++ b/tools/NosCore.EcsGenerator/ComponentBundleGenerator.cs
@@ -122,10 +122,14 @@ public class ComponentBundleGenerator : IIncrementalGenerator
     {
         if (type is INamedTypeSymbol namedType)
         {
-            var ns = namedType.ContainingNamespace?.ToDisplayString();
-            if (!string.IsNullOrEmpty(ns) && ns != "System" && !ns!.StartsWith("System."))
+            var containing = namedType.ContainingNamespace;
+            if (containing != null && !containing.IsGlobalNamespace)
             {
-                namespaces.Add(ns);
+                var ns = containing.ToDisplayString();
+                if (!string.IsNullOrEmpty(ns) && ns != "System" && !ns!.StartsWith("System."))
+                {
+                    namespaces.Add(ns);
+                }
             }
 
             foreach (var typeArg in namedType.TypeArguments)


### PR DESCRIPTION
## Summary
Starts untangling `PlayerStateComponent`'s god-object role. It was mixing per-character game state, flags, network plumbing, and global service references. Services don't belong in a per-entity component — they're singletons that were being duplicated across every player entity.

## What changes
- **New `PlayerNetworkComponent(IPacketSender? Sender, IChannel? Channel)`**. Sender/Channel move here. Bundles still expose them via the generator, call sites still access them the same way — they're just in a 2-field component instead of a 30-field one. No indirection added, no bus hops, no lookup on send.
- **`IItemGenerationService ItemProvider` fully evicted** from `PlayerStateComponent` *and* from the `ICharacterEntity` interface. Extension methods that needed it (`BuyAsync`, `ChangeClassAsync`) now take it as a parameter. Its three call sites (`BuyPacketHandler`, `ChangeClassPacketHandler`, `ChangeClassEventHandler`) resolve it via DI like any other service.
- **`EcsGenerator` bugfix**: `CollectNamespaces` now skips the global namespace instead of emitting `using <global namespace>;` when a type has no containing namespace. The extra `PlayerNetworkComponent` fields exposed the pre-existing bug.

## Left for follow-up
`IReputationService` / `IDignityService` / `IGameLanguageLocalizer` still sit in `PlayerStateComponent` — they're wired into the bundle's `ICharacterEntity` implementation (`ReputIcon` / `DignityIcon` / `GetMessageFromKey`). Cleanly evicting them needs either precomputing icon levels into components or dropping the `ICharacterEntity` polymorphic shape entirely. Separate PR.

## Test plan
- [x] Solution builds clean (0 warnings, 0 errors)
- [x] Full test suite: **829 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)