### PR TITLE
Refactor quest engine: self-describing IQuestTypeHandler

### DIFF
--- a/src/NosCore.GameObject/Messaging/WolverineDependencyRegistrar.cs
+++ b/src/NosCore.GameObject/Messaging/WolverineDependencyRegistrar.cs
@@ -93,6 +93,14 @@ public static class WolverineDependencyRegistrar
             services.AddTransient(impl);
         }
 
+        foreach (var impl in gameObjectAssembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
+            .Where(t => typeof(Services.QuestService.IQuestTypeHandler).IsAssignableFrom(t)))
+        {
+            services.AddTransient(typeof(Services.QuestService.IQuestTypeHandler), impl);
+            services.AddTransient(impl);
+        }
+
         var suffixes = new[] { "Service", "Provider", "Resolver", "Calculator", "Catalog", "Queue", "Ai" };
         foreach (var impl in gameObjectAssembly.GetTypes()
             .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)

--- a/src/NosCore.GameObject/Services/BattleService/RewardService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/RewardService.cs
@@ -10,12 +10,10 @@ using System.Threading.Tasks;
 using Arch.Core;
 using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Ecs;
-using NosCore.GameObject.Ecs.Extensions;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.GameObject.Services.MapItemGenerationService;
 using NosCore.GameObject.Services.QuestService;
-using NosCore.Packets.Enumerations;
 using NosCore.Shared.Helpers;
 using Serilog;
 
@@ -31,6 +29,7 @@ public sealed class RewardService(
     IItemGenerationService itemGenerationService,
     IMapItemGenerationService mapItemGenerationService,
     INpcCombatCatalog catalog,
+    IQuestService questService,
     ILogger logger) : IRewardService
 {
     // Gold item vnum. The GoldDropHandler already treats vnum 1046 as the "gold"
@@ -71,54 +70,24 @@ public sealed class RewardService(
         AwardExperience(victim, mob, totalDamage);
         SpawnDrops(victim, mob, mapInstance);
         SpawnGold(victim, mob, mapInstance);
-        _ = ProgressKillQuestsAsync(victim, mob);
+        _ = ProgressQuestsAsync(victim, mob);
 
         victim.HitList.Clear();
         _ = killer;
         return Task.CompletedTask;
     }
 
-    private static async Task ProgressKillQuestsAsync(IAliveEntity victim, NpcMonsterDto mob)
+    private Task ProgressQuestsAsync(IAliveEntity victim, NpcMonsterDto mob)
     {
+        var tasks = new List<Task>();
         foreach (var (handle, _) in victim.HitList)
         {
-            if (!TryFindCharacter(victim, handle, out var character))
+            if (TryFindCharacter(victim, handle, out var character))
             {
-                continue;
-            }
-
-            var updated = false;
-            foreach (var questKv in character.Quests)
-            {
-                var quest = questKv.Value;
-                if (quest.CompletedOn != null)
-                {
-                    continue;
-                }
-                if (quest.Quest.QuestType != QuestType.Hunt && quest.Quest.QuestType != QuestType.NumberOfKill)
-                {
-                    continue;
-                }
-                foreach (var objective in quest.Quest.QuestObjectives)
-                {
-                    if (objective.FirstData != mob.NpcMonsterVNum)
-                    {
-                        continue;
-                    }
-                    var required = objective.SecondData ?? 0;
-                    var current = quest.ObjectiveProgress.AddOrUpdate(objective.QuestObjectiveId, 1, (_, existing) => existing + 1);
-                    if (current > required && required > 0)
-                    {
-                        quest.ObjectiveProgress[objective.QuestObjectiveId] = required;
-                    }
-                    updated = true;
-                }
-                if (updated)
-                {
-                    await character.SendPacketAsync(quest.GenerateQstiPacket(false));
-                }
+                tasks.Add(questService.OnMonsterKilledAsync(character, mob));
             }
         }
+        return Task.WhenAll(tasks);
     }
 
     private static void AwardExperience(IAliveEntity victim, NpcMonsterDto mob, int totalDamage)

--- a/src/NosCore.GameObject/Services/QuestService/Handlers/GoToQuestHandler.cs
+++ b/src/NosCore.GameObject/Services/QuestService/Handlers/GoToQuestHandler.cs
@@ -1,0 +1,36 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.GameObject.Services.QuestService.Handlers;
+
+[UsedImplicitly]
+public sealed class GoToQuestHandler : IQuestTypeHandler
+{
+    public QuestType QuestType => QuestType.GoTo;
+
+    public async Task<bool> ValidateAsync(ICharacterEntity character, CharacterQuest quest)
+    {
+        var targetX = quest.Quest.TargetX ?? 0;
+        var targetY = quest.Quest.TargetY ?? 0;
+        var targetMap = quest.Quest.TargetMap ?? 0;
+
+        var inRange = character.MapX <= targetX + 5 && character.MapX >= targetX - 5
+            && character.MapY <= targetY + 5 && character.MapY >= targetY - 5
+            && character.MapId == targetMap;
+        if (!inRange)
+        {
+            return false;
+        }
+
+        await character.SendPacketAsync(quest.Quest.GenerateTargetOffPacket());
+        return true;
+    }
+}

--- a/src/NosCore.GameObject/Services/QuestService/Handlers/HuntQuestHandler.cs
+++ b/src/NosCore.GameObject/Services/QuestService/Handlers/HuntQuestHandler.cs
@@ -1,0 +1,44 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Extensions;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.GameObject.Services.QuestService.Handlers;
+
+[UsedImplicitly]
+public sealed class HuntQuestHandler : IQuestTypeHandler
+{
+    public QuestType QuestType => QuestType.Hunt;
+
+    public async Task OnMonsterKilledAsync(ICharacterEntity character, NpcMonsterDto mob, CharacterQuest quest)
+    {
+        var progressed = false;
+        foreach (var objective in quest.Quest.QuestObjectives)
+        {
+            if (objective.FirstData != mob.NpcMonsterVNum)
+            {
+                continue;
+            }
+            var required = objective.SecondData ?? 0;
+            var current = quest.ObjectiveProgress.AddOrUpdate(objective.QuestObjectiveId, 1, (_, e) => e + 1);
+            if (required > 0 && current > required)
+            {
+                quest.ObjectiveProgress[objective.QuestObjectiveId] = required;
+            }
+            progressed = true;
+        }
+
+        if (progressed)
+        {
+            await character.SendPacketAsync(quest.GenerateQstiPacket(false));
+        }
+    }
+}

--- a/src/NosCore.GameObject/Services/QuestService/Handlers/NumberOfKillQuestHandler.cs
+++ b/src/NosCore.GameObject/Services/QuestService/Handlers/NumberOfKillQuestHandler.cs
@@ -1,0 +1,44 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Extensions;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.GameObject.Services.QuestService.Handlers;
+
+[UsedImplicitly]
+public sealed class NumberOfKillQuestHandler : IQuestTypeHandler
+{
+    public QuestType QuestType => QuestType.NumberOfKill;
+
+    public async Task OnMonsterKilledAsync(ICharacterEntity character, NpcMonsterDto mob, CharacterQuest quest)
+    {
+        var progressed = false;
+        foreach (var objective in quest.Quest.QuestObjectives)
+        {
+            if (objective.FirstData != mob.NpcMonsterVNum)
+            {
+                continue;
+            }
+            var required = objective.SecondData ?? 0;
+            var current = quest.ObjectiveProgress.AddOrUpdate(objective.QuestObjectiveId, 1, (_, e) => e + 1);
+            if (required > 0 && current > required)
+            {
+                quest.ObjectiveProgress[objective.QuestObjectiveId] = required;
+            }
+            progressed = true;
+        }
+
+        if (progressed)
+        {
+            await character.SendPacketAsync(quest.GenerateQstiPacket(false));
+        }
+    }
+}

--- a/src/NosCore.GameObject/Services/QuestService/IQuestService.cs
+++ b/src/NosCore.GameObject/Services/QuestService/IQuestService.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.Packets.ClientPackets.Quest;
 using System.Threading.Tasks;
@@ -14,5 +15,6 @@ namespace NosCore.GameObject.Services.QuestService
     {
         Task RunScriptAsync(ICharacterEntity character);
         Task RunScriptAsync(ICharacterEntity character, ScriptClientPacket? packet);
+        Task OnMonsterKilledAsync(ICharacterEntity character, NpcMonsterDto mob);
     }
 }

--- a/src/NosCore.GameObject/Services/QuestService/IQuestTypeHandler.cs
+++ b/src/NosCore.GameObject/Services/QuestService/IQuestTypeHandler.cs
@@ -1,0 +1,21 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Threading.Tasks;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.Packets.Enumerations;
+
+namespace NosCore.GameObject.Services.QuestService;
+
+public interface IQuestTypeHandler
+{
+    QuestType QuestType { get; }
+
+    Task<bool> ValidateAsync(ICharacterEntity character, CharacterQuest quest) => Task.FromResult(false);
+
+    Task OnMonsterKilledAsync(ICharacterEntity character, NpcMonsterDto mob, CharacterQuest quest) => Task.CompletedTask;
+}

--- a/src/NosCore.GameObject/Services/QuestService/QuestService.cs
+++ b/src/NosCore.GameObject/Services/QuestService/QuestService.cs
@@ -29,7 +29,8 @@ namespace NosCore.GameObject.Services.QuestService
     public class QuestService(List<ScriptDto> scripts,
             IOptions<WorldConfiguration> worldConfiguration, List<QuestDto> quests,
             List<QuestObjectiveDto> questObjectives, ILogger logger, IClock clock,
-            ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+            ILogLanguageLocalizer<LogLanguageKey> logLanguage,
+            IEnumerable<IQuestTypeHandler> questTypeHandlers)
         : IQuestService
     {
         public Task RunScriptAsync(ICharacterEntity character) => RunScriptAsync(character, null);
@@ -243,74 +244,28 @@ namespace NosCore.GameObject.Services.QuestService
             return true;
         }
 
-        public async Task<bool> ValidateQuestAsync(ICharacterEntity character, short questId)
+        public Task<bool> ValidateQuestAsync(ICharacterEntity character, short questId)
         {
-            var isValid = false;
             var characterQuest = character.Quests.Values.FirstOrDefault(s => s.QuestId == questId);
-            switch (characterQuest?.Quest.QuestType)
+            if (characterQuest is null)
             {
-                case QuestType.Hunt:
-                    break;
-                case QuestType.SpecialCollect:
-                    break;
-                case QuestType.CollectInRaid:
-                    break;
-                case QuestType.Brings:
-                    break;
-                case QuestType.CaptureWithoutGettingTheMonster:
-                    break;
-                case QuestType.Capture:
-                    break;
-                case QuestType.TimesSpace:
-                    break;
-                case QuestType.Product:
-                    break;
-                case QuestType.NumberOfKill:
-                    break;
-                case QuestType.TargetReput:
-                    break;
-                case QuestType.TsPoint:
-                    break;
-                case QuestType.Dialog1:
-                    break;
-                case QuestType.CollectInTs:
-                    break;
-                case QuestType.Required:
-                    break;
-                case QuestType.Wear:
-                    break;
-                case QuestType.Needed:
-                    break;
-                case QuestType.Collect:
-                    break;
-                case QuestType.TransmitGold:
-                    break;
-                case QuestType.GoTo:
-                    isValid = (character.MapX <= (characterQuest.Quest.TargetX ?? 0) + 5 && character.MapX >= (characterQuest.Quest.TargetX ?? 0) - 5)
-                        && (character.MapY <= (characterQuest.Quest.TargetY ?? 0) + 5 && character.MapY >= (characterQuest.Quest.TargetY ?? 0) - 5)
-                        && (character.MapId == (characterQuest.Quest.TargetMap ?? 0));
-                    if (isValid)
-                    {
-                        await character.SendPacketAsync(characterQuest.Quest.GenerateTargetOffPacket());
-                    }
-                    break;
-                case QuestType.CollectMapEntity:
-                    break;
-                case QuestType.Use:
-                    break;
-                case QuestType.Dialog2:
-                    break;
-                case QuestType.UnKnow:
-                    break;
-                case QuestType.Inspect:
-                    break;
-                case QuestType.WinRaid:
-                    break;
-                case QuestType.FlowerQuest:
-                    break;
+                return Task.FromResult(false);
             }
 
-            return isValid;
+            var handler = questTypeHandlers.FirstOrDefault(h => h.QuestType == characterQuest.Quest.QuestType);
+            return handler?.ValidateAsync(character, characterQuest) ?? Task.FromResult(false);
+        }
+
+        public Task OnMonsterKilledAsync(ICharacterEntity character, NpcMonsterDto mob)
+        {
+            var tasks = character.Quests.Values
+                .Where(q => q.CompletedOn is null)
+                .Select(q =>
+                {
+                    var handler = questTypeHandlers.FirstOrDefault(h => h.QuestType == q.Quest.QuestType);
+                    return handler?.OnMonsterKilledAsync(character, mob, q) ?? Task.CompletedTask;
+                });
+            return Task.WhenAll(tasks);
         }
     }
 }

--- a/test/NosCore.GameObject.Tests/Services/QuestService/QuestServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/QuestService/QuestServiceTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.QuestService;
+using NosCore.GameObject.Services.QuestService.Handlers;
 using NosCore.Packets.Enumerations;
 using NosCore.Tests.Shared;
 using Serilog;
@@ -109,7 +110,13 @@ namespace NosCore.GameObject.Tests.Services.QuestService
                 QuestObjectives,
                 Logger,
                 TestHelpers.Instance.Clock,
-                TestHelpers.Instance.LogLanguageLocalizer);
+                TestHelpers.Instance.LogLanguageLocalizer,
+                new IQuestTypeHandler[]
+                {
+                    new HuntQuestHandler(),
+                    new NumberOfKillQuestHandler(),
+                    new GoToQuestHandler(),
+                });
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- Introduces `IQuestTypeHandler` with a `QuestType` discriminator property — same pattern as `INrunEventHandler` from #2082.
- Replaces the 27-case switch in `QuestService.ValidateQuestAsync` with `questTypeHandlers.FirstOrDefault(h => h.QuestType == quest.Quest.QuestType)`.
- Moves kill-progress tracking out of `RewardService` into per-type handlers via a new `IQuestService.OnMonsterKilledAsync`. `Hunt` and `NumberOfKill` each own their own handler file; adding e.g. `Capture` or `Collect` is a new file, not an edited switch.
- Auto-registration in `WolverineDependencyRegistrar` so new handler files wire themselves up.

## Test plan
- [x] `dotnet build NosCore.sln` — clean
- [x] `dotnet test test/NosCore.GameObject.Tests/` — 250/250 pass
- [ ] Smoke-test: pick up a Hunt quest, kill mobs, confirm `qsti` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)