### PR TITLE
Dedupe SpCooldown and IsSitting across components

### DIFF
--- a/src/NosCore.GameObject/Ecs/Components/PlayerFlagsComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerFlagsComponent.cs
@@ -18,5 +18,4 @@ public record struct PlayerFlagsComponent(
     bool UseSp,
     bool IsVehicled,
     bool Invisible,
-    bool IsSitting,
     bool Camouflage);

--- a/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/PlayerStateComponent.cs
@@ -17,7 +17,6 @@ public record struct PlayerStateComponent(
     bool CanFight,
     Instant LastPortal,
     Instant LastSp,
-    short SpCooldown,
     byte VehicleSpeed,
     IGameLanguageLocalizer GameLanguageLocalizer
 );

--- a/src/NosCore.GameObject/Ecs/Components/SpComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/SpComponent.cs
@@ -1,3 +1,3 @@
 namespace NosCore.GameObject.Ecs.Components;
 
-public record struct SpComponent(int SpCooldown, int SpPoint, int SpAdditionPoint);
+public record struct SpComponent(short SpCooldown, int SpPoint, int SpAdditionPoint);

--- a/src/NosCore.GameObject/Ecs/MapWorld.cs
+++ b/src/NosCore.GameObject/Ecs/MapWorld.cs
@@ -191,7 +191,7 @@ public class MapWorld : IDisposable
             new NameComponent(name),
             new CombatComponent(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, new SemaphoreSlim(1, 1), new ConcurrentDictionary<Entity, int>()),
             new PlayerComponent(accountId, characterId, isGm, serverId),
-            new PlayerFlagsComponent(false, false, false, false, false, false, false, false, false, false, false, authority, false, false, false, false, false),
+            new PlayerFlagsComponent(false, false, false, false, false, false, false, false, false, false, false, authority, false, false, false, false),
             new TimingComponent(now, now),
             new SpeedComponent(speed)
         );

--- a/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
+++ b/src/NosCore.GameObject/Ecs/PlayerComponentBundle.cs
@@ -57,25 +57,12 @@ public readonly partial struct PlayerComponentBundle : ICharacterEntity
     // IVisualEntity - VisualId and VisualType are generated
     public short VNum => 0;
 
-    // IAliveEntity
-    public bool IsSitting
-    {
-        get => VisualIsSitting;
-        set => VisualIsSitting = value;
-    }
-
     public short Race => (short)Class;
 
     // INamedEntity - LevelXp is generated
 
     // ICharacterEntity
     byte? ICharacterEntity.VehicleSpeed => VehicleSpeed;
-
-    public short SpCooldown
-    {
-        get => PlayerStateSpCooldown;
-        set => PlayerStateSpCooldown = value;
-    }
 
     public short MapId
     {

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -164,7 +164,6 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     now,
                     now,
                     0,
-                    0,
                     gameLanguageLocalizer
                 );
 

--- a/test/NosCore.Tests.Shared/TestHelpers.cs
+++ b/test/NosCore.Tests.Shared/TestHelpers.cs
@@ -415,7 +415,6 @@ namespace NosCore.Tests.Shared
                 now,
                 now,
                 0,
-                0,
                 Instance.GameLanguageLocalizer
             );
 


### PR DESCRIPTION
## Summary
- Remove duplicate `SpCooldown` from `PlayerStateComponent`; keep it on `SpComponent` and widen the type from `int` to `short` to match existing usage
- Remove duplicate `IsSitting` from `PlayerFlagsComponent`; keep it on `VisualComponent`
- Drop the manual pass-through properties in `PlayerComponentBundle` — with unique names the source generator emits natural accessors

## Test plan
- [x] Solution builds with 0 warnings / 0 errors
- [x] All existing tests pass (312 + 412 + others)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>