### PR TITLE
Evict IGameLanguageLocalizer from PlayerStateComponent

### DIFF
--- a/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
@@ -1,8 +1,6 @@
 using NodaTime;
-using NosCore.Core.I18N;
 using NosCore.Data.Dto;
 using NosCore.Data.StaticEntities;
-using NosCore.Shared.I18N;
 
 namespace NosCore.GameObject.Ecs.Components;
 
@@ -17,6 +15,5 @@ public record struct PlayerStateComponent(
     bool CanFight,
     Instant LastPortal,
     Instant LastSp,
-    byte VehicleSpeed,
-    IGameLanguageLocalizer GameLanguageLocalizer
+    byte VehicleSpeed
 );

--- a/src/NosCore.GameObject/Ecs/Extensions/CharacterEntityExtension.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/CharacterEntityExtension.cs
@@ -41,6 +41,7 @@ using NosCore.Packets.ServerPackets.Relations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Packets.ServerPackets.Visibility;
 using NosCore.Shared.Enumerations;
+using NosCore.Core.I18N;
 using NosCore.Shared.I18N;
 using Serilog;
 using System;
@@ -349,28 +350,28 @@ namespace NosCore.GameObject.Ecs.Extensions
             return characterEntity.SendPacketAsync(GenerateGoldPacket(characterEntity));
         }
 
-        public static async Task AddGoldAsync(this ICharacterEntity characterEntity, long gold)
+        public static async Task AddGoldAsync(this ICharacterEntity characterEntity, long gold, IGameLanguageLocalizer localizer)
         {
             characterEntity.Gold += gold;
             await characterEntity.SendPacketAsync(GenerateGoldPacket(characterEntity));
-            await characterEntity.SendPacketAsync(GenerateUpdateGoldSayPacket(characterEntity));
+            await characterEntity.SendPacketAsync(GenerateUpdateGoldSayPacket(characterEntity, localizer));
         }
 
-        public static async Task RemoveGoldAsync(this ICharacterEntity characterEntity, long gold)
+        public static async Task RemoveGoldAsync(this ICharacterEntity characterEntity, long gold, IGameLanguageLocalizer localizer)
         {
             characterEntity.Gold -= gold;
             await characterEntity.SendPacketAsync(GenerateGoldPacket(characterEntity));
-            await characterEntity.SendPacketAsync(GenerateUpdateGoldSayPacket(characterEntity));
+            await characterEntity.SendPacketAsync(GenerateUpdateGoldSayPacket(characterEntity, localizer));
         }
 
-        private static SayPacket GenerateUpdateGoldSayPacket(ICharacterEntity characterEntity)
+        private static SayPacket GenerateUpdateGoldSayPacket(ICharacterEntity characterEntity, IGameLanguageLocalizer localizer)
         {
             return new SayPacket
             {
                 VisualType = VisualType.Player,
                 VisualId = characterEntity.VisualId,
                 Type = SayColorType.Red,
-                Message = characterEntity.GetMessageFromKey(LanguageKey.UPDATE_GOLD)
+                Message = localizer[LanguageKey.UPDATE_GOLD, characterEntity.AccountLanguage]
             };
         }
 
@@ -463,7 +464,8 @@ namespace NosCore.GameObject.Ecs.Extensions
 
         public static async Task BuyAsync(this ICharacterEntity characterEntity, Shop shop, short slot, short amount,
             Microsoft.Extensions.Options.IOptions<NosCore.Core.Configuration.WorldConfiguration> worldConfiguration,
-            IItemGenerationService itemProvider)
+            IItemGenerationService itemProvider,
+            IGameLanguageLocalizer localizer)
         {
             if (amount <= 0)
             {
@@ -537,7 +539,7 @@ namespace NosCore.GameObject.Ecs.Extensions
                     await characterEntity.SendPacketAsync(new SMemoPacket
                     {
                         Type = SMemoType.FailPlayer,
-                        Message = characterEntity.GetMessageFromKey(LanguageKey.TOO_RICH_SELLER)
+                        Message = localizer[LanguageKey.TOO_RICH_SELLER, characterEntity.AccountLanguage]
                     });
                     return;
                 }

--- a/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
@@ -10,6 +10,7 @@ using NosCore.Algorithm.HeroExperienceService;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Algorithm.JobExperienceService;
 using NosCore.Core.Configuration;
+using NosCore.Core.I18N;
 using NosCore.Data.Dto;
 using NosCore.Data.Enumerations;
 using NosCore.GameObject.Ecs.Extensions;
@@ -143,19 +144,21 @@ public static class PlayerBundleExtensions
         return new BlinitPacket { SubPackets = subpackets };
     }
 
-    public static async Task SetReputationAsync(this PlayerComponentBundle player, long reputation)
+    public static async Task SetReputationAsync(this PlayerComponentBundle player, long reputation,
+        IGameLanguageLocalizer localizer)
     {
         player.Reputation = reputation;
         await player.SendPacketAsync(player.GenerateFd());
         await player.SendPacketAsync(player.GenerateSay(
-            player.GetMessageFromKey(LanguageKey.REPUTATION_CHANGED),
+            localizer[LanguageKey.REPUTATION_CHANGED, player.Account.Language],
             SayColorType.Red));
         await player.MapInstance.SendPacketAsync(player.GenerateIn(""));
     }
 
     public static async Task SetLevelAsync(this PlayerComponentBundle player, byte level,
         IExperienceService experienceService, IJobExperienceService jobExperienceService,
-        IHeroExperienceService heroExperienceService, ISessionRegistry sessionRegistry)
+        IHeroExperienceService heroExperienceService, ISessionRegistry sessionRegistry,
+        IGameLanguageLocalizer localizer)
     {
         player.Level = level;
         player.LevelXp = 0;
@@ -169,7 +172,7 @@ public static class PlayerBundleExtensions
         var visualId = player.VisualId;
         var authority = player.Authority;
         var supportPrefix = authority == AuthorityType.Moderator
-            ? player.GetMessageFromKey(LanguageKey.SUPPORT) : string.Empty;
+            ? localizer[LanguageKey.SUPPORT, player.Account.Language] : string.Empty;
         var inPacket = player.GenerateIn(supportPrefix);
         var eff6 = player.GenerateEff(6);
         var eff198 = player.GenerateEff(198);
@@ -366,12 +369,12 @@ public static class PlayerBundleExtensions
         };
     }
 
-    public static CInfoPacket GenerateCInfo(this PlayerComponentBundle player)
+    public static CInfoPacket GenerateCInfo(this PlayerComponentBundle player, IGameLanguageLocalizer localizer)
     {
         return new CInfoPacket
         {
             Name = player.Authority == AuthorityType.Moderator
-                ? $"[{player.GetMessageFromKey(LanguageKey.SUPPORT)}]" + player.Name : player.Name,
+                ? $"[{localizer[LanguageKey.SUPPORT, player.Account.Language]}]" + player.Name : player.Name,
             Unknown1 = null,
             GroupId = -1,
             FamilyId = -1,

--- a/src/NosCore.GameObject/Ecs/Interfaces/ICharacterEntity.cs
+++ b/src/NosCore.GameObject/Ecs/Interfaces/ICharacterEntity.cs
@@ -97,7 +97,5 @@ namespace NosCore.GameObject.Ecs.Interfaces
         Task SendPacketAsync(IPacket packetDefinition);
 
         Task SendPacketsAsync(IEnumerable<IPacket> packetDefinitions);
-
-        string GetMessageFromKey(LanguageKey support);
     }
 }

--- a/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
@@ -1,4 +1,3 @@
-using NosCore.Data.Enumerations.I18N;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Ecs.Attributes;
 using NosCore.GameObject.Ecs.Components;
@@ -107,10 +106,5 @@ public readonly partial struct PlayerComponentBundle : ICharacterEntity
     public Task SendPacketsAsync(IEnumerable<IPacket?> packets)
     {
         return Sender?.SendPacketsAsync(packets) ?? Task.CompletedTask;
-    }
-
-    public string GetMessageFromKey(LanguageKey languageKey)
-    {
-        return GameLanguageLocalizer[languageKey, Account.Language];
     }
 }

--- a/src/NosCore.GameObject/Services/MapChangeService/MapChangeService.cs
+++ b/src/NosCore.GameObject/Services/MapChangeService/MapChangeService.cs
@@ -179,7 +179,7 @@ namespace NosCore.GameObject.Services.MapChangeService
                 var invisible = character.Invisible;
                 var authority = character.Authority;
 
-                await session.SendPacketAsync(character.GenerateCInfo());
+                await session.SendPacketAsync(character.GenerateCInfo(gameLanguageLocalizer));
                 await session.SendPacketAsync(character.GenerateCMode());
                 await session.SendPacketAsync(character.GenerateEq());
                 await session.SendPacketAsync(character.GenerateEquipment());

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -58,7 +58,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
             IOptions<WorldConfiguration> configuration, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             IPubSubHub pubSubHub, IClock clock,
             List<ItemDto> items, IHpService hpService, IMpService mpService, ISessionGroupFactory sessionGroupFactory,
-            ICharacterInitializationService characterInitializationService, IGameLanguageLocalizer gameLanguageLocalizer)
+            ICharacterInitializationService characterInitializationService)
         : PacketHandler<SelectPacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(SelectPacket packet, ClientSession clientSession)
@@ -161,8 +161,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     true,
                     now,
                     now,
-                    0,
-                    gameLanguageLocalizer
+                    0
                 );
 
                 mapInstance.EcsWorld.AddComponent(playerEntity, playerStateComponent);

--- a/src/NosCore.PacketHandlers/Command/SetLevelCommandPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Command/SetLevelCommandPacketHandler.cs
@@ -7,6 +7,7 @@
 using NosCore.Algorithm.ExperienceService;
 using NosCore.Algorithm.HeroExperienceService;
 using NosCore.Algorithm.JobExperienceService;
+using NosCore.Core.I18N;
 using NosCore.Data.CommandPackets;
 using NosCore.Data.Enumerations;
 using NosCore.GameObject.Ecs.Extensions;
@@ -26,14 +27,15 @@ namespace NosCore.PacketHandlers.Command
 {
     public class SetLevelCommandPacketHandler(IPubSubHub pubSubHub, IChannelHub channelHub,
         IExperienceService experienceService, IJobExperienceService jobExperienceService,
-        IHeroExperienceService heroExperienceService, ISessionRegistry sessionRegistry)
+        IHeroExperienceService heroExperienceService, ISessionRegistry sessionRegistry,
+        IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<SetLevelCommandPacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(SetLevelCommandPacket levelPacket, ClientSession session)
         {
             if (string.IsNullOrEmpty(levelPacket.Name) || (levelPacket.Name == session.Character.Name))
             {
-                await session.Character.SetLevelAsync(levelPacket.Level, experienceService, jobExperienceService, heroExperienceService, sessionRegistry);
+                await session.Character.SetLevelAsync(levelPacket.Level, experienceService, jobExperienceService, heroExperienceService, sessionRegistry, gameLanguageLocalizer);
                 return;
             }
 

--- a/src/NosCore.PacketHandlers/Command/SetReputationPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Command/SetReputationPacketHandler.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Core.I18N;
 using NosCore.Data.CommandPackets;
 using NosCore.Data.Enumerations;
 using NosCore.GameObject.Ecs.Extensions;
@@ -19,14 +20,14 @@ using Character = NosCore.Data.WebApi.Character;
 
 namespace NosCore.PacketHandlers.Command
 {
-    public class SetReputationPacketHandler(IPubSubHub pubSubHub)
+    public class SetReputationPacketHandler(IPubSubHub pubSubHub, IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<SetReputationPacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(SetReputationPacket setReputationPacket, ClientSession session)
         {
             if ((setReputationPacket.Name == session.Character.Name) || string.IsNullOrEmpty(setReputationPacket.Name))
             {
-                await session.Character.SetReputationAsync(setReputationPacket.Reputation);
+                await session.Character.SetReputationAsync(setReputationPacket.Reputation, gameLanguageLocalizer);
                 return;
             }
 

--- a/src/NosCore.PacketHandlers/Exchange/ExchangeRequestPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Exchange/ExchangeRequestPacketHandler.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Core.I18N;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.GameObject.Ecs.Extensions;
 using NosCore.GameObject.Ecs;
@@ -28,7 +29,7 @@ namespace NosCore.PacketHandlers.Exchange
 {
     public class ExchangeRequestPackettHandler(IExchangeService exchangeService, ILogger logger,
             IBlacklistHub blacklistHttpClient, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
-            ISessionRegistry sessionRegistry)
+            ISessionRegistry sessionRegistry, IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<ExchangeRequestPacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(ExchangeRequestPacket packet, ClientSession clientSession)
@@ -219,17 +220,17 @@ namespace NosCore.PacketHandlers.Exchange
                         }
 
                         var getSessionData = exchangeService.GetData(clientSession.Character.CharacterId);
-                        await clientSession.Character.RemoveGoldAsync(getSessionData.Gold);
+                        await clientSession.Character.RemoveGoldAsync(getSessionData.Gold, gameLanguageLocalizer);
                         clientSession.Character.RemoveBankGold(getSessionData.BankGold * 1000);
 
-                        await exchangeTarget.AddGoldAsync(getSessionData.Gold);
+                        await exchangeTarget.AddGoldAsync(getSessionData.Gold, gameLanguageLocalizer);
                         exchangeTarget.AddBankGold(getSessionData.BankGold * 1000);
 
                         var getTargetData = exchangeService.GetData(exchangeTarget.VisualId);
-                        await exchangeTarget.RemoveGoldAsync(getTargetData.Gold);
+                        await exchangeTarget.RemoveGoldAsync(getTargetData.Gold, gameLanguageLocalizer);
                         exchangeTarget.RemoveBankGold(getTargetData.BankGold * 1000);
 
-                        await clientSession.Character.AddGoldAsync(getTargetData.Gold);
+                        await clientSession.Character.AddGoldAsync(getTargetData.Gold, gameLanguageLocalizer);
                         clientSession.Character.AddBankGold(getTargetData.BankGold * 1000);
                     }
 

--- a/src/NosCore.PacketHandlers/Shops/BuyPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Shops/BuyPacketHandler.cs
@@ -12,6 +12,7 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Infastructure;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.BroadcastService;
+using NosCore.Core.I18N;
 using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Shared.Enumerations;
@@ -23,7 +24,7 @@ namespace NosCore.PacketHandlers.Shops
 {
     public class BuyPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             ISessionRegistry sessionRegistry, IOptions<WorldConfiguration> worldConfiguration,
-            IItemGenerationService itemProvider)
+            IItemGenerationService itemProvider, IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<BuyPacket>, IWorldPacketHandler
     {
         public override Task ExecuteAsync(BuyPacket buyPacket, ClientSession clientSession)
@@ -46,7 +47,7 @@ namespace NosCore.PacketHandlers.Shops
 
             if (aliveEntity != null)
             {
-                return clientSession.Character.BuyAsync(aliveEntity.Shop!, buyPacket.Slot, buyPacket.Amount, worldConfiguration, itemProvider);
+                return clientSession.Character.BuyAsync(aliveEntity.Shop!, buyPacket.Slot, buyPacket.Amount, worldConfiguration, itemProvider, gameLanguageLocalizer);
             }
 
             logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);

--- a/test/NosCore.GameObject.Tests/ShopTests.cs
+++ b/test/NosCore.GameObject.Tests/ShopTests.cs
@@ -160,7 +160,7 @@ namespace NosCore.GameObject.Tests
         {
             var itemBuilder = CreateItemBuilder();
             var shop = CreateShop(itemBuilder);
-            await Session.Character.BuyAsync(shop, 1, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
+            await Session.Character.BuyAsync(shop, 1, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
 
@@ -176,7 +176,7 @@ namespace NosCore.GameObject.Tests
                 Amount = 98
             });
             var shop = new Shop { ShopItems = list };
-            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
+            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         private async Task AttemptingToBuy_ItemsAsync(int value)
@@ -184,7 +184,7 @@ namespace NosCore.GameObject.Tests
             var itemBuilder = CreateItemBuilder();
             var shop = CreateShop(itemBuilder);
 
-            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
+            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         private void ShouldReceiveNotEnoughGoldMessage()
@@ -198,7 +198,7 @@ namespace NosCore.GameObject.Tests
         {
             var itemBuilder = CreateItemBuilder(0, 500000);
             var shop = CreateShop(itemBuilder);
-            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder);
+            await Session.Character.BuyAsync(shop, 0, 99, TestHelpers.Instance.WorldConfiguration, itemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         private void ShouldReceiveReputationError()
@@ -227,7 +227,7 @@ namespace NosCore.GameObject.Tests
         private async Task AttemptingToBuyWithFullInventoryAsync()
         {
             var shop = CreateShop(ItemBuilder, -1, 1);
-            await Session.Character.BuyAsync(shop, 0, 999, TestHelpers.Instance.WorldConfiguration, ItemBuilder);
+            await Session.Character.BuyAsync(shop, 0, 999, TestHelpers.Instance.WorldConfiguration, ItemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         private void ShouldReceiveNotEnoughSpaceMessage()
@@ -254,7 +254,7 @@ namespace NosCore.GameObject.Tests
         private async Task Buying998ItemsAt1GoldEachAsync()
         {
             var shop = CreateShop(ItemBuilder);
-            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration, ItemBuilder);
+            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration, ItemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         private void AllInventorySlotsShouldHave_Items(int value)
@@ -288,7 +288,7 @@ namespace NosCore.GameObject.Tests
             var list = new ConcurrentDictionary<int, ShopItem>();
             list.TryAdd(0, new ShopItem { Slot = 0, ItemInstance = ItemBuilder.Create(1), Type = 0 });
             var shop = new Shop { ShopItems = list };
-            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration, ItemBuilder);
+            await Session.Character.BuyAsync(shop, 0, 998, TestHelpers.Instance.WorldConfiguration, ItemBuilder, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         private void ReputationShouldBeDeducted()

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
@@ -63,8 +63,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
                 new HpService(),
                 new MpService(),
                 new Mock<ISessionGroupFactory>().Object,
-                new CharacterInitializationService(),
-                TestHelpers.Instance.GameLanguageLocalizer);
+                new CharacterInitializationService());
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Command/SetLevelCommandPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Command/SetLevelCommandPacketHandlerTests.cs
@@ -52,7 +52,8 @@ namespace NosCore.PacketHandlers.Tests.Command
                 .Returns(Task.FromResult(new List<ChannelInfo>()));
 
             Handler = new SetLevelCommandPacketHandler(PubSubHub.Object, ChannelHub.Object,
-                new ExperienceService(), new JobExperienceService(), new HeroExperienceService(), TestHelpers.Instance.SessionRegistry);
+                new ExperienceService(), new JobExperienceService(), new HeroExperienceService(), TestHelpers.Instance.SessionRegistry,
+                TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Command/SetReputationPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Command/SetReputationPacketHandlerTests.cs
@@ -41,7 +41,7 @@ namespace NosCore.PacketHandlers.Tests.Command
             PubSubHub.Setup(x => x.GetSubscribersAsync())
                 .Returns(Task.FromResult(new List<Subscriber>()));
 
-            Handler = new SetReputationPacketHandler(PubSubHub.Object);
+            Handler = new SetReputationPacketHandler(PubSubHub.Object, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Exchange/ExchangeRequestPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Exchange/ExchangeRequestPacketHandlerTests.cs
@@ -53,7 +53,8 @@ namespace NosCore.PacketHandlers.Tests.Exchange
                 Logger,
                 BlacklistHub.Object,
                 TestHelpers.Instance.LogLanguageLocalizer,
-                TestHelpers.Instance.SessionRegistry);
+                TestHelpers.Instance.SessionRegistry,
+                TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Shops/BuyPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/BuyPacketHandlerTests.cs
@@ -36,7 +36,8 @@ namespace NosCore.PacketHandlers.Tests.Shops
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.SessionRegistry,
                 TestHelpers.Instance.WorldConfiguration,
-                TestHelpers.Instance.GenerateItemProvider());
+                TestHelpers.Instance.GenerateItemProvider(),
+                TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         [TestMethod]

--- a/test/NosCore.Tests.Shared/TestHelpers.cs
+++ b/test/NosCore.Tests.Shared/TestHelpers.cs
@@ -302,7 +302,7 @@ namespace NosCore.Tests.Shared
                 new FinsPacketHandler(FriendHttpClient.Object, ChannelHttpClient.Object, TestHelpers.Instance.PubSubHub.Object, Instance.SessionRegistry),
                 new SelectPacketHandler(CharacterDao, Logger, new Mock<IItemGenerationService>().Object, MapInstanceAccessorService,
                     ItemInstanceDao, InventoryItemInstanceDao, StaticBonusDao, new Mock<IDao<QuicklistEntryDto, Guid>>().Object, new Mock<IDao<TitleDto, Guid>>().Object, new Mock<IDao<CharacterQuestDto, Guid>>().Object,
-                    new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, Instance.Clock, ItemList, new HpService(), new MpService(), SessionGroupFactory, new CharacterInitializationService(), Instance.GameLanguageLocalizer),
+                    new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, Instance.Clock, ItemList, new HpService(), new MpService(), SessionGroupFactory, new CharacterInitializationService()),
                 new CSkillPacketHandler(Instance.Clock),
                 new CBuyPacketHandler(new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, Logger, ItemInstanceDao, Instance.LogLanguageLocalizer),
                 new CRegPacketHandler(WorldConfiguration, new Mock<IBazaarHub>().Object, ItemInstanceDao, InventoryItemInstanceDao),
@@ -400,8 +400,7 @@ namespace NosCore.Tests.Shared
                 true,
                 now,
                 now,
-                0,
-                Instance.GameLanguageLocalizer
+                0
             );
 
             mapInstance.EcsWorld.AddComponent(playerEntity, playerStateComponent);


### PR DESCRIPTION
## Summary
Finishes the `PlayerStateComponent` god-class extraction. The last service left in the component (`IGameLanguageLocalizer`) was wired into `ICharacterEntity.GetMessageFromKey` and the bundle's instance method of the same name. Extracted to a per-call-site parameter on the ~5 extension methods that actually need localized strings.

## Changes
**Extensions taking the localizer as a parameter now:**
- `PlayerBundleExtensions.SetReputationAsync` — `REPUTATION_CHANGED`
- `PlayerBundleExtensions.SetLevelAsync` — `SUPPORT` prefix on levelup broadcast
- `PlayerBundleExtensions.GenerateCInfo` — `SUPPORT` prefix on moderator names
- `CharacterEntityExtension.AddGoldAsync` / `RemoveGoldAsync` (+ their private `GenerateUpdateGoldSayPacket`) — `UPDATE_GOLD`
- `CharacterEntityExtension.BuyAsync` — `TOO_RICH_SELLER`

**Callers now pass the localizer (injected via DI):**
- `SetReputationPacketHandler`, `SetLevelCommandPacketHandler`
- `MapChangeService.ChangeMapInstanceAsync`
- `ExchangeRequestPackettHandler` (for the Add/RemoveGold calls during trades)
- `BuyPacketHandler`

**Cleanup:**
- `ICharacterEntity.GetMessageFromKey` removed from the interface
- `PlayerComponentBundle.GetMessageFromKey` removed from the bundle
- `SelectPacketHandler` no longer takes the localizer (nothing needs it there now)
- `PlayerStateComponent` drops the last service field

## End state
`PlayerStateComponent` is now **12 fields of pure data**: character state (`CharacterDto`, `Account`, `Script`) + flags + timings + `SpCooldown` + `VehicleSpeed`. Zero service references. God-class is gone.

## Test plan
- [x] Solution builds clean (0 warnings, 0 errors)
- [x] Full test suite: **829 passed / 0 failed**

## Context
Follow-up to #2072. No runtime behavior change — the same `LanguageKey → string` lookups happen, just sourced from DI at the call site instead of from a per-player service reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)