### PR TITLE
Evict IReputationService + IDignityService from PlayerStateComponent

### DIFF
--- a/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
@@ -1,6 +1,4 @@
 using NodaTime;
-using NosCore.Algorithm.DignityService;
-using NosCore.Algorithm.ReputationService;
 using NosCore.Core.I18N;
 using NosCore.Data.Dto;
 using NosCore.Data.StaticEntities;
@@ -21,7 +19,5 @@ public record struct PlayerStateComponent(
     Instant LastSp,
     short SpCooldown,
     byte VehicleSpeed,
-    IReputationService ReputationService,
-    IDignityService DignityService,
     IGameLanguageLocalizer GameLanguageLocalizer
 );

--- a/src/NosCore.GameObject/Ecs/DignityLevels.cs
+++ b/src/NosCore.GameObject/Ecs/DignityLevels.cs
@@ -1,0 +1,22 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs;
+
+public static class DignityLevels
+{
+    public static DignityType FromDignity(short dignity) => dignity switch
+    {
+        <= -801 => DignityType.Failed,
+        <= -601 => DignityType.Useless,
+        <= -401 => DignityType.Unqualified,
+        <= -201 => DignityType.Dreadful,
+        <= -100 => DignityType.Dubious,
+        _ => DignityType.Default
+    };
+}

--- a/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
@@ -1,5 +1,3 @@
-using NosCore.Algorithm.DignityService;
-using NosCore.Algorithm.ReputationService;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Ecs.Attributes;
@@ -7,7 +5,6 @@ using NosCore.GameObject.Ecs.Components;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.Enumerations;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -110,10 +107,10 @@ public readonly partial struct PlayerComponentBundle : ICharacterEntity
 
     public string? Prefix => null;
 
-    ReputationType ICharacterEntity.ReputIcon => ReputationService.GetLevelFromReputation(Reputation);
-    DignityType ICharacterEntity.DignityIcon => DignityService.GetLevelFromDignity(Dignity);
+    ReputationType ICharacterEntity.ReputIcon => ReputationLevels.FromReputation(Reputation);
+    DignityType ICharacterEntity.DignityIcon => DignityLevels.FromDignity(Dignity);
 
-    public int ReputIconValue => (int)ReputationService.GetLevelFromReputation(Reputation);
+    public int ReputIconValue => (int)ReputationLevels.FromReputation(Reputation);
 
     public Task SendPacketAsync(IPacket? packet)
     {

--- a/src/NosCore.GameObject/Ecs/ReputationLevels.cs
+++ b/src/NosCore.GameObject/Ecs/ReputationLevels.cs
@@ -1,0 +1,36 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Ecs;
+
+public static class ReputationLevels
+{
+    public static ReputationType FromReputation(long reputation) => reputation switch
+    {
+        >= 5_000_001 => ReputationType.RedElite,
+        >= 4_950_001 => ReputationType.BlueElite,
+        >= 2_500_001 => ReputationType.GreenElite,
+        >= 2_450_001 => ReputationType.RedNos,
+        >= 500_001 => ReputationType.BlueNos,
+        >= 495_001 => ReputationType.GreenNos,
+        >= 245_001 => ReputationType.BlueMaster,
+        >= 95_001 => ReputationType.GreenLeader,
+        >= 45_001 => ReputationType.BlueExpert,
+        >= 25_001 => ReputationType.GreenExpert,
+        >= 19_001 => ReputationType.RedSoldier,
+        >= 9_501 => ReputationType.BlueSoldier,
+        >= 5_001 => ReputationType.GreenSoldier,
+        >= 4_901 => ReputationType.RedExperienced,
+        >= 2_251 => ReputationType.BlueExperienced,
+        >= 2_001 => ReputationType.GreenExperienced,
+        >= 501 => ReputationType.BlueTrainee,
+        >= 251 => ReputationType.GreenTrainee,
+        >= 201 => ReputationType.RedBeginner,
+        _ => ReputationType.GreenBeginner
+    };
+}

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -58,7 +58,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
             IDao<CharacterQuestDto, Guid> characterQuestDao,
             IDao<ScriptDto, Guid> scriptDao, List<QuestDto> quests, List<QuestObjectiveDto> questObjectives,
             IOptions<WorldConfiguration> configuration, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
-            IPubSubHub pubSubHub, IReputationService reputationService, IDignityService dignityService, IClock clock,
+            IPubSubHub pubSubHub, IClock clock,
             List<ItemDto> items, IHpService hpService, IMpService mpService, ISessionGroupFactory sessionGroupFactory,
             ICharacterInitializationService characterInitializationService, IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<SelectPacket>, IWorldPacketHandler
@@ -165,8 +165,6 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     now,
                     0,
                     0,
-                    reputationService,
-                    dignityService,
                     gameLanguageLocalizer
                 );
 

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
@@ -58,8 +58,6 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
                 TestHelpers.Instance.WorldConfiguration,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.PubSubHub.Object,
-                new ReputationService(),
-                new DignityService(),
                 TestHelpers.Instance.Clock,
                 new List<ItemDto>(),
                 new HpService(),

--- a/test/NosCore.Tests.Shared/TestHelpers.cs
+++ b/test/NosCore.Tests.Shared/TestHelpers.cs
@@ -316,7 +316,7 @@ namespace NosCore.Tests.Shared
                 new FinsPacketHandler(FriendHttpClient.Object, ChannelHttpClient.Object, TestHelpers.Instance.PubSubHub.Object, Instance.SessionRegistry),
                 new SelectPacketHandler(CharacterDao, Logger, new Mock<IItemGenerationService>().Object, MapInstanceAccessorService,
                     ItemInstanceDao, InventoryItemInstanceDao, StaticBonusDao, new Mock<IDao<QuicklistEntryDto, Guid>>().Object, new Mock<IDao<TitleDto, Guid>>().Object, new Mock<IDao<CharacterQuestDto, Guid>>().Object,
-                    new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, new ReputationService(), new DignityService(), Instance.Clock, ItemList, new HpService(), new MpService(), SessionGroupFactory, new CharacterInitializationService(), Instance.GameLanguageLocalizer),
+                    new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, Instance.Clock, ItemList, new HpService(), new MpService(), SessionGroupFactory, new CharacterInitializationService(), Instance.GameLanguageLocalizer),
                 new CSkillPacketHandler(Instance.Clock),
                 new CBuyPacketHandler(new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, Logger, ItemInstanceDao, Instance.LogLanguageLocalizer),
                 new CRegPacketHandler(WorldConfiguration, new Mock<IBazaarHub>().Object, ItemInstanceDao, InventoryItemInstanceDao),
@@ -416,8 +416,6 @@ namespace NosCore.Tests.Shared
                 now,
                 0,
                 0,
-                new ReputationService(),
-                new DignityService(),
                 Instance.GameLanguageLocalizer
             );
 


### PR DESCRIPTION
## Summary
Both `IReputationService` and `IDignityService` are pure-function lookups: raw reputation / dignity integer → enum level. They were being carried per-player as a service reference even though every player's instance does the exact same work.

Replaced with local static lookup tables:
- **`Ecs/ReputationLevels.cs`** — `FromReputation(long) → ReputationType` (20 bands, thresholds extracted by enumerating the NuGet service's outputs)
- **`Ecs/DignityLevels.cs`** — `FromDignity(short) → DignityType` (6 bands)

`PlayerComponentBundle.ReputIcon` / `DignityIcon` / `ReputIconValue` now use these helpers instead of the services. `PlayerStateComponent` drops the two service fields. `SelectPacketHandler` no longer takes them as dependencies; test fixtures no longer fake them.

## Not in this PR
`IGameLanguageLocalizer` stays in `PlayerStateComponent`. It's wired into `ICharacterEntity.GetMessageFromKey`, and evicting it cleanly means adding a localizer parameter to ~5 extension methods (`SetLevelAsync`, `SetReputationAsync`, `GenerateCInfo`, `SetGoldAsync`, `BuyAsync`) and cascading to their callers. That's its own PR.

## Test plan
- [x] Solution builds clean
- [x] Full test suite: **829 passed / 0 failed**

## Context
Follow-up to #2071. No runtime behavior change — local tables reproduce the service's `GetLevelFromReputation` / `GetLevelFromDignity` outputs exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)