### PR TITLE
chore: support local NuGet source via NOSCORE_LOCAL_PACKAGES env var

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(NOSCORE_LOCAL_PACKAGES)' != ''">
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(NOSCORE_LOCAL_PACKAGES)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ We recommend usage of :
 ## 4. Start services ##
 - script to start services are in .\scripts 
 
+## 5. (Optional) Local NuGet packages ##
+Every NosCore repo ships a `Directory.Build.props` that adds a NuGet source when the `NOSCORE_LOCAL_PACKAGES` environment variable is set — useful for testing an un-released `NosCore.Packets` / `NosCore.Dao` / `NosCore.Shared` build without publishing it.
+
+One-time setup (run once per machine):
+```
+setx NOSCORE_LOCAL_PACKAGES C:\LocalPackages
+mkdir C:\LocalPackages
+```
+Restart Visual Studio / your shell so the new variable is picked up.
+
+Drop any `.nupkg` file into that folder, then restore as usual. If the variable is unset the property group is skipped and only nuget.org is used — no action needed for contributors who don't want local packages.
+


### PR DESCRIPTION
## Summary
- Adds a conditional `RestoreAdditionalProjectSources` PropertyGroup to `Directory.Build.props` that activates only when `NOSCORE_LOCAL_PACKAGES` is set.
- No runtime cost for contributors who don't opt in — the property group is skipped, restore uses nuget.org only.
- Documents the setup in README section 5.

## Test plan
- [ ] `dotnet restore` succeeds with `NOSCORE_LOCAL_PACKAGES` unset.
- [ ] `dotnet restore` with `NOSCORE_LOCAL_PACKAGES` pointing to a folder with a .nupkg picks it up.

Generated with [Claude Code](https://claude.com/claude-code)