### PR TITLE
refactor: migrate Serilog.ILogger to Microsoft.Extensions.Logging.ILogger<T>

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,9 +42,9 @@
     <PackageVersion Include="NodaTime.Testing" Version="3.3.1" />
     <PackageVersion Include="NosCore.Algorithm" Version="2.0.0" />
     <PackageVersion Include="NosCore.Analyzers" Version="2.0.0" />
-    <PackageVersion Include="NosCore.Dao" Version="4.0.5" />
+    <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
     <PackageVersion Include="NosCore.FastMember" Version="1.5.0" />
-    <PackageVersion Include="NosCore.Networking" Version="7.1.0" />
+    <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
     <PackageVersion Include="NosCore.Packets" Version="17.0.0" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
     <PackageVersion Include="NosCore.Shared" Version="6.0.0" />

--- a/src/NosCore.Database/Hosting/PersistenceModule.cs
+++ b/src/NosCore.Database/Hosting/PersistenceModule.cs
@@ -23,7 +23,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.Database.Entities;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.Database.Hosting;
 
@@ -160,14 +160,14 @@ public sealed class PersistenceModule : Autofac.Module
                 if (staticMetaDataAttribute != null &&
                     staticMetaDataAttribute.LoadedMessage != LogLanguageKey.UNKNOWN)
                 {
-                    c.Resolve<ILogger>().Information(
+                    c.Resolve<ILogger<PersistenceModule>>().LogInformation(
                         c.Resolve<ILogLanguageLocalizer<LogLanguageKey>>()[staticMetaDataAttribute.LoadedMessage],
                         items.Count);
                 }
             }
             else
             {
-                c.Resolve<ILogger>().Error(
+                c.Resolve<ILogger<PersistenceModule>>().LogError(
                     c.Resolve<ILogLanguageLocalizer<LogLanguageKey>>()[staticMetaDataAttribute.EmptyMessage]);
             }
 

--- a/src/NosCore.GameObject/Ecs/Extensions/CharacterEntityExtension.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/CharacterEntityExtension.cs
@@ -43,7 +43,7 @@ using NosCore.Packets.ServerPackets.Visibility;
 using NosCore.Shared.Enumerations;
 using NosCore.Core.I18N;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -175,7 +175,7 @@ namespace NosCore.GameObject.Ecs.Extensions
                     case NoscorePocketType.Wear:
                         break;
                     default:
-                        logger.Information(
+                        logger.LogInformation(
                             logLanguageLocalizer[LogLanguageKey.POCKETTYPE_UNKNOWN]);
                         break;
                 }

--- a/src/NosCore.GameObject/Ecs/Extensions/NonPlayableEntityExtension.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/NonPlayableEntityExtension.cs
@@ -20,7 +20,7 @@ using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Packets.Enumerations;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -127,7 +127,7 @@ namespace NosCore.GameObject.Ecs.Extensions
                 }
                 catch (Exception e)
                 {
-                    logger.Error(e.Message, e);
+                    logger.LogError(e.Message, e);
                 }
             }
             entity.Life = Observable.Interval(TimeSpan.FromMilliseconds(400)).Select(_ => LifeAsync()).Subscribe();

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/BaseHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/BaseHubClient.cs
@@ -5,9 +5,9 @@
 //
 
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Retry;
-using Serilog;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,39 +19,39 @@ public abstract class BaseHubClient : IAsyncDisposable
     private readonly HubConnection _hubConnection;
     private readonly SemaphoreSlim _connectionLock = new(1, 1);
     private readonly ILogger _logger;
+    private readonly AsyncRetryPolicy _retryPolicy;
     private bool _isStarted;
-
-    private static readonly AsyncRetryPolicy RetryPolicy = Policy
-        .Handle<Exception>()
-        .WaitAndRetryAsync(
-            3,
-            attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)),
-            (exception, timeSpan, retryCount, _) =>
-            {
-                Log.Warning(exception, "Hub call failed. Retry {RetryCount} in {TimeSpan}", retryCount, timeSpan);
-            });
 
     protected BaseHubClient(HubConnectionFactory hubConnectionFactory, string hubName, ILogger logger)
     {
         _logger = logger;
+        _retryPolicy = Policy
+            .Handle<Exception>()
+            .WaitAndRetryAsync(
+                3,
+                attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)),
+                (exception, timeSpan, retryCount, _) =>
+                {
+                    _logger.LogWarning(exception, "Hub call failed. Retry {RetryCount} in {TimeSpan}", retryCount, timeSpan);
+                });
         _hubConnection = hubConnectionFactory.Create(hubName);
 
         _hubConnection.Reconnecting += error =>
         {
-            _logger.Warning("Hub {HubName} reconnecting...", hubName);
+            _logger.LogWarning("Hub {HubName} reconnecting...", hubName);
             return Task.CompletedTask;
         };
 
         _hubConnection.Reconnected += connectionId =>
         {
-            _logger.Information("Hub {HubName} reconnected", hubName);
+            _logger.LogInformation("Hub {HubName} reconnected", hubName);
             return Task.CompletedTask;
         };
 
         _hubConnection.Closed += error =>
         {
             _isStarted = false;
-            _logger.Warning("Hub {HubName} connection closed", hubName);
+            _logger.LogWarning("Hub {HubName} connection closed", hubName);
             return Task.CompletedTask;
         };
     }
@@ -80,7 +80,7 @@ public abstract class BaseHubClient : IAsyncDisposable
 
     protected async Task<T> InvokeAsync<T>(string methodName, params object?[] args)
     {
-        return await RetryPolicy.ExecuteAsync(async () =>
+        return await _retryPolicy.ExecuteAsync(async () =>
         {
             await EnsureConnectedAsync();
             return await _hubConnection.InvokeCoreAsync<T>(methodName, args);
@@ -89,7 +89,7 @@ public abstract class BaseHubClient : IAsyncDisposable
 
     protected async Task InvokeAsync(string methodName, params object?[] args)
     {
-        await RetryPolicy.ExecuteAsync(async () =>
+        await _retryPolicy.ExecuteAsync(async () =>
         {
             await EnsureConnectedAsync();
             await _hubConnection.InvokeCoreAsync(methodName, args);

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/BazaarHub/BazaarHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/BazaarHub/BazaarHubClient.cs
@@ -7,13 +7,13 @@
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.WebApi;
 using NosCore.Packets.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.InterChannelCommunication.Hubs.BazaarHub
 {
-    public class BazaarHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger)
+    public class BazaarHubClient(HubConnectionFactory hubConnectionFactory, ILogger<BazaarHubClient> logger)
         : BaseHubClient(hubConnectionFactory, nameof(BazaarHub), logger), IBazaarHub
     {
         public Task<List<BazaarLink>> GetBazaar(long id, byte? index, byte? pageSize, BazaarListType? typeFilter,

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/BlacklistHub/BlacklistHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/BlacklistHub/BlacklistHubClient.cs
@@ -6,14 +6,14 @@
 
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.WebApi;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.InterChannelCommunication.Hubs.BlacklistHub
 {
-    public class BlacklistHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger)
+    public class BlacklistHubClient(HubConnectionFactory hubConnectionFactory, ILogger<BlacklistHubClient> logger)
         : BaseHubClient(hubConnectionFactory, nameof(BlacklistHub), logger), IBlacklistHub
     {
         public Task<LanguageKey> AddBlacklistAsync(BlacklistRequest blacklistRequest) =>

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/ChannelHub/ChannelHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/ChannelHub/ChannelHubClient.cs
@@ -3,14 +3,14 @@ using NosCore.Core;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
 using Polly;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.InterChannelCommunication.Hubs.ChannelHub
 {
-    public class ChannelHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage) : IChannelHub
+    public class ChannelHubClient(HubConnectionFactory hubConnectionFactory, ILogger<ChannelHubClient> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage) : IChannelHub
     {
         private readonly HubConnection _hubConnection = hubConnectionFactory.Create(nameof(ChannelHub));
 
@@ -18,16 +18,16 @@ namespace NosCore.GameObject.InterChannelCommunication.Hubs.ChannelHub
         {
             await _hubConnection.StartAsync();
             await _hubConnection.InvokeAsync(nameof(Bind), data);
-            logger.Debug(logLanguage[LogLanguageKey.REGISTRED_ON_MASTER]);
+            logger.LogDebug(logLanguage[LogLanguageKey.REGISTRED_ON_MASTER]);
 
             await Policy
                 .HandleResult<bool>(ping => ping)
                 .WaitAndRetryForeverAsync(retryAttempt => TimeSpan.FromSeconds(1),
                     (_, __, timeSpan) =>
-                        logger.Verbose(
+                        logger.LogTrace(
                             logLanguage[LogLanguageKey.MASTER_SERVER_PING])
                 ).ExecuteAsync(Ping);
-            logger.Error(
+            logger.LogError(
                 logLanguage[LogLanguageKey.MASTER_SERVER_PING_FAILED]);
             Environment.Exit(0);
         }

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/FriendHub/FriendHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/FriendHub/FriendHubClient.cs
@@ -6,14 +6,14 @@
 
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.WebApi;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.InterChannelCommunication.Hubs.FriendHub
 {
-    public class FriendHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger)
+    public class FriendHubClient(HubConnectionFactory hubConnectionFactory, ILogger<FriendHubClient> logger)
         : BaseHubClient(hubConnectionFactory, nameof(FriendHub), logger), IFriendHub
     {
         public Task<LanguageKey> AddFriendAsync(FriendShipRequest friendPacket) =>

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/MailHub/MailHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/MailHub/MailHubClient.cs
@@ -7,13 +7,13 @@
 using Json.Patch;
 using NosCore.Data.WebApi;
 using NosCore.GameObject.InterChannelCommunication.Messages;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.InterChannelCommunication.Hubs.MailHub
 {
-    public class MailHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger)
+    public class MailHubClient(HubConnectionFactory hubConnectionFactory, ILogger<MailHubClient> logger)
         : BaseHubClient(hubConnectionFactory, nameof(MailHub), logger), IMailHub
     {
         public Task<List<MailData>> GetMails(long id, long characterId, bool senderCopy) =>

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/PubSub/PubSubHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/PubSub/PubSubHubClient.cs
@@ -3,7 +3,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.WebApi;
 using NosCore.GameObject.InterChannelCommunication.Messages;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -14,7 +14,7 @@ namespace NosCore.GameObject.InterChannelCommunication.Hubs.PubSub
     public class PubSubHubClient : IPubSubHubClient, IAsyncDisposable
     {
         private readonly HubConnection _hubConnection;
-        private readonly ILogger _logger;
+        private readonly ILogger<PubSubHubClient> _logger;
         private readonly ILogLanguageLocalizer<LogLanguageKey> _logLanguage;
         private readonly SemaphoreSlim _connectionLock = new(1, 1);
         private bool _isStarted;
@@ -23,7 +23,7 @@ namespace NosCore.GameObject.InterChannelCommunication.Hubs.PubSub
 
         public bool IsConnected => _hubConnection.State == HubConnectionState.Connected;
 
-        public PubSubHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        public PubSubHubClient(HubConnectionFactory hubConnectionFactory, ILogger<PubSubHubClient> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         {
             _logger = logger;
             _logLanguage = logLanguage;
@@ -36,19 +36,19 @@ namespace NosCore.GameObject.InterChannelCommunication.Hubs.PubSub
 
             _hubConnection.Reconnecting += error =>
             {
-                _logger.Warning(_logLanguage[LogLanguageKey.PUBSUB_RECONNECTING]);
+                _logger.LogWarning(_logLanguage[LogLanguageKey.PUBSUB_RECONNECTING]);
                 return Task.CompletedTask;
             };
 
             _hubConnection.Reconnected += connectionId =>
             {
-                _logger.Information(_logLanguage[LogLanguageKey.PUBSUB_RECONNECTED]);
+                _logger.LogInformation(_logLanguage[LogLanguageKey.PUBSUB_RECONNECTED]);
                 return Task.CompletedTask;
             };
 
             _hubConnection.Closed += error =>
             {
-                _logger.Warning(_logLanguage[LogLanguageKey.PUBSUB_CONNECTION_CLOSED]);
+                _logger.LogWarning(_logLanguage[LogLanguageKey.PUBSUB_CONNECTION_CLOSED]);
                 return Task.CompletedTask;
             };
         }
@@ -67,7 +67,7 @@ namespace NosCore.GameObject.InterChannelCommunication.Hubs.PubSub
                 {
                     await _hubConnection.StartAsync();
                     _isStarted = true;
-                    _logger.Information(_logLanguage[LogLanguageKey.PUBSUB_CONNECTION_STARTED]);
+                    _logger.LogInformation(_logLanguage[LogLanguageKey.PUBSUB_CONNECTION_STARTED]);
                 }
             }
             finally
@@ -85,7 +85,7 @@ namespace NosCore.GameObject.InterChannelCommunication.Hubs.PubSub
                 {
                     await _hubConnection.StopAsync();
                     _isStarted = false;
-                    _logger.Information(_logLanguage[LogLanguageKey.PUBSUB_CONNECTION_STOPPED]);
+                    _logger.LogInformation(_logLanguage[LogLanguageKey.PUBSUB_CONNECTION_STOPPED]);
                 }
             }
             finally

--- a/src/NosCore.GameObject/InterChannelCommunication/Hubs/WarehouseHub/WarehouseHubClient.cs
+++ b/src/NosCore.GameObject/InterChannelCommunication/Hubs/WarehouseHub/WarehouseHubClient.cs
@@ -6,14 +6,14 @@
 
 using NosCore.Data.Enumerations.Miniland;
 using NosCore.Data.WebApi;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.InterChannelCommunication.Hubs.WarehouseHub
 {
-    public class WarehouseHubClient(HubConnectionFactory hubConnectionFactory, ILogger logger)
+    public class WarehouseHubClient(HubConnectionFactory hubConnectionFactory, ILogger<WarehouseHubClient> logger)
         : BaseHubClient(hubConnectionFactory, nameof(WarehouseHub), logger), IWarehouseHub
     {
         public Task<List<WarehouseLink>> GetWarehouseItems(Guid? id, long? ownerId, WarehouseType warehouseType, byte? slot) =>

--- a/src/NosCore.GameObject/Messaging/Handlers/Battle/DeathBCardHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Battle/DeathBCardHandler.cs
@@ -14,12 +14,12 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Messaging.Events;
 using NosCore.GameObject.Services.BattleService;
 using NosCore.Networking;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Battle
 {
     [UsedImplicitly]
-    public sealed class DeathBCardHandler(INpcCombatCatalog catalog, ILogger logger)
+    public sealed class DeathBCardHandler(INpcCombatCatalog catalog, ILogger<DeathBCardHandler> logger)
     {
         [UsedImplicitly]
         public async Task Handle(EntityDiedEvent evt)
@@ -66,7 +66,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Battle
             }
             catch (Exception ex)
             {
-                logger.Warning(ex, "Failed to broadcast death-BCard stat update for character {CharacterId}",
+                logger.LogWarning(ex, "Failed to broadcast death-BCard stat update for character {CharacterId}",
                     killer.CharacterId);
             }
         }

--- a/src/NosCore.GameObject/Messaging/Handlers/Battle/MonsterRespawnHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Battle/MonsterRespawnHandler.cs
@@ -13,7 +13,7 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Messaging.Events;
 using NosCore.GameObject.Services.BattleService;
 using NosCore.Networking;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Battle
 {
@@ -22,7 +22,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Battle
     // an OutPacket here would cut the animation short, so we only clear aggro and
     // schedule the respawn. Player deaths are handled by the revive/warp flow.
     [UsedImplicitly]
-    public sealed class MonsterRespawnHandler(IAggroService aggroService, ILogger logger)
+    public sealed class MonsterRespawnHandler(IAggroService aggroService, ILogger<MonsterRespawnHandler> logger)
     {
         [UsedImplicitly]
         public Task Handle(EntityDiedEvent evt)
@@ -57,7 +57,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Battle
             }
             catch (Exception ex)
             {
-                logger.Warning(ex, "Failed to respawn monster {VisualId}", monster.VisualId);
+                logger.LogWarning(ex, "Failed to respawn monster {VisualId}", monster.VisualId);
             }
         }
     }

--- a/src/NosCore.GameObject/Messaging/Handlers/Battle/PlayerRevivalHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Battle/PlayerRevivalHandler.cs
@@ -15,7 +15,7 @@ using NosCore.Packets.ClientPackets.Event;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Battle
 {
@@ -31,7 +31,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Battle
     // TODO: post-revive protection (card 684, ~30s invuln) isn't granted — the
     // buff/card application layer isn't wired up yet. See death.txt line 6352.
     [UsedImplicitly]
-    public sealed class PlayerRevivalHandler(ILogger logger)
+    public sealed class PlayerRevivalHandler(ILogger<PlayerRevivalHandler> logger)
     {
         // Canonical NosTale fork default for dignity penalty on death.
         private const short DignityLossPerDeath = 50;
@@ -76,7 +76,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Battle
             }
             catch (Exception ex)
             {
-                logger.Warning(ex, "PlayerRevivalHandler failed for {CharacterId}", player.CharacterId);
+                logger.LogWarning(ex, "PlayerRevivalHandler failed for {CharacterId}", player.CharacterId);
             }
         }
     }

--- a/src/NosCore.GameObject/Messaging/Handlers/Guri/SpeakerHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Guri/SpeakerHandler.cs
@@ -18,13 +18,13 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.InventoryService;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Guri
 {
     [UsedImplicitly]
     public sealed class SpeakerHandler(
-        ILogger logger,
+        ILogger<SpeakerHandler> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
         IGameLanguageLocalizer gameLanguageLocalizer,
         ISessionRegistry sessionRegistry)
@@ -53,7 +53,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Guri
                 (short)(packet.VisualId ?? 0), NoscorePocketType.Etc);
             if (inv?.ItemInstance?.Item?.Effect != ItemEffectType.Speaker)
             {
-                logger.Error(string.Format(logLanguage[LogLanguageKey.ITEM_NOT_FOUND],
+                logger.LogError(string.Format(logLanguage[LogLanguageKey.ITEM_NOT_FOUND],
                     NoscorePocketType.Etc, (short)(packet.VisualId ?? 0)));
                 return;
             }
@@ -71,7 +71,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Guri
                 }
                 if (deeplink == null)
                 {
-                    logger.Error(string.Format(logLanguage[LogLanguageKey.ITEM_NOT_FOUND], type, slot));
+                    logger.LogError(string.Format(logLanguage[LogLanguageKey.ITEM_NOT_FOUND], type, slot));
                     return;
                 }
                 message = CraftMessage(message, valueSplit.Skip(2).ToArray()).Replace(' ', '|');

--- a/src/NosCore.GameObject/Messaging/Handlers/Nrun/ChangeClassHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Nrun/ChangeClassHandler.cs
@@ -21,13 +21,13 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Nrun
 {
     [UsedImplicitly]
     public sealed class ChangeClassHandler(
-        ILogger logger,
+        ILogger<ChangeClassHandler> logger,
         ILogLanguageLocalizer<LogLanguageKey> languageLocalizer,
         IOptions<WorldConfiguration> worldConfiguration,
         IExperienceService experienceService,
@@ -81,7 +81,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Nrun
             var classType = (CharacterClassType)(packet.Type ?? 0);
             if ((CharacterClassType)session.Character.Class == classType)
             {
-                logger.Error(languageLocalizer[LogLanguageKey.CANT_CHANGE_SAME_CLASS]);
+                logger.LogError(languageLocalizer[LogLanguageKey.CANT_CHANGE_SAME_CLASS]);
                 return;
             }
 

--- a/src/NosCore.GameObject/Messaging/Handlers/Nrun/OpenShopHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Nrun/OpenShopHandler.cs
@@ -13,12 +13,12 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.Packets.ClientPackets.Npcs;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Nrun
 {
     [UsedImplicitly]
-    public sealed class OpenShopHandler(ILogger logger) : INrunEventHandler
+    public sealed class OpenShopHandler(ILogger<OpenShopHandler> logger) : INrunEventHandler
     {
         public NrunRunnerType Runner => NrunRunnerType.ProbabilityUIs;
 
@@ -32,7 +32,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Nrun
             var raw = (byte)(packet.Type ?? 0);
             if (!Enum.IsDefined(typeof(WindowType), raw))
             {
-                logger.Warning(
+                logger.LogWarning(
                     "n_run ProbabilityUIs requested unknown WindowType={Raw} (NPC visualId={VisualId}); extend WindowType or add a mapping",
                     raw,
                     npc.VisualId);

--- a/src/NosCore.GameObject/Messaging/Handlers/Quest/OnEntityDiedHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/Quest/OnEntityDiedHandler.cs
@@ -14,7 +14,7 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Messaging.Events;
 using NosCore.GameObject.Services.QuestService;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.Quest
 {
@@ -23,7 +23,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Quest
     // the reward distributor uses so the quest logic never has to be called
     // from BattleService or RewardService directly.
     [UsedImplicitly]
-    public sealed class OnEntityDiedHandler(IQuestService questService, ILogger logger)
+    public sealed class OnEntityDiedHandler(IQuestService questService, ILogger<OnEntityDiedHandler> logger)
     {
         [UsedImplicitly]
         public async Task Handle(EntityDiedEvent evt)
@@ -49,7 +49,7 @@ namespace NosCore.GameObject.Messaging.Handlers.Quest
                 }
                 catch (Exception ex)
                 {
-                    logger.Warning(ex, "Failed to progress kill quest for character {CharacterId}", character.VisualId);
+                    logger.LogWarning(ex, "Failed to progress kill quest for character {CharacterId}", character.VisualId);
                 }
             }
         }

--- a/src/NosCore.GameObject/Messaging/Handlers/UseItem/VehicleHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/UseItem/VehicleHandler.cs
@@ -14,13 +14,13 @@ using NosCore.GameObject.Services.TransformationService;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.UseItem
 {
     [UsedImplicitly]
     public sealed class VehicleHandler(
-        ILogger logger,
+        ILogger<VehicleHandler> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
         ITransformationService transformationService)
     {
@@ -40,7 +40,7 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
             var character = session.Character;
             if (character.InExchangeOrShop)
             {
-                logger.Error(logLanguage[LogLanguageKey.CANT_USE_ITEM_IN_SHOP]);
+                logger.LogError(logLanguage[LogLanguageKey.CANT_USE_ITEM_IN_SHOP]);
                 return;
             }
 

--- a/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
@@ -23,13 +23,13 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Messaging.Handlers.UseItem
 {
     [UsedImplicitly]
     public sealed class WearHandler(
-        ILogger logger,
+        ILogger<WearHandler> logger,
         IClock clock,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
         IOptions<WorldConfiguration> worldConfiguration)
@@ -55,7 +55,7 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
 
             if (session.Character.InExchangeOrShop)
             {
-                logger.Error(logLanguage[LogLanguageKey.CANT_USE_ITEM_IN_SHOP]);
+                logger.LogError(logLanguage[LogLanguageKey.CANT_USE_ITEM_IN_SHOP]);
                 return;
             }
 

--- a/src/NosCore.GameObject/Networking/ClientSession/ClientSession.cs
+++ b/src/NosCore.GameObject/Networking/ClientSession/ClientSession.cs
@@ -19,7 +19,7 @@ using NosCore.Networking.Encoding;
 using NosCore.Packets.Attributes;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 namespace NosCore.GameObject.Networking.ClientSession
 {
     public class ClientSession(
-        ILogger logger,
+        ILogger<ClientSession> logger,
         IPacketHandlerRegistry packetHandlerRegistry,
         ILogLanguageLocalizer<NosCore.Networking.Resource.LogLanguageKey> networkingLogLanguage,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
@@ -42,7 +42,7 @@ namespace NosCore.GameObject.Networking.ClientSession
         : NetworkClient(logger, networkingLogLanguage, encoder), IPacketSender
     {
         private readonly AsyncLock _handlingPacketLock = new();
-        private readonly ILogger _logger = logger;
+        private readonly ILogger<ClientSession> _logger = logger;
         private PlayerComponentBundle _characterBundle;
 
         public bool HasPlayerEntity =>
@@ -147,7 +147,7 @@ namespace NosCore.GameObject.Networking.ClientSession
             }
             catch (Exception ex)
             {
-                _logger.Error(logLanguage[LogLanguageKey.PACKET_HANDLING_ERROR], ex);
+                _logger.LogError(logLanguage[LogLanguageKey.PACKET_HANDLING_ERROR], ex);
                 await pubSubHub.UnsubscribeAsync(SessionId);
                 await DisconnectAsync();
             }
@@ -179,7 +179,7 @@ namespace NosCore.GameObject.Networking.ClientSession
             }
             catch (Exception ex)
             {
-                _logger.Information(logLanguage[LogLanguageKey.CLIENT_DISCONNECTED], ex);
+                _logger.LogInformation(logLanguage[LogLanguageKey.CLIENT_DISCONNECTED], ex);
             }
             finally
             {
@@ -194,7 +194,7 @@ namespace NosCore.GameObject.Networking.ClientSession
                     sessionRegistry.Unregister(Channel.Id);
                 }
                 await pubSubHub.UnsubscribeAsync(SessionId);
-                _logger.Information(logLanguage[LogLanguageKey.CLIENT_DISCONNECTED]);
+                _logger.LogInformation(logLanguage[LogLanguageKey.CLIENT_DISCONNECTED]);
             }
         }
 

--- a/src/NosCore.GameObject/Networking/ClientSession/LoginPacketHandlingStrategy.cs
+++ b/src/NosCore.GameObject/Networking/ClientSession/LoginPacketHandlingStrategy.cs
@@ -8,12 +8,12 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.Networking.ClientSession;
 
-public class LoginPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+public class LoginPacketHandlingStrategy(ILogger<LoginPacketHandlingStrategy> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     : IPacketHandlingStrategy
 {
     public async Task HandlePacketAsync(IPacket packet, ClientSession session, bool isFromNetwork)
@@ -28,14 +28,14 @@ public class LoginPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<L
         var attr = session.GetPacketAttribute(packet.GetType());
         if (attr != null && (attr.Scopes & Scope.OnLoginScreen) == 0)
         {
-            logger.Warning(logLanguage[LogLanguageKey.PACKET_USED_WHILE_NOT_ON_LOGIN], packet.Header);
+            logger.LogWarning(logLanguage[LogLanguageKey.PACKET_USED_WHILE_NOT_ON_LOGIN], packet.Header);
             return;
         }
 
         var handler = session.GetHandler(packet.GetType());
         if (handler == null)
         {
-            logger.Warning(logLanguage[LogLanguageKey.HANDLER_NOT_FOUND], packetHeader);
+            logger.LogWarning(logLanguage[LogLanguageKey.HANDLER_NOT_FOUND], packetHeader);
             return;
         }
 

--- a/src/NosCore.GameObject/Networking/ClientSession/WorldPacketHandlingStrategy.cs
+++ b/src/NosCore.GameObject/Networking/ClientSession/WorldPacketHandlingStrategy.cs
@@ -14,12 +14,12 @@ using NosCore.Packets.ClientPackets.UI;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.Networking.ClientSession;
 
-public class WorldPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRefHolder sessionRefHolder)
+public class WorldPacketHandlingStrategy(ILogger<WorldPacketHandlingStrategy> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRefHolder sessionRefHolder)
     : IPacketHandlingStrategy
 {
     public async Task HandlePacketAsync(IPacket packet, ClientSession session, bool isFromNetwork)
@@ -46,7 +46,7 @@ public class WorldPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<L
         var packetHeader = processedPacket.Header;
         if (string.IsNullOrWhiteSpace(packetHeader) && isFromNetwork)
         {
-            logger.Warning(logLanguage[LogLanguageKey.CORRUPT_PACKET], processedPacket);
+            logger.LogWarning(logLanguage[LogLanguageKey.CORRUPT_PACKET], processedPacket);
             await session.DisconnectAsync();
             return;
         }
@@ -54,7 +54,7 @@ public class WorldPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<L
         var handler = session.GetHandler(processedPacket.GetType());
         if (handler == null)
         {
-            logger.Warning(logLanguage[LogLanguageKey.HANDLER_NOT_FOUND], packetHeader);
+            logger.LogWarning(logLanguage[LogLanguageKey.HANDLER_NOT_FOUND], packetHeader);
             return;
         }
 
@@ -81,7 +81,7 @@ public class WorldPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<L
     {
         if (session.LastKeepAliveIdentity != 0 && packet.KeepAliveId != session.LastKeepAliveIdentity + 1)
         {
-            logger.Error(logLanguage[LogLanguageKey.CORRUPTED_KEEPALIVE], session.SessionId);
+            logger.LogError(logLanguage[LogLanguageKey.CORRUPTED_KEEPALIVE], session.SessionId);
             await session.DisconnectAsync();
             return false;
         }
@@ -105,7 +105,7 @@ public class WorldPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<L
         }
 
         session.SessionId = sessionRefHolder[session.SessionKey].SessionId;
-        logger.Debug(logLanguage[LogLanguageKey.CLIENT_ARRIVED], session.SessionId);
+        logger.LogDebug(logLanguage[LogLanguageKey.CLIENT_ARRIVED], session.SessionId);
         session.WaitForPacketsAmount = 2;
         return Task.FromResult(true);
     }
@@ -155,20 +155,20 @@ public class WorldPacketHandlingStrategy(ILogger logger, ILogLanguageLocalizer<L
 
         if (session.HasSelectedCharacter && (attr.Scopes & Scope.InTrade) == 0 && session.Character.InExchangeOrShop)
         {
-            logger.Warning(logLanguage[LogLanguageKey.PLAYER_IN_SHOP], packet.Header);
+            logger.LogWarning(logLanguage[LogLanguageKey.PLAYER_IN_SHOP], packet.Header);
             return false;
         }
 
         var isMfa = packet is GuriPacket guri && guri.Type == GuriPacketType.TextInput && guri.Argument == 3 && guri.VisualId == 0;
         if (!session.HasSelectedCharacter && (attr.Scopes & Scope.OnCharacterScreen) == 0 && !isMfa)
         {
-            logger.Warning(logLanguage[LogLanguageKey.PACKET_USED_WITHOUT_CHARACTER], packet.Header);
+            logger.LogWarning(logLanguage[LogLanguageKey.PACKET_USED_WITHOUT_CHARACTER], packet.Header);
             return false;
         }
 
         if (session.HasSelectedCharacter && (attr.Scopes & Scope.InGame) == 0)
         {
-            logger.Warning(logLanguage[LogLanguageKey.PACKET_USED_WHILE_IN_GAME], packet.Header);
+            logger.LogWarning(logLanguage[LogLanguageKey.PACKET_USED_WHILE_IN_GAME], packet.Header);
             return false;
         }
 

--- a/src/NosCore.GameObject/Services/BattleService/BattleService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleService.cs
@@ -18,7 +18,7 @@ using NosCore.Networking;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Packets.ServerPackets.Battle;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using Wolverine;
 
 namespace NosCore.GameObject.Services.BattleService
@@ -33,7 +33,7 @@ namespace NosCore.GameObject.Services.BattleService
         IHitQueue hitQueue,
         IMessageBus messageBus,
         ISessionRegistry sessionRegistry,
-        ILogger logger) : IBattleService
+        ILogger<BattleService> logger) : IBattleService
     {
         public async Task Hit(IAliveEntity origin, IAliveEntity target, HitArguments arguments)
         {
@@ -66,7 +66,7 @@ namespace NosCore.GameObject.Services.BattleService
                 }
                 catch (Exception ex)
                 {
-                    logger.Error(ex, "Hit processing failed: {Attacker} -> {Target}", origin.VisualId, currentTarget.VisualId);
+                    logger.LogError(ex, "Hit processing failed: {Attacker} -> {Target}", origin.VisualId, currentTarget.VisualId);
                 }
             }
 
@@ -197,7 +197,7 @@ namespace NosCore.GameObject.Services.BattleService
                 }
                 catch (Exception ex)
                 {
-                    logger.Warning(ex, "Failed to reset cooldown for skill {CastId}", skill.CastId);
+                    logger.LogWarning(ex, "Failed to reset cooldown for skill {CastId}", skill.CastId);
                 }
             });
         }

--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -14,7 +14,7 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Services.BattleService.Model;
 using NosCore.GameObject.Infastructure;
 using NosCore.Packets.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.BattleService;
 
@@ -30,7 +30,7 @@ public sealed class HitQueue(
     IBattleStatsProvider statsProvider,
     IBuffService buffService,
     IRegenerationService regenerationService,
-    ILogger logger) : IHitQueue, ISingletonService
+    ILogger<HitQueue> logger) : IHitQueue, ISingletonService
 {
     private readonly ConcurrentDictionary<Entity, Channel<HitRequest>> _channels = new();
 
@@ -90,7 +90,7 @@ public sealed class HitQueue(
         }
         catch (Exception ex)
         {
-            logger.Error(ex, "Hit queue worker for entity {Handle} crashed", target.Handle);
+            logger.LogError(ex, "Hit queue worker for entity {Handle} crashed", target.Handle);
         }
         finally
         {
@@ -170,7 +170,7 @@ public sealed class HitQueue(
         }
         catch (Exception ex)
         {
-            logger.Error(ex, "Failed to apply hit to entity {Handle}", request.Target.Handle);
+            logger.LogError(ex, "Failed to apply hit to entity {Handle}", request.Target.Handle);
             request.Completion.TrySetException(ex);
         }
         return Task.CompletedTask;

--- a/src/NosCore.GameObject/Services/BattleService/MonsterAi.cs
+++ b/src/NosCore.GameObject/Services/BattleService/MonsterAi.cs
@@ -22,7 +22,7 @@ using NosCore.GameObject.Services.PathfindingService;
 using NosCore.Networking;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.BattleService;
 
@@ -52,7 +52,7 @@ public sealed class MonsterAi : IMonsterAi, ISingletonService
     private readonly INpcCombatCatalog catalog;
     private readonly IRandomProvider random;
     private readonly IClock clock;
-    private readonly ILogger logger;
+    private readonly ILogger<MonsterAi> logger;
     private readonly IReadOnlyDictionary<short, SkillDto> skillsByVnum;
 
     public MonsterAi(
@@ -65,7 +65,7 @@ public sealed class MonsterAi : IMonsterAi, ISingletonService
         IRandomProvider random,
         IClock clock,
         List<SkillDto> skills,
-        ILogger logger)
+        ILogger<MonsterAi> logger)
         : this(battleService, aggroService, pathfindingService, sessionRegistry, distanceCalculator,
             catalog, random, clock, skills.ToDictionary(s => s.SkillVNum, s => s), logger)
     {
@@ -81,7 +81,7 @@ public sealed class MonsterAi : IMonsterAi, ISingletonService
         IRandomProvider random,
         IClock clock,
         IReadOnlyDictionary<short, SkillDto> skillsByVnum,
-        ILogger logger)
+        ILogger<MonsterAi> logger)
     {
         this.battleService = battleService;
         this.aggroService = aggroService;
@@ -156,7 +156,7 @@ public sealed class MonsterAi : IMonsterAi, ISingletonService
         }
         catch (Exception ex)
         {
-            logger.Error(ex, "AI tick failed for {VisualId}", entity.VisualId);
+            logger.LogError(ex, "AI tick failed for {VisualId}", entity.VisualId);
             return false;
         }
     }

--- a/src/NosCore.GameObject/Services/BattleService/RegenerationService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/RegenerationService.cs
@@ -14,6 +14,7 @@ using NosCore.GameObject.Infastructure;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.MapInstanceGenerationService;
 using NosCore.Shared.Enumerations;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.BattleService;
 
@@ -26,7 +27,7 @@ namespace NosCore.GameObject.Services.BattleService;
 public sealed class RegenerationService(
     ISessionRegistry sessionRegistry,
     IClock clock,
-    Serilog.ILogger logger) : IRegenerationService, ISingletonService
+    ILogger<RegenerationService> logger) : IRegenerationService, ISingletonService
 {
     private static readonly Duration SittingInterval = Duration.FromMilliseconds(1500);
     private static readonly Duration StandingInterval = Duration.FromMilliseconds(2000);
@@ -109,7 +110,7 @@ public sealed class RegenerationService(
         }
         catch (Exception ex)
         {
-            logger.Warning(ex, "Regeneration tick failed for map {MapId}", mapInstance.Map.MapId);
+            logger.LogWarning(ex, "Regeneration tick failed for map {MapId}", mapInstance.Map.MapId);
         }
     }
 }

--- a/src/NosCore.GameObject/Services/BattleService/RewardService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/RewardService.cs
@@ -24,7 +24,7 @@ using NosCore.GameObject.Services.MapItemGenerationService;
 using NosCore.Networking;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Helpers;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.BattleService;
 
@@ -39,7 +39,7 @@ public sealed class RewardService(
     IMapItemGenerationService mapItemGenerationService,
     INpcCombatCatalog catalog,
     IExperienceProgressionService experienceProgression,
-    ILogger logger) : IRewardService
+    ILogger<RewardService> logger) : IRewardService
 {
     // Flat fairy XP granted per qualifying kill. OpenNos exposes this as a runtime knob
     // on ServerManager; we keep it constant until there's a gameplay reason to tune it.
@@ -175,7 +175,7 @@ public sealed class RewardService(
             }
             catch (System.Exception ex)
             {
-                logger.Warning(ex, "Failed to spawn drop {VNum} from {Mob}", drop.VNum, mob.NpcMonsterVNum);
+                logger.LogWarning(ex, "Failed to spawn drop {VNum} from {Mob}", drop.VNum, mob.NpcMonsterVNum);
             }
         }
     }
@@ -199,7 +199,7 @@ public sealed class RewardService(
         }
         catch (System.Exception ex)
         {
-            logger.Warning(ex, "Failed to spawn gold drop from {Mob}", mob.NpcMonsterVNum);
+            logger.LogWarning(ex, "Failed to spawn gold drop from {Mob}", mob.NpcMonsterVNum);
         }
     }
 

--- a/src/NosCore.GameObject/Services/BroadcastService/SessionRegistry.cs
+++ b/src/NosCore.GameObject/Services/BroadcastService/SessionRegistry.cs
@@ -8,7 +8,7 @@ using NosCore.Data.WebApi;
 using NosCore.GameObject.Ecs;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.Packets.Interfaces;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.GameObject.Services.BroadcastService
 {
-    public class SessionRegistry(ILogger logger) : ISessionRegistry
+    public class SessionRegistry(ILogger<SessionRegistry> logger) : ISessionRegistry
     {
         private readonly ConcurrentDictionary<string, SessionInfo> _sessionsByChannelId = new();
         private readonly ConcurrentDictionary<long, string> _channelIdByCharacterId = new();
@@ -163,7 +163,7 @@ namespace NosCore.GameObject.Services.BroadcastService
                 }
                 catch (Exception ex)
                 {
-                    logger.Warning(ex, "Broadcast to {ChannelId} failed", s.ChannelId);
+                    logger.LogWarning(ex, "Broadcast to {ChannelId} failed", s.ChannelId);
                 }
             });
             await Task.WhenAll(tasks);
@@ -181,7 +181,7 @@ namespace NosCore.GameObject.Services.BroadcastService
                     }
                     catch (Exception ex)
                     {
-                        logger.Warning(ex, "Broadcast to {ChannelId} failed", s.ChannelId);
+                        logger.LogWarning(ex, "Broadcast to {ChannelId} failed", s.ChannelId);
                     }
                 });
             await Task.WhenAll(tasks);

--- a/src/NosCore.GameObject/Services/ChannelCommunicationService/ChannelCommunicationRunner.cs
+++ b/src/NosCore.GameObject/Services/ChannelCommunicationService/ChannelCommunicationRunner.cs
@@ -10,7 +10,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.GameObject.InterChannelCommunication.Hubs.PubSub;
 using NosCore.GameObject.Services.ChannelCommunicationService.Handlers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,13 +25,13 @@ namespace NosCore.GameObject.Services.ChannelCommunicationService
     {
         private readonly IPubSubHubClient _pubSubHubClient;
         private readonly Dictionary<Type, IChannelCommunicationMessageHandler<IMessage>> _handlers;
-        private readonly ILogger _logger;
+        private readonly ILogger<ChannelCommunicationRunner> _logger;
         private readonly ILogLanguageLocalizer<LogLanguageKey> _logLanguage;
 
         public ChannelCommunicationRunner(
             IPubSubHubClient pubSubHubClient,
             IEnumerable<IChannelCommunicationMessageHandler<IMessage>> handlers,
-            ILogger logger,
+            ILogger<ChannelCommunicationRunner> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         {
             _pubSubHubClient = pubSubHubClient;
@@ -56,12 +56,12 @@ namespace NosCore.GameObject.Services.ChannelCommunicationService
                     }
                     else
                     {
-                        _logger.Warning(_logLanguage[LogLanguageKey.UNKWNOWN_RECEIVERTYPE]);
+                        _logger.LogWarning(_logLanguage[LogLanguageKey.UNKWNOWN_RECEIVERTYPE]);
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, _logLanguage[LogLanguageKey.PACKET_HANDLING_ERROR]);
+                    _logger.LogError(ex, _logLanguage[LogLanguageKey.PACKET_HANDLING_ERROR]);
                 }
             });
         }

--- a/src/NosCore.GameObject/Services/ChannelCommunicationService/Handlers/PostedPacketMessageChannelCommunicationMessageHandler.cs
+++ b/src/NosCore.GameObject/Services/ChannelCommunicationService/Handlers/PostedPacketMessageChannelCommunicationMessageHandler.cs
@@ -10,13 +10,13 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.Packets.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using PostedPacket = NosCore.GameObject.InterChannelCommunication.Messages.PostedPacket;
 
 namespace NosCore.GameObject.Services.ChannelCommunicationService.Handlers
 {
-    public class PostedPacketMessageChannelCommunicationMessageHandler(ILogger logger, IDeserializer deserializer,
+    public class PostedPacketMessageChannelCommunicationMessageHandler(ILogger<PostedPacketMessageChannelCommunicationMessageHandler> logger, IDeserializer deserializer,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry) : ChannelCommunicationMessageHandler<PostedPacket>
     {
         public override async Task Handle(PostedPacket postedPacket)
@@ -49,7 +49,7 @@ namespace NosCore.GameObject.Services.ChannelCommunicationService.Handlers
                     await receiverSession.SendPacketAsync(message);
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.UNKWNOWN_RECEIVERTYPE]);
+                    logger.LogError(logLanguage[LogLanguageKey.UNKWNOWN_RECEIVERTYPE]);
                     break;
             }
         }

--- a/src/NosCore.GameObject/Services/ChannelCommunicationService/Handlers/StatDataMessageChannelCommunicationMessageHandler.cs
+++ b/src/NosCore.GameObject/Services/ChannelCommunicationService/Handlers/StatDataMessageChannelCommunicationMessageHandler.cs
@@ -20,14 +20,14 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
 using StatData = NosCore.GameObject.InterChannelCommunication.Messages.StatData;
 
 namespace NosCore.GameObject.Services.ChannelCommunicationService.Handlers
 {
-    public class StatDataMessageChannelCommunicationMessageHandler(ILogger logger,
+    public class StatDataMessageChannelCommunicationMessageHandler(ILogger<StatDataMessageChannelCommunicationMessageHandler> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage, IOptions<WorldConfiguration> worldConfiguration, ISessionRegistry sessionRegistry,
         IExperienceService experienceService, IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService) : ChannelCommunicationMessageHandler<StatData>
     {
@@ -141,7 +141,7 @@ namespace NosCore.GameObject.Services.ChannelCommunicationService.Handlers
                     }
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.UNKWNOWN_RECEIVERTYPE]);
+                    logger.LogError(logLanguage[LogLanguageKey.UNKWNOWN_RECEIVERTYPE]);
                     break;
             }
         }

--- a/src/NosCore.GameObject/Services/ExchangeService/ExchangeService.cs
+++ b/src/NosCore.GameObject/Services/ExchangeService/ExchangeService.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.ServerPackets.Exchanges;
 using NosCore.Packets.ServerPackets.Inventory;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,7 +27,7 @@ using System.Linq;
 namespace NosCore.GameObject.Services.ExchangeService
 {
     public class ExchangeService(IItemGenerationService itemBuilderService,
-            IOptions<WorldConfiguration> worldConfiguration, ILogger logger, IExchangeRequestRegistry exchangeRegistry,
+            IOptions<WorldConfiguration> worldConfiguration, ILogger<ExchangeService> logger, IExchangeRequestRegistry exchangeRegistry,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, IGameLanguageLocalizer gameLanguageLocalizer)
         : IExchangeService
     {
@@ -152,7 +152,7 @@ namespace NosCore.GameObject.Services.ExchangeService
             var request = exchangeRegistry.GetExchangeRequest(visualId);
             if (request == null)
             {
-                logger.Error(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
+                logger.LogError(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
                 return;
             }
 
@@ -189,19 +189,19 @@ namespace NosCore.GameObject.Services.ExchangeService
             var pair = exchangeRegistry.GetExchangeRequestPair(visualId);
             if (pair == null)
             {
-                logger.Error(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
+                logger.LogError(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
                 return null;
             }
 
             var data = pair.Value;
             if (!exchangeRegistry.RemoveExchangeData(data.Key) || !exchangeRegistry.RemoveExchangeRequest(data.Key))
             {
-                logger.Error(logLanguage[LogLanguageKey.TRY_REMOVE_FAILED], data.Key);
+                logger.LogError(logLanguage[LogLanguageKey.TRY_REMOVE_FAILED], data.Key);
             }
 
             if (!exchangeRegistry.RemoveExchangeData(data.Value) || !exchangeRegistry.RemoveExchangeRequest(data.Value))
             {
-                logger.Error(logLanguage[LogLanguageKey.TRY_REMOVE_FAILED], data.Value);
+                logger.LogError(logLanguage[LogLanguageKey.TRY_REMOVE_FAILED], data.Value);
             }
 
             return new ExcClosePacket
@@ -214,7 +214,7 @@ namespace NosCore.GameObject.Services.ExchangeService
         {
             if (CheckExchange(visualId) || CheckExchange(targetVisualId))
             {
-                logger.Error(logLanguage[LogLanguageKey.ALREADY_EXCHANGE]);
+                logger.LogError(logLanguage[LogLanguageKey.ALREADY_EXCHANGE]);
                 return false;
             }
 

--- a/src/NosCore.GameObject/Services/FriendService/FriendService.cs
+++ b/src/NosCore.GameObject/Services/FriendService/FriendService.cs
@@ -13,7 +13,7 @@ using NosCore.GameObject.InterChannelCommunication.Hubs.PubSub;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.GameObject.Services.FriendService
 {
-    public class FriendService(ILogger logger, IDao<CharacterRelationDto, Guid> characterRelationDao,
+    public class FriendService(ILogger<FriendService> logger, IDao<CharacterRelationDto, Guid> characterRelationDao,
             IDao<CharacterDto, long> characterDao, IFriendRequestRegistry friendRequestRegistry,
             IPubSubHub pubSubHub, IChannelHub channelHub, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : IFriendService
@@ -103,7 +103,7 @@ namespace NosCore.GameObject.Services.FriendService
                         friendRequestRegistry.UnregisterRequest(friendRequest.First().Key);
                         return LanguageKey.FRIEND_REJECTED;
                     default:
-                        logger.Error(logLanguage[LogLanguageKey.INVITETYPE_UNKNOWN]);
+                        logger.LogError(logLanguage[LogLanguageKey.INVITETYPE_UNKNOWN]);
                         friendRequestRegistry.UnregisterRequest(friendRequest.First().Key);
                         throw new ArgumentException();
                 }

--- a/src/NosCore.GameObject/Services/InventoryService/InventoryService.cs
+++ b/src/NosCore.GameObject/Services/InventoryService/InventoryService.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations;
 using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Services.ItemGenerationService.Item;
 using NosCore.GameObject.Services.ItemStorage;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -19,7 +19,7 @@ using System.Linq;
 
 namespace NosCore.GameObject.Services.InventoryService
 {
-    public class InventoryService(List<ItemDto> items, IOptions<WorldConfiguration> configuration, ILogger logger)
+    public class InventoryService(List<ItemDto> items, IOptions<WorldConfiguration> configuration, ILogger<InventoryService> logger)
         : ConcurrentDictionary<Guid, InventoryItemInstance>, IInventoryService
     {
         public int GetMaxSlots(NoscorePocketType pocket)
@@ -60,7 +60,7 @@ namespace NosCore.GameObject.Services.InventoryService
             }
             catch (InvalidOperationException ioEx)
             {
-                logger.Error(ioEx.Message, ioEx);
+                logger.LogError(ioEx.Message, ioEx);
             }
 
             return retItem;
@@ -154,7 +154,7 @@ namespace NosCore.GameObject.Services.InventoryService
             if (ContainsKey(newItem.ItemInstanceId))
             {
                 var e = new InvalidOperationException("Cannot add the same ItemInstance twice to pocket.");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -168,7 +168,7 @@ namespace NosCore.GameObject.Services.InventoryService
             {
                 var e = new InvalidOperationException(
                     "Cannot add an item of type Specialist without beeing a SpecialistInstance.");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -177,7 +177,7 @@ namespace NosCore.GameObject.Services.InventoryService
             {
                 var e = new InvalidOperationException(
                     "Cannot add an item of type Equipment or Wear without beeing a WearableInstance or a SpecialistInstance.");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -201,7 +201,7 @@ namespace NosCore.GameObject.Services.InventoryService
             }
 
             var e = new InvalidOperationException("Expected item wasn't deleted, Type or Slot did not match!");
-            logger.Error(e.Message, e);
+            logger.LogError(e.Message, e);
             return null;
         }
 
@@ -225,7 +225,7 @@ namespace NosCore.GameObject.Services.InventoryService
             }
 
             var e = new InvalidOperationException("Expected item wasn't deleted, Type or Slot did not match!");
-            logger.Error(e.Message, e);
+            logger.LogError(e.Message, e);
             return null;
         }
 
@@ -242,7 +242,7 @@ namespace NosCore.GameObject.Services.InventoryService
             if ((sourceSlot == targetSlot) && (sourceType == targetType))
             {
                 var e = new InvalidOperationException("SourceInstance can't be moved on the same spot");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -250,7 +250,7 @@ namespace NosCore.GameObject.Services.InventoryService
             if (!(sourceInstance!.ItemInstance is WearableInstance || sourceInstance.ItemInstance is SpecialistInstance))
             {
                 var e = new InvalidOperationException("SourceInstance can't be moved between pockets");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -258,7 +258,7 @@ namespace NosCore.GameObject.Services.InventoryService
                 (targetType != NoscorePocketType.Costume) && (targetType != NoscorePocketType.Wear))
             {
                 var e = new InvalidOperationException("WearableInstance can't be move to this inventory");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -266,7 +266,7 @@ namespace NosCore.GameObject.Services.InventoryService
                 (targetType != NoscorePocketType.Specialist) && (targetType != NoscorePocketType.Wear))
             {
                 var e = new InvalidOperationException("SpecialistInstance can't be move to this inventory");
-                logger.Error(e.Message, e);
+                logger.LogError(e.Message, e);
                 return null;
             }
 
@@ -292,7 +292,7 @@ namespace NosCore.GameObject.Services.InventoryService
                 else
                 {
                     var e = new InvalidOperationException("Source can not be swapped");
-                    logger.Error(e.Message, e);
+                    logger.LogError(e.Message, e);
                     return null;
                 }
 
@@ -472,7 +472,7 @@ namespace NosCore.GameObject.Services.InventoryService
             }
 
             var e = new InvalidOperationException("Expected item wasn't deleted, Type or Slot did not match!");
-            logger.Error(e.Message, e);
+            logger.LogError(e.Message, e);
             return null;
         }
 

--- a/src/NosCore.GameObject/Services/ItemGenerationService/Item/WearableInstance.cs
+++ b/src/NosCore.GameObject/Services/ItemGenerationService/Item/WearableInstance.cs
@@ -10,17 +10,17 @@ using NosCore.Data.Enumerations.Items;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Helpers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace NosCore.GameObject.Services.ItemGenerationService.Item
 {
     public class WearableInstance : WearableInstanceDto, IItemInstance
     {
-        private readonly ILogger _logger = null!;
+        private readonly ILogger<WearableInstance> _logger = null!;
         private readonly ILogLanguageLocalizer<LogLanguageKey> _logLanguage = null!;
 
-        public WearableInstance(Item item, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        public WearableInstance(Item item, ILogger<WearableInstance> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         {
             Id = Guid.NewGuid();
             Item = item;
@@ -122,7 +122,7 @@ namespace NosCore.GameObject.Services.ItemGenerationService.Item
                     break;
 
                 default:
-                    _logger.Error(_logLanguage[LogLanguageKey.UNKNOWN_EQUIPMENTTYPE],
+                    _logger.LogError(_logLanguage[LogLanguageKey.UNKNOWN_EQUIPMENTTYPE],
                         Item.EquipmentSlot);
                     break;
             }

--- a/src/NosCore.GameObject/Services/ItemGenerationService/ItemGenerationService.cs
+++ b/src/NosCore.GameObject/Services/ItemGenerationService/ItemGenerationService.cs
@@ -13,7 +13,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Services.InventoryService;
 using NosCore.GameObject.Services.ItemGenerationService.Item;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -21,7 +21,7 @@ namespace NosCore.GameObject.Services.ItemGenerationService
 {
     public class ItemGenerationService(
         List<ItemDto> items,
-        ILogger logger,
+        ILoggerFactory loggerFactory,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage) : IItemGenerationService
     {
         public IItemInstance Convert(IItemInstanceDto k)
@@ -86,7 +86,7 @@ namespace NosCore.GameObject.Services.ItemGenerationService
                                 Design = design
                             };
                         default:
-                            var wear = new WearableInstance(itemToCreate, logger, logLanguage)
+                            var wear = new WearableInstance(itemToCreate, loggerFactory.CreateLogger<WearableInstance>(), logLanguage)
                             {
                                 Amount = amount,
                                 Rare = rare,

--- a/src/NosCore.GameObject/Services/MapChangeService/MapChangeService.cs
+++ b/src/NosCore.GameObject/Services/MapChangeService/MapChangeService.cs
@@ -23,7 +23,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Map;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -33,7 +33,7 @@ namespace NosCore.GameObject.Services.MapChangeService
     public class MapChangeService(IExperienceService experienceService, IJobExperienceService jobExperienceService,
             IHeroExperienceService heroExperienceService, IMapInstanceAccessorService mapInstanceAccessorService,
             IClock clock,
-            ILogLanguageLocalizer<LogLanguageKey> logLanguage, IMinilandService minilandProvider, ILogger logger,
+            ILogLanguageLocalizer<LogLanguageKey> logLanguage, IMinilandService minilandProvider, ILogger<MapChangeService> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguageLocalizer, IGameLanguageLocalizer gameLanguageLocalizer,
             ISessionRegistry sessionRegistry, Wolverine.IMessageBus messageBus)
         : IMapChangeService
@@ -52,7 +52,7 @@ namespace NosCore.GameObject.Services.MapChangeService
 
                 if (mapInstance == null)
                 {
-                    logger.Error(
+                    logger.LogError(
                         logLanguageLocalizer[LogLanguageKey.MAP_DONT_EXIST, session.Account.Language]);
                     return;
                 }
@@ -253,7 +253,7 @@ namespace NosCore.GameObject.Services.MapChangeService
             }
             catch (Exception ex)
             {
-                logger.Warning(ex, logLanguage[LogLanguageKey.ERROR_CHANGE_MAP]);
+                logger.LogWarning(ex, logLanguage[LogLanguageKey.ERROR_CHANGE_MAP]);
             }
             finally
             {

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -27,7 +27,7 @@ using NosCore.PathFinder.Interfaces;
 using NosCore.Packets.ServerPackets.MiniMap;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.Helpers;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -42,7 +42,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
     public class MapInstance : IBroadcastable, IDisposable
     {
         public short MaxPacketsBuffer { get; } = 250;
-        private readonly ILogger _logger;
+        private readonly ILogger<MapInstance> _logger;
 
         private readonly IMapItemGenerationService _mapItemGenerationService;
         private bool _isSleeping;
@@ -66,7 +66,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
         public MapWorld EcsWorld { get; }
 
         public MapInstance(Map.Map map, Guid guid, bool shopAllowed, MapInstanceType type,
-            IMapItemGenerationService mapItemGenerationService, ILogger logger, IClock clock, IMapChangeService mapChangeService,
+            IMapItemGenerationService mapItemGenerationService, ILogger<MapInstance> logger, IClock clock, IMapChangeService mapChangeService,
             ISessionGroupFactory sessionGroupFactory, ISessionRegistry sessionRegistry, IHeuristic distanceCalculator,
             IMonsterAi? monsterAi = null, IBuffService? buffService = null, IRegenerationService? regenerationService = null)
         {
@@ -427,7 +427,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e.Message, e);
+                    _logger.LogError(e.Message, e);
                 }
             }
             Life = Observable.Interval(TimeSpan.FromMilliseconds(400)).Select(_ => LifeAsync()).Subscribe();

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstanceGenerationService.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstanceGenerationService.cs
@@ -22,7 +22,7 @@ using NosCore.GameObject.Services.MapItemGenerationService;
 using NosCore.Networking.SessionGroup;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,7 +34,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             List<NpcTalkDto> npcTalks, List<ShopDto> shopDtos,
             IMapItemGenerationService mapItemGenerationService, IDao<MapNpcDto, int> mapNpcs,
             IDao<MapMonsterDto, int> mapMonsters, IDao<PortalDto, int> portalDao, IDao<ShopItemDto, int>? shopItems,
-            ILogger logger, IMapInstanceRegistry mapInstanceRegistry,
+            ILoggerFactory loggerFactory, IMapInstanceRegistry mapInstanceRegistry,
             IMapInstanceAccessorService mapInstanceAccessorService,
             IClock clock, ILogLanguageLocalizer<LogLanguageKey> logLanguage, IMapChangeService mapChangeService,
             ISessionGroupFactory sessionGroupFactory, ISessionRegistry sessionRegistry, IItemGenerationService itemProvider, IHeuristic distanceCalculator,
@@ -57,9 +57,11 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             }
         }
 
+        private readonly ILogger<MapInstanceGeneratorService> _logger = loggerFactory.CreateLogger<MapInstanceGeneratorService>();
+
         public async Task InitializeAsync()
         {
-            logger.Information(logLanguage[LogLanguageKey.LOADING_MAPINSTANCES]);
+            _logger.LogInformation(logLanguage[LogLanguageKey.LOADING_MAPINSTANCES]);
             try
             {
                 mapMonsters.LoadAll();
@@ -124,7 +126,8 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
 
         public MapInstance CreateMapInstance(Map.Map map, Guid guid, bool shopAllowed, MapInstanceType normalInstance)
         {
-            return new MapInstance(map, guid, shopAllowed, normalInstance, mapItemGenerationService, logger, clock,
+            return new MapInstance(map, guid, shopAllowed, normalInstance, mapItemGenerationService,
+                loggerFactory.CreateLogger<MapInstance>(), clock,
                 mapChangeService, sessionGroupFactory, sessionRegistry, distanceCalculator, monsterAi, buffService, regenerationService);
         }
 

--- a/src/NosCore.GameObject/Services/QuestService/Handlers/HuntQuestHandler.cs
+++ b/src/NosCore.GameObject/Services/QuestService/Handlers/HuntQuestHandler.cs
@@ -6,12 +6,12 @@
 
 using JetBrains.Annotations;
 using NosCore.Packets.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.QuestService.Handlers;
 
 [UsedImplicitly]
-public sealed class HuntQuestHandler(ILogger logger) : KillQuestHandlerBase(logger)
+public sealed class HuntQuestHandler(ILogger<HuntQuestHandler> logger) : KillQuestHandlerBase(logger)
 {
     public override QuestType QuestType => QuestType.Hunt;
 }

--- a/src/NosCore.GameObject/Services/QuestService/Handlers/KillQuestHandlerBase.cs
+++ b/src/NosCore.GameObject/Services/QuestService/Handlers/KillQuestHandlerBase.cs
@@ -14,7 +14,7 @@ using NosCore.Packets;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.QuestService.Handlers;
 
@@ -69,7 +69,7 @@ public abstract class KillQuestHandlerBase(ILogger logger) : IQuestTypeHandler
         }
         catch (Exception ex)
         {
-            logger.Warning(ex, "Failed to send quest progress for character {CharacterId} quest {QuestId}",
+            logger.LogWarning(ex, "Failed to send quest progress for character {CharacterId} quest {QuestId}",
                 character.CharacterId, quest.QuestId);
         }
     }

--- a/src/NosCore.GameObject/Services/QuestService/Handlers/NumberOfKillQuestHandler.cs
+++ b/src/NosCore.GameObject/Services/QuestService/Handlers/NumberOfKillQuestHandler.cs
@@ -6,12 +6,12 @@
 
 using JetBrains.Annotations;
 using NosCore.Packets.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.QuestService.Handlers;
 
 [UsedImplicitly]
-public sealed class NumberOfKillQuestHandler(ILogger logger) : KillQuestHandlerBase(logger)
+public sealed class NumberOfKillQuestHandler(ILogger<NumberOfKillQuestHandler> logger) : KillQuestHandlerBase(logger)
 {
     public override QuestType QuestType => QuestType.NumberOfKill;
 }

--- a/src/NosCore.GameObject/Services/QuestService/QuestService.cs
+++ b/src/NosCore.GameObject/Services/QuestService/QuestService.cs
@@ -22,7 +22,7 @@ using NosCore.Packets.ServerPackets.Quest;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +32,7 @@ namespace NosCore.GameObject.Services.QuestService
 {
     public class QuestService(List<ScriptDto> scripts,
             IOptions<WorldConfiguration> worldConfiguration, List<QuestDto> quests,
-            List<QuestObjectiveDto> questObjectives, ILogger logger, IClock clock,
+            List<QuestObjectiveDto> questObjectives, ILogger<QuestService> logger, IClock clock,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             IEnumerable<IQuestTypeHandler> questTypeHandlers,
             Wolverine.IMessageBus messageBus,
@@ -231,14 +231,14 @@ namespace NosCore.GameObject.Services.QuestService
                     var item = itemBuilderService.Create((short)reward.Data, (short)amount, (sbyte)reward.Rarity, reward.Upgrade, reward.Design);
                     if (item == null)
                     {
-                        logger.Warning("Quest reward skipped: invalid item vnum {VNum} for character {CharacterId}",
+                        logger.LogWarning("Quest reward skipped: invalid item vnum {VNum} for character {CharacterId}",
                             reward.Data, character.CharacterId);
                         break;
                     }
                     var added = character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(item, character.VisualId));
                     if (added == null || added.Count == 0)
                     {
-                        logger.Warning("Quest reward lost: inventory full for item {VNum}x{Amount} character {CharacterId}",
+                        logger.LogWarning("Quest reward lost: inventory full for item {VNum}x{Amount} character {CharacterId}",
                             reward.Data, amount, character.CharacterId);
                         await character.SendPacketAsync(new SayiPacket
                         {
@@ -255,7 +255,7 @@ namespace NosCore.GameObject.Services.QuestService
                     }
                     break;
                 default:
-                    logger.Warning("Unhandled quest reward type {Type}", reward.RewardType);
+                    logger.LogWarning("Unhandled quest reward type {Type}", reward.RewardType);
                     break;
             }
         }
@@ -274,7 +274,7 @@ namespace NosCore.GameObject.Services.QuestService
                 return await ValidateQuestAsync(character, questId);
             }
 
-            logger.Error(logLanguage[LogLanguageKey.QUEST_NOT_FOUND]);
+            logger.LogError(logLanguage[LogLanguageKey.QUEST_NOT_FOUND]);
             return false;
         }
 
@@ -314,7 +314,7 @@ namespace NosCore.GameObject.Services.QuestService
             var questDto = quests.FirstOrDefault(s => s.QuestId == questId);
             if (questDto == null)
             {
-                logger.Error(logLanguage[LogLanguageKey.QUEST_NOT_FOUND]);
+                logger.LogError(logLanguage[LogLanguageKey.QUEST_NOT_FOUND]);
                 return true;
             }
             var quest = questDto.Adapt<Quest>();

--- a/src/NosCore.GameObject/Services/SaveService/SaveService.cs
+++ b/src/NosCore.GameObject/Services/SaveService/SaveService.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.Map;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.MinilandService;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +26,7 @@ namespace NosCore.GameObject.Services.SaveService
             IMinilandService minilandProvider, IDao<TitleDto, Guid> titleDao,
             IDao<CharacterQuestDto, Guid> characterQuestDao,
             IDao<CharacterQuestObjectiveDto, Guid> characterQuestObjectiveDao,
-            IDao<RespawnDto, long> respawnDao, ILogger logger,
+            IDao<RespawnDto, long> respawnDao, ILogger<SaveService> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : ISaveService
     {
@@ -95,7 +95,7 @@ namespace NosCore.GameObject.Services.SaveService
                     .TryInsertOrUpdateAsync(inventoryService.Values.Select(s => s.ItemInstance).ToArray());
                 if (!itemInstancesSaved)
                 {
-                    logger.Error(
+                    logger.LogError(
                         new InvalidOperationException("ItemInstance batch insert failed; skipping InventoryItemInstance to avoid FK cascade."),
                         logLanguage[LogLanguageKey.SAVE_CHARACTER_FAILED], session.Character.CharacterId);
                     return;
@@ -120,7 +120,7 @@ namespace NosCore.GameObject.Services.SaveService
                 var questsSaved = await characterQuestDao.TryInsertOrUpdateAsync(quests.Values);
                 if (!questsSaved)
                 {
-                    logger.Error(
+                    logger.LogError(
                         new InvalidOperationException("CharacterQuest upsert failed; skipping objective upsert to avoid FK cascade."),
                         logLanguage[LogLanguageKey.SAVE_CHARACTER_FAILED], characterId);
                     return;
@@ -154,7 +154,7 @@ namespace NosCore.GameObject.Services.SaveService
                 var objectivesDeleted = await characterQuestObjectiveDao.TryDeleteAsync(objectivesToDelete);
                 if (objectivesDeleted == null)
                 {
-                    logger.Error(
+                    logger.LogError(
                         new InvalidOperationException("CharacterQuestObjective delete failed; skipping objective upsert to avoid orphaned-row conflicts on next save."),
                         logLanguage[LogLanguageKey.SAVE_CHARACTER_FAILED], characterId);
                     return;
@@ -162,7 +162,7 @@ namespace NosCore.GameObject.Services.SaveService
                 var objectivesSaved = await characterQuestObjectiveDao.TryInsertOrUpdateAsync(liveObjectives);
                 if (!objectivesSaved)
                 {
-                    logger.Error(
+                    logger.LogError(
                         new InvalidOperationException("CharacterQuestObjective upsert failed; quest progress will reset on reconnect."),
                         logLanguage[LogLanguageKey.SAVE_CHARACTER_FAILED], characterId);
                     return;
@@ -172,7 +172,7 @@ namespace NosCore.GameObject.Services.SaveService
             }
             catch (Exception e)
             {
-                logger.Error(e, logLanguage[LogLanguageKey.SAVE_CHARACTER_FAILED], session.Character.CharacterId);
+                logger.LogError(e, logLanguage[LogLanguageKey.SAVE_CHARACTER_FAILED], session.Character.CharacterId);
             }
         }
     }

--- a/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
+++ b/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
@@ -22,7 +22,7 @@ using NosCore.Packets.ServerPackets.Specialists;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 namespace NosCore.GameObject.Services.TransformationService
 {
     public class TransformationService(IClock clock, IExperienceService experienceService,
-            IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService, ILogger logger,
+            IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService, ILogger<TransformationService> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, IOptions<WorldConfiguration> worldConfiguration)
         : ITransformationService
     {
@@ -93,7 +93,7 @@ namespace NosCore.GameObject.Services.TransformationService
             if (character.InventoryService.LoadBySlotAndType((byte)EquipmentType.Sp, NoscorePocketType.Wear)?.ItemInstance is
                 not SpecialistInstance sp)
             {
-                logger.Error(logLanguage[LogLanguageKey.USE_SP_WITHOUT_SP_ERROR]);
+                logger.LogError(logLanguage[LogLanguageKey.USE_SP_WITHOUT_SP_ERROR]);
                 return;
             }
 
@@ -191,7 +191,7 @@ namespace NosCore.GameObject.Services.TransformationService
                 }
                 else
                 {
-                    logger.Error(logLanguage[LogLanguageKey.USE_SP_WITHOUT_SP_ERROR]);
+                    logger.LogError(logLanguage[LogLanguageKey.USE_SP_WITHOUT_SP_ERROR]);
                 }
             }
             else

--- a/src/NosCore.LoginServer/LoginServer.cs
+++ b/src/NosCore.LoginServer/LoginServer.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NosCore.Core;
 using NosCore.Core.Configuration;
@@ -23,7 +24,7 @@ using System.Threading.Tasks;
 namespace NosCore.LoginServer
 {
     public class LoginServer(IOptions<LoginConfiguration> loginConfiguration, NetworkManager networkManager,
-            Serilog.ILogger logger, NosCoreContext context,
+            ILogger<LoginServer> logger, NosCoreContext context,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, Channel channel, IChannelHub channelHubClient)
         : BackgroundService
     {
@@ -38,19 +39,19 @@ namespace NosCore.LoginServer
             {
                 await context.Database.MigrateAsync(stoppingToken);
                 await context.Database.GetDbConnection().OpenAsync(stoppingToken);
-                logger.Information(logLanguage[LogLanguageKey.DATABASE_INITIALIZED]);
+                logger.LogInformation(logLanguage[LogLanguageKey.DATABASE_INITIALIZED]);
             }
             catch (Exception ex)
             {
-                logger.Error(logLanguage[LogLanguageKey.DATABASE_ERROR], ex);
-                logger.Error(logLanguage[LogLanguageKey.DATABASE_NOT_UPTODATE]);
+                logger.LogError(logLanguage[LogLanguageKey.DATABASE_ERROR], ex);
+                logger.LogError(logLanguage[LogLanguageKey.DATABASE_NOT_UPTODATE]);
                 throw;
             }
             var connectTask = Policy
                  .Handle<Exception>()
                  .WaitAndRetryForeverAsync(retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                      (_, __, timeSpan) =>
-                         logger.Error(
+                         logger.LogError(
                              logLanguage[LogLanguageKey.MASTER_SERVER_RETRY],
                              timeSpan.TotalSeconds)
                  ).ExecuteAsync(() => channelHubClient.Bind(channel));

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -84,7 +84,6 @@ namespace NosCore.LoginServer
             containerBuilder.RegisterModule<NetworkingModule>();
 
             containerBuilder.RegisterType<NosCoreContext>().As<DbContext>();
-            containerBuilder.Register(_ => Log.Logger).As<Serilog.ILogger>().SingleInstance();
             containerBuilder.RegisterType<Dao<Account, AccountDto, long>>().As<IDao<AccountDto, long>>()
                 .SingleInstance();
             containerBuilder.RegisterType<Dao<Database.Entities.Character, CharacterDto, long>>().As<IDao<CharacterDto, long>>()

--- a/src/NosCore.MasterServer/MasterServer.cs
+++ b/src/NosCore.MasterServer/MasterServer.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.MasterServer
 {
-    public class MasterServer(IOptions<MasterConfiguration> masterConfiguration, ILogger logger, 
+    public class MasterServer(IOptions<MasterConfiguration> masterConfiguration, ILogger<MasterServer> logger, 
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : BackgroundService
     {
@@ -24,7 +24,7 @@ namespace NosCore.MasterServer
 
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            logger.Information(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
+            logger.LogInformation(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}";

--- a/src/NosCore.MasterServer/MasterServerBootstrap.cs
+++ b/src/NosCore.MasterServer/MasterServerBootstrap.cs
@@ -62,7 +62,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ConfigureJwtBearerOptions = NosCore.Core.ConfigureJwtBearerOptions;
-using ILogger = Serilog.ILogger;
 
 namespace NosCore.MasterServer
 {
@@ -174,7 +173,6 @@ namespace NosCore.MasterServer
             });
             containerBuilder.RegisterType<NosCoreContext>().As<DbContext>();
             containerBuilder.Register<IIdService<ChannelInfo>>(_ => new IdService<ChannelInfo>(1)).SingleInstance();
-            containerBuilder.Register(_ => Log.Logger).As<Serilog.ILogger>().SingleInstance();
             containerBuilder.Register(_ => SystemClock.Instance).As<IClock>().SingleInstance();
 
             containerBuilder.RegisterType<BazaarRegistry>().As<IBazaarRegistry>().SingleInstance();
@@ -246,14 +244,14 @@ namespace NosCore.MasterServer
                 {
                     if ((items.Count != 0) && (staticMetaDataAttribute != null))
                     {
-                        c.Resolve<ILogger>().Information(c.Resolve<ILogLanguageLocalizer<LogLanguageKey>>()[staticMetaDataAttribute.LoadedMessage],
+                        c.Resolve<ILoggerFactory>().CreateLogger(nameof(MasterServerBootstrap)).LogInformation(c.Resolve<ILogLanguageLocalizer<LogLanguageKey>>()[staticMetaDataAttribute.LoadedMessage],
                             items.Count);
                     }
                 }
                 else
                 {
-                    c.Resolve<ILogger>()
-                        .Error(c.Resolve<ILogLanguageLocalizer<LogLanguageKey>>()[staticMetaDataAttribute.EmptyMessage]);
+                    c.Resolve<ILoggerFactory>().CreateLogger(nameof(MasterServerBootstrap))
+                        .LogError(c.Resolve<ILogLanguageLocalizer<LogLanguageKey>>()[staticMetaDataAttribute.EmptyMessage]);
                 }
 
                 return items;

--- a/src/NosCore.PacketHandlers/Battle/RevivalPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Battle/RevivalPacketHandler.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.ServerPackets.Battle;
 using NosCore.Packets.ServerPackets.Entities;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.PacketHandlers.Battle
 {
@@ -34,7 +34,7 @@ namespace NosCore.PacketHandlers.Battle
     // Every branch ends with `tp` (position) + `revive` + refreshed `stat`, mirroring
     // the death.txt trace at lines 6338–6344.
     public class RevivalPacketHandler(
-        ILogger logger,
+        ILogger<RevivalPacketHandler> logger,
         IMapChangeService mapChangeService,
         IRespawnService respawnService)
         : PacketHandler<RevivalPacket>, IWorldPacketHandler
@@ -65,7 +65,7 @@ namespace NosCore.PacketHandlers.Battle
             catch (Exception ex)
             {
                 character.IsAlive = false;
-                logger.Warning(ex, "Revival failed for character {CharacterId} type {Type}",
+                logger.LogWarning(ex, "Revival failed for character {CharacterId} type {Type}",
                     character.CharacterId, packet.Type);
             }
         }

--- a/src/NosCore.PacketHandlers/Battle/UseSkillPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Battle/UseSkillPacketHandler.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Battle;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.PacketHandlers.Battle
 {
@@ -28,7 +28,7 @@ namespace NosCore.PacketHandlers.Battle
     // the target entity, and hand off to IBattleService. All damage math lives behind
     // IBattleService so swapping formulas doesn't touch this file.
     public class UseSkillPacketHandler(
-        ILogger logger,
+        ILogger<UseSkillPacketHandler> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
         IBattleService battleService,
         ISessionRegistry sessionRegistry)
@@ -137,13 +137,13 @@ namespace NosCore.PacketHandlers.Battle
                     candidate = clientSession.Character.MapInstance.FindMonster(s => s.VisualId == packet.TargetId);
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN], packet.TargetVisualType);
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN], packet.TargetVisualType);
                     return null;
             }
 
             if (candidate == null)
             {
-                logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
+                logger.LogError(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
                 return null;
             }
             return candidate;

--- a/src/NosCore.PacketHandlers/Bazaar/CBuyPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Bazaar/CBuyPacketHandler.cs
@@ -20,7 +20,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 namespace NosCore.PacketHandlers.Bazaar
 {
     public class CBuyPacketHandler(IBazaarHub bazaarHttpClient, IItemGenerationService itemProvider,
-            ILogger logger,
+            ILogger<CBuyPacketHandler> logger,
             IDao<IItemInstanceDto?, Guid> itemInstanceDao, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<CBuyPacket>, IWorldPacketHandler
     {
@@ -95,7 +95,7 @@ namespace NosCore.PacketHandlers.Bazaar
                             return;
                         }
 
-                        logger.Error(logLanguage[LogLanguageKey.BAZAAR_BUY_ERROR]);
+                        logger.LogError(logLanguage[LogLanguageKey.BAZAAR_BUY_ERROR]);
                     }
                     else
                     {

--- a/src/NosCore.PacketHandlers/Bazaar/CModPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Bazaar/CModPacketHandler.cs
@@ -17,13 +17,13 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Bazaar
 {
-    public class CModPacketHandler(IBazaarHub bazaarHttpClient, ILogger logger,
+    public class CModPacketHandler(IBazaarHub bazaarHttpClient, ILogger<CModPacketHandler> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<CModPacket>, IWorldPacketHandler
     {
@@ -74,7 +74,7 @@ namespace NosCore.PacketHandlers.Bazaar
             }
             else
             {
-                logger.Error(logLanguage[LogLanguageKey.BAZAAR_MOD_ERROR]);
+                logger.LogError(logLanguage[LogLanguageKey.BAZAAR_MOD_ERROR]);
             }
         }
     }

--- a/src/NosCore.PacketHandlers/Bazaar/CScalcPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Bazaar/CScalcPacketHandler.cs
@@ -22,7 +22,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace NosCore.PacketHandlers.Bazaar
 {
     public class CScalcPacketHandler(IOptions<WorldConfiguration> worldConfiguration,
             IBazaarHub bazaarHttpClient,
-            IItemGenerationService itemProvider, ILogger logger, IDao<IItemInstanceDto?, Guid> itemInstanceDao,
+            IItemGenerationService itemProvider, ILogger<CScalcPacketHandler> logger, IDao<IItemInstanceDto?, Guid> itemInstanceDao,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<CScalcPacket>, IWorldPacketHandler
     {
@@ -106,7 +106,7 @@ namespace NosCore.PacketHandlers.Bazaar
                             return;
                         }
 
-                        logger.Error(logLanguage[LogLanguageKey.BAZAAR_DELETE_ERROR]);
+                        logger.LogError(logLanguage[LogLanguageKey.BAZAAR_DELETE_ERROR]);
                     }
                     else
                     {

--- a/src/NosCore.PacketHandlers/CharacterScreen/CharNewPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/CharNewPacketHandler.cs
@@ -23,7 +23,7 @@ using NosCore.Packets.ServerPackets.CharacterSelectionScreen;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.Helpers;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,7 +37,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
             IDao<QuicklistEntryDto, Guid> quicklistEntryDao, IDao<IItemInstanceDto?, Guid> itemInstanceDao,
             IDao<InventoryItemInstanceDto, Guid> inventoryItemInstanceDao, IHpService hpService, IMpService mpService,
             IOptions<WorldConfiguration> worldConfiguration, IDao<CharacterSkillDto, Guid> characterSkillDao,
-            List<ItemDto> items, ILogger logger)
+            List<ItemDto> items, ILoggerFactory loggerFactory)
         : PacketHandler<CharNewPacket>, IWorldPacketHandler
     {
         private readonly WorldConfiguration _worldConfiguration = worldConfiguration.Value;
@@ -130,7 +130,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     };
                     chara = await characterDao.TryInsertOrUpdateAsync(chara);
 
-                    var inventory = new InventoryService(items, worldConfiguration, logger);
+                    var inventory = new InventoryService(items, worldConfiguration, loggerFactory.CreateLogger<InventoryService>());
                     var origin = ResolveStarterOrigin(@class, _worldConfiguration.AllClassAvailableOnCreate);
                     var itemsToAdd = ResolvePack(_worldConfiguration.BasicEquipments, @class, origin, new List<BasicEquipment>());
 

--- a/src/NosCore.PacketHandlers/CharacterScreen/DacPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/DacPacketHandler.cs
@@ -15,13 +15,13 @@ using NosCore.Networking.SessionRef;
 using NosCore.Packets.ClientPackets.CharacterSelectionScreen;
 using NosCore.Packets.ClientPackets.Infrastructure;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.CharacterScreen
 {
     public class DacPacketHandler(IDao<AccountDto, long> accountDao,
-            ILogger logger, IAuthHub authHttpClient,
+            ILogger<DacPacketHandler> logger, IAuthHub authHttpClient,
             IPubSubHub pubSubHub, ISessionRefHolder sessionRefHolder,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<DacPacket>, IWorldPacketHandler
@@ -37,7 +37,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
             await clientSession.HandlePacketsAsync(new[] { new SelectPacket { Slot = packet.Slot } })
                 ;
 
-            logger.Information(logLanguage[LogLanguageKey.ACCOUNT_ARRIVED],
+            logger.LogInformation(logLanguage[LogLanguageKey.ACCOUNT_ARRIVED],
                 clientSession.Account.Name);
         }
     }

--- a/src/NosCore.PacketHandlers/CharacterScreen/EntryPointPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/EntryPointPacketHandler.cs
@@ -25,7 +25,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.CharacterSelectionScreen;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +35,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
 {
     public class EntryPointPacketHandler(IDao<CharacterDto, long> characterDao,
             IDao<AccountDto, long> accountDao,
-            IDao<MateDto, long> mateDao, ILogger logger, IAuthHub authHttpClient,
+            IDao<MateDto, long> mateDao, ILogger<EntryPointPacketHandler> logger, IAuthHub authHttpClient,
             IPubSubHub pubSubHub, IOptions<WorldConfiguration> configuration,
             ISessionRefHolder sessionRefHolder, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<EntryPointPacket>, IWorldPacketHandler
@@ -48,7 +48,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
 
             if (alreadyConnnected)
             {
-                _logger.Error(logLanguage[LogLanguageKey.ALREADY_CONNECTED], new
+                _logger.LogError(logLanguage[LogLanguageKey.ALREADY_CONNECTED], new
                 {
                     accountName
                 });
@@ -60,7 +60,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
 
             if (account == null)
             {
-                _logger.Error(logLanguage[LogLanguageKey.INVALID_ACCOUNT], new
+                _logger.LogError(logLanguage[LogLanguageKey.INVALID_ACCOUNT], new
                 {
                     accountName
                 });
@@ -78,7 +78,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
 
             if (!awaitingConnection)
             {
-                _logger.Error(logLanguage[LogLanguageKey.INVALID_PASSWORD], new
+                _logger.LogError(logLanguage[LogLanguageKey.INVALID_PASSWORD], new
                 {
                     accountName
                 });
@@ -120,7 +120,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
                     clientSession.MfaValidated = true;
                 }
 
-                logger.Information(logLanguage[LogLanguageKey.ACCOUNT_ARRIVED],
+                logger.LogInformation(logLanguage[LogLanguageKey.ACCOUNT_ARRIVED],
                     clientSession.Account.Name);
                 if (!clientSession.MfaValidated && clientSession.Account.MfaSecret != null)
                 {

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -39,7 +39,7 @@ using NosCore.Packets.ClientPackets.CharacterSelectionScreen;
 using NosCore.Packets.ServerPackets.CharacterSelectionScreen;
 using NosCore.Core.I18N;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -50,7 +50,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.CharacterScreen
 {
-    public class SelectPacketHandler(IDao<CharacterDto, long> characterDao, ILogger logger,
+    public class SelectPacketHandler(IDao<CharacterDto, long> characterDao, ILogger<SelectPacketHandler> logger, ILoggerFactory loggerFactory,
             IItemGenerationService itemProvider,
             IMapInstanceAccessorService mapInstanceAccessorService, IDao<IItemInstanceDto?, Guid> itemInstanceDao,
             IDao<InventoryItemInstanceDto, Guid> inventoryItemInstanceDao, IDao<StaticBonusDto, long> staticBonusDao,
@@ -75,7 +75,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
                         && (s.State == CharacterState.Active) && s.ServerId == configuration.Value.ServerId);
                 if (characterDto == null)
                 {
-                    logger.Error(logLanguage[LogLanguageKey.CHARACTER_SLOT_EMPTY], new
+                    logger.LogError(logLanguage[LogLanguageKey.CHARACTER_SLOT_EMPTY], new
                     {
                         clientSession.Account.AccountId,
                         packet.Slot
@@ -110,7 +110,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
                 var ids = inventories.Select(o => o.ItemInstanceId).ToList();
                 var itemInstances = itemInstanceDao.Where(s => ids.Contains(s!.Id))?.ToList() ?? new List<IItemInstanceDto?>();
 
-                var inventoryService = new InventoryService(items, configuration, logger);
+                var inventoryService = new InventoryService(items, configuration, loggerFactory.CreateLogger<InventoryService>());
                 inventories.ForEach(k => inventoryService[k.ItemInstanceId] =
                     InventoryItemInstance.Create(itemProvider.Convert(itemInstances.First(s => s!.Id == k.ItemInstanceId)!),
                         characterId, k));
@@ -258,7 +258,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
             }
             catch (Exception ex)
             {
-                logger.Error(logLanguage[LogLanguageKey.CHARACTER_SELECTION_FAILED], ex, new
+                logger.LogError(logLanguage[LogLanguageKey.CHARACTER_SELECTION_FAILED], ex, new
                 {
                     clientSession.Account.AccountId,
                     packet.Slot

--- a/src/NosCore.PacketHandlers/Chat/BtkPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Chat/BtkPacketHandler.cs
@@ -19,14 +19,14 @@ using NosCore.Packets.ClientPackets.Chat;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.UI;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
 using Character = NosCore.Data.WebApi.Character;
 
 namespace NosCore.PacketHandlers.Chat
 {
-    public class BtkPacketHandler(ILogger logger, ISerializer packetSerializer, IFriendHub friendHttpClient,
+    public class BtkPacketHandler(ILogger<BtkPacketHandler> logger, ISerializer packetSerializer, IFriendHub friendHttpClient,
             IPubSubHub packetHttpClient, IPubSubHub pubSubHub, Channel channel,
             IGameLanguageLocalizer gameLanguageLocalizer, ISessionRegistry sessionRegistry)
         : PacketHandler<BtkPacket>, IWorldPacketHandler
@@ -37,7 +37,7 @@ namespace NosCore.PacketHandlers.Chat
 
             if (friendlist.All(s => s.CharacterId != btkPacket.CharacterId))
             {
-                logger.Error(gameLanguageLocalizer[LanguageKey.USER_IS_NOT_A_FRIEND,
+                logger.LogError(gameLanguageLocalizer[LanguageKey.USER_IS_NOT_A_FRIEND,
                     session.Account.Language]);
                 return;
             }

--- a/src/NosCore.PacketHandlers/Chat/WhisperPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Chat/WhisperPacketHandler.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Text;
@@ -30,7 +30,7 @@ using Character = NosCore.Data.WebApi.Character;
 
 namespace NosCore.PacketHandlers.Chat
 {
-    public class WhisperPacketHandler(ILogger logger, ISerializer packetSerializer,
+    public class WhisperPacketHandler(ILogger<WhisperPacketHandler> logger, ISerializer packetSerializer,
             IBlacklistHub blacklistHttpClient,
              IPubSubHub pubSubHub, Channel channel,
             IGameLanguageLocalizer gameLanguageLocalizer,
@@ -107,7 +107,7 @@ namespace NosCore.PacketHandlers.Chat
             }
             catch (Exception e)
             {
-                logger.Error("Whisper failed.", e);
+                logger.LogError(e, "Whisper failed.");
             }
         }
     }

--- a/src/NosCore.PacketHandlers/Command/CreateItemPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Command/CreateItemPacketHandler.cs
@@ -22,13 +22,13 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Command
 {
-    public class CreateItemPackettHandler(ILogger logger, List<ItemDto> items,
+    public class CreateItemPackettHandler(ILogger<CreateItemPackettHandler> logger, List<ItemDto> items,
             IOptions<WorldConfiguration> worldConfiguration,
             IItemGenerationService itemProvider, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<CreateItemPacket>, IWorldPacketHandler
@@ -139,7 +139,7 @@ namespace NosCore.PacketHandlers.Command
                         wearable.WaterResistance = (short)(wearable.Item.WaterResistance * upgrade);
                         break;
                     default:
-                        logger.Debug(
+                        logger.LogDebug(
                             logLanguage[LogLanguageKey.NO_SPECIAL_PROPERTIES_WEARABLE]);
                         break;
                 }

--- a/src/NosCore.PacketHandlers/Command/SizePacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Command/SizePacketHandler.cs
@@ -13,12 +13,12 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.Networking;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Command
 {
-    public class SizePacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class SizePacketHandler(ILogger<SizePacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<SizePacket>, IWorldPacketHandler
     {
         public override Task ExecuteAsync(SizePacket sizePacket, ClientSession session)
@@ -36,14 +36,14 @@ namespace NosCore.PacketHandlers.Command
                     entity = session.Character.MapInstance.FindNpc(s => s.VisualId == sizePacket.VisualId);
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
                         sizePacket.VisualType);
                     return Task.CompletedTask;
             }
 
             if (entity == null)
             {
-                logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST],
+                logger.LogError(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST],
                     sizePacket.VisualType);
                 return Task.CompletedTask;
             }

--- a/src/NosCore.PacketHandlers/Command/TeleportPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Command/TeleportPacketHandler.cs
@@ -11,12 +11,12 @@ using NosCore.GameObject.Infastructure;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.MapChangeService;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Command
 {
-    public class TeleportPacketHandler(ILogger logger, IMapChangeService mapChangeService,
+    public class TeleportPacketHandler(ILogger<TeleportPacketHandler> logger, IMapChangeService mapChangeService,
             IGameLanguageLocalizer gameLanguageLocalizer, ISessionRegistry sessionRegistry)
         : PacketHandler<TeleportPacket>, IWorldPacketHandler
     {
@@ -30,7 +30,7 @@ namespace NosCore.PacketHandlers.Command
                         targetSession.MapY);
                 }
 
-                logger.Error(gameLanguageLocalizer[LanguageKey.USER_NOT_CONNECTED,
+                logger.LogError(gameLanguageLocalizer[LanguageKey.USER_NOT_CONNECTED,
                     session.Account.Language]);
                 return Task.CompletedTask;
             }

--- a/src/NosCore.PacketHandlers/Exchange/ExcListPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Exchange/ExcListPacketHandler.cs
@@ -15,13 +15,13 @@ using NosCore.Packets.ClientPackets.Exchanges;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Exchanges;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Exchange
 {
-    public class ExcListPacketHandler(IExchangeService exchangeService, ILogger logger,
+    public class ExcListPacketHandler(IExchangeService exchangeService, ILogger<ExcListPacketHandler> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry)
         : PacketHandler<ExcListPacket>, IWorldPacketHandler
     {
@@ -29,7 +29,7 @@ namespace NosCore.PacketHandlers.Exchange
         {
             if ((packet.Gold > clientSession.Character.Gold) || (packet.BankGold > clientSession.Account.BankMoney))
             {
-                logger.Error(logLanguage[LogLanguageKey.NOT_ENOUGH_GOLD]);
+                logger.LogError(logLanguage[LogLanguageKey.NOT_ENOUGH_GOLD]);
                 return;
             }
 
@@ -54,7 +54,7 @@ namespace NosCore.PacketHandlers.Exchange
                                 ExchangeResultType.Failure);
                         await clientSession.SendPacketAsync(closeExchange);
                         await target.SendPacketAsync(closeExchange);
-                        logger.Error(logLanguage[LogLanguageKey.INVALID_EXCHANGE_LIST]);
+                        logger.LogError(logLanguage[LogLanguageKey.INVALID_EXCHANGE_LIST]);
                         return;
                     }
 
@@ -63,7 +63,7 @@ namespace NosCore.PacketHandlers.Exchange
                         await clientSession.SendPacketAsync(exchangeService.CloseExchange(clientSession.Character.CharacterId,
                             ExchangeResultType.Failure));
                         await target.SendPacketAsync(exchangeService.CloseExchange(target.VisualId, ExchangeResultType.Failure));
-                        logger.Error(
+                        logger.LogError(
                             logLanguage[LogLanguageKey.CANNOT_TRADE_NOT_TRADABLE_ITEM]);
                         return;
                     }

--- a/src/NosCore.PacketHandlers/Exchange/ExchangeRequestPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Exchange/ExchangeRequestPacketHandler.cs
@@ -20,14 +20,14 @@ using NosCore.Packets.ServerPackets.Exchanges;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Exchange
 {
-    public class ExchangeRequestPackettHandler(IExchangeService exchangeService, ILogger logger,
+    public class ExchangeRequestPackettHandler(IExchangeService exchangeService, ILogger<ExchangeRequestPackettHandler> logger,
             IBlacklistHub blacklistHttpClient, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             ISessionRegistry sessionRegistry, IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<ExchangeRequestPacket>, IWorldPacketHandler
@@ -42,13 +42,13 @@ namespace NosCore.PacketHandlers.Exchange
             if (hasTarget && ((packet.RequestType == RequestExchangeType.Confirmed) ||
                 (packet.RequestType == RequestExchangeType.Cancelled)))
             {
-                logger.Error(logLanguage[LogLanguageKey.CANT_FIND_CHARACTER]);
+                logger.LogError(logLanguage[LogLanguageKey.CANT_FIND_CHARACTER]);
                 return;
             }
 
             if (clientSession.Character.InShop || (hasTarget && target.InShop))
             {
-                logger.Error(logLanguage[LogLanguageKey.PLAYER_IN_SHOP]);
+                logger.LogError(logLanguage[LogLanguageKey.PLAYER_IN_SHOP]);
                 return;
             }
 
@@ -159,14 +159,14 @@ namespace NosCore.PacketHandlers.Exchange
 
                     if (!targetId.HasValue)
                     {
-                        logger.Error(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
+                        logger.LogError(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
                         return;
                     }
 
                     if (!sessionRegistry.TryGetCharacter(s =>
                         (s.VisualId == targetId.Value) && (s.MapInstance == clientSession.Character.MapInstance), out var exchangeTarget))
                     {
-                        logger.Error(logLanguage[LogLanguageKey.CANT_FIND_CHARACTER]);
+                        logger.LogError(logLanguage[LogLanguageKey.CANT_FIND_CHARACTER]);
                         return;
                     }
 
@@ -198,7 +198,7 @@ namespace NosCore.PacketHandlers.Exchange
                             }
                             else
                             {
-                                logger.Error(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
+                                logger.LogError(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
                             }
                         }
                     }
@@ -243,7 +243,7 @@ namespace NosCore.PacketHandlers.Exchange
                     var cancelId = exchangeService.GetTargetId(clientSession.Character.CharacterId);
                     if (!cancelId.HasValue)
                     {
-                        logger.Error(logLanguage[LogLanguageKey.USER_NOT_IN_EXCHANGE]);
+                        logger.LogError(logLanguage[LogLanguageKey.USER_NOT_IN_EXCHANGE]);
                         return;
                     }
 

--- a/src/NosCore.PacketHandlers/Friend/BlInsPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Friend/BlInsPacketHandler.cs
@@ -14,12 +14,12 @@ using NosCore.Packets.ClientPackets.Relations;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Friend
 {
-    public class BlInsPackettHandler(IBlacklistHub blacklistHttpClient, ILogger logger,
+    public class BlInsPackettHandler(IBlacklistHub blacklistHttpClient, ILogger<BlInsPackettHandler> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<BlInsPacket>, IWorldPacketHandler
     {
@@ -49,7 +49,7 @@ namespace NosCore.PacketHandlers.Friend
                     await session.SendPacketAsync(await session.Character.GenerateBlinitAsync(blacklistHttpClient));
                     break;
                 default:
-                    logger.Warning(logLanguage[LogLanguageKey.FRIEND_REQUEST_DISCONNECTED]);
+                    logger.LogWarning(logLanguage[LogLanguageKey.FRIEND_REQUEST_DISCONNECTED]);
                     break;
             }
         }

--- a/src/NosCore.PacketHandlers/Game/NcifPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Game/NcifPacketHandler.cs
@@ -13,12 +13,12 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.Packets.ClientPackets.Battle;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Game
 {
-    public class NcifPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
+    public class NcifPacketHandler(ILogger<NcifPacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             ISessionRegistry sessionRegistry)
         : PacketHandler<NcifPacket>, IWorldPacketHandler
     {
@@ -38,7 +38,7 @@ namespace NosCore.PacketHandlers.Game
                     entity = session.Character.MapInstance.FindNpc(s => s.VisualId == ncifPacket.TargetId);
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
                         ncifPacket.Type);
                     return;
             }

--- a/src/NosCore.PacketHandlers/Game/ReqInfoPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Game/ReqInfoPacketHandler.cs
@@ -17,7 +17,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Entities;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.PacketHandlers.Game
 {
@@ -35,7 +35,7 @@ namespace NosCore.PacketHandlers.Game
     // Type 6 is not mate-only — it's "info for any map entity"; the VisualType field picks
     // between player/npc/monster/mate. For NPC (2) and monster (3) branches we use the same
     // NpcMonsterDto template the in-packet carries.
-    public sealed class ReqInfoPacketHandler(ILogger logger,
+    public sealed class ReqInfoPacketHandler(ILogger<ReqInfoPacketHandler> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             ISessionRegistry sessionRegistry,
             List<NpcMonsterDto> npcMonsters)
@@ -76,7 +76,7 @@ namespace NosCore.PacketHandlers.Game
                     return;
 
                 default:
-                    logger.Warning(logLanguage[LogLanguageKey.UNHANDLED_REQINFO_TYPE], packet.ReqType);
+                    logger.LogWarning(logLanguage[LogLanguageKey.UNHANDLED_REQINFO_TYPE], packet.ReqType);
                     return;
             }
         }
@@ -100,7 +100,7 @@ namespace NosCore.PacketHandlers.Game
                     template = monsterLookup?.NpcMonster;
                     break;
                 default:
-                    logger.Debug("req_info 6 for unsupported visualType={VisualType} visualId={VisualId}", visualType, visualId);
+                    logger.LogDebug("req_info 6 for unsupported visualType={VisualType} visualId={VisualId}", visualType, visualId);
                     return;
             }
 
@@ -120,7 +120,7 @@ namespace NosCore.PacketHandlers.Game
         // mate subsystem lands.
         private Task HandleMateInfoAsync(ReqInfoPacket packet, ClientSession session)
         {
-            logger.Debug("req_info 6 <mateTransportId={TransportId}> received but mate subsystem is not wired",
+            logger.LogDebug("req_info 6 <mateTransportId={TransportId}> received but mate subsystem is not wired",
                 packet.TargetVNum);
             return Task.CompletedTask;
         }

--- a/src/NosCore.PacketHandlers/Group/PjoinPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Group/PjoinPacketHandler.cs
@@ -23,13 +23,13 @@ using NosCore.Packets.ServerPackets.Groups;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Group
 {
-    public class PjoinPacketHandler(ILogger logger, IBlacklistHub blacklistHttpCLient, IClock clock,
+    public class PjoinPacketHandler(ILogger<PjoinPacketHandler> logger, IBlacklistHub blacklistHttpCLient, IClock clock,
             IIdService<GameObject.Services.GroupService.Group> groupIdService,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, IGameLanguageLocalizer gameLanguageLocalizer,
             ISessionRegistry sessionRegistry)
@@ -42,7 +42,7 @@ namespace NosCore.PacketHandlers.Group
 
             if (!hasTargetSession && (pjoinPacket.RequestType != GroupRequestType.Sharing))
             {
-                logger.Error(gameLanguageLocalizer[LanguageKey.UNABLE_TO_REQUEST_GROUP,
+                logger.LogError(gameLanguageLocalizer[LanguageKey.UNABLE_TO_REQUEST_GROUP,
                     clientSession.Account.Language]);
                 return;
             }
@@ -321,7 +321,7 @@ namespace NosCore.PacketHandlers.Group
                     });
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.GROUPREQUESTTYPE_UNKNOWN]);
+                    logger.LogError(logLanguage[LogLanguageKey.GROUPREQUESTTYPE_UNKNOWN]);
                     break;
             }
         }

--- a/src/NosCore.PacketHandlers/Inventory/BiPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Inventory/BiPacketHandler.cs
@@ -13,12 +13,12 @@ using NosCore.Packets.ClientPackets.Inventory;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Inventory
 {
-    public class BiPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class BiPacketHandler(ILogger<BiPacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<BiPacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(BiPacket bIPacket, ClientSession clientSession)
@@ -68,7 +68,7 @@ namespace NosCore.PacketHandlers.Inventory
                 case RequestDeletionType.Confirmed:
                     if (clientSession.Character.InExchangeOrShop)
                     {
-                        logger.Error(logLanguage[LogLanguageKey.CANT_MOVE_ITEM_IN_SHOP]);
+                        logger.LogError(logLanguage[LogLanguageKey.CANT_MOVE_ITEM_IN_SHOP]);
                         return;
                     }
 

--- a/src/NosCore.PacketHandlers/Inventory/GetPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Inventory/GetPacketHandler.cs
@@ -15,13 +15,13 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using Wolverine;
 
 namespace NosCore.PacketHandlers.Inventory
 {
-    public class GetPacketHandler(ILogger logger, IHeuristic distanceCalculator, IClock clock,
+    public class GetPacketHandler(ILogger<GetPacketHandler> logger, IHeuristic distanceCalculator, IClock clock,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, IMessageBus messageBus)
         : PacketHandler<GetPacket>, IWorldPacketHandler
     {
@@ -49,7 +49,7 @@ namespace NosCore.PacketHandlers.Inventory
                     return;
 
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.UNKNOWN_PICKERTYPE]);
+                    logger.LogError(logLanguage[LogLanguageKey.UNKNOWN_PICKERTYPE]);
                     return;
             }
 

--- a/src/NosCore.PacketHandlers/Login/NoS0575PacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Login/NoS0575PacketHandler.cs
@@ -12,13 +12,13 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.LoginService;
 using NosCore.Packets.ClientPackets.Login;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Login
 {
     public class NoS0575PacketHandler(ILoginService loginService, IOptions<LoginConfiguration> loginConfiguration,
-            ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+            ILogger<NoS0575PacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<NoS0575Packet>, ILoginPacketHandler
     {
         public override Task ExecuteAsync(NoS0575Packet packet, ClientSession clientSession)
@@ -30,7 +30,7 @@ namespace NosCore.PacketHandlers.Login
                     false, packet.RegionType);
             }
 
-            logger.Warning(logLanguage[LogLanguageKey.TRY_OLD_AUTH], packet.Username);
+            logger.LogWarning(logLanguage[LogLanguageKey.TRY_OLD_AUTH], packet.Username);
             return Task.CompletedTask;
 
         }

--- a/src/NosCore.PacketHandlers/Movement/ClientDirPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Movement/ClientDirPacketHandler.cs
@@ -12,12 +12,12 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.Packets.ClientPackets.Movement;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Movement
 {
-    public class ClientDirPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class ClientDirPacketHandler(ILogger<ClientDirPacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<ClientDirPacket>, IWorldPacketHandler
     {
         public override Task ExecuteAsync(ClientDirPacket dirpacket, ClientSession session)
@@ -29,7 +29,7 @@ namespace NosCore.PacketHandlers.Movement
                     entity = session.Character;
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
                         dirpacket.VisualType);
                     return Task.CompletedTask;
             }

--- a/src/NosCore.PacketHandlers/Movement/SitPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Movement/SitPacketHandler.cs
@@ -13,13 +13,13 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.Packets.ClientPackets.Movement;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Movement
 {
-    public class SitPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry)
+    public class SitPacketHandler(ILogger<SitPacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry)
         : PacketHandler<SitPacket>, IWorldPacketHandler
     {
         public override Task ExecuteAsync(SitPacket sitpacket, ClientSession clientSession)
@@ -37,7 +37,7 @@ namespace NosCore.PacketHandlers.Movement
                         }
                         if (player.VisualId != clientSession.Character.VisualId)
                         {
-                            logger.Error(
+                            logger.LogError(
                                 logLanguage[LogLanguageKey.DIRECT_ACCESS_OBJECT_DETECTED],
                                 clientSession.Character, sitpacket);
                             return Task.CompletedTask;
@@ -45,7 +45,7 @@ namespace NosCore.PacketHandlers.Movement
                         entity = player;
                         break;
                     default:
-                        logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
+                        logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
                             u.VisualType);
                         return Task.CompletedTask;
                 }

--- a/src/NosCore.PacketHandlers/Movement/WalkPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Movement/WalkPacketHandler.cs
@@ -16,13 +16,13 @@ using NosCore.Networking.SessionGroup.ChannelMatcher;
 using NosCore.Packets.ClientPackets.Movement;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using Wolverine;
 
 namespace NosCore.PacketHandlers.Movement
 {
-    public class WalkPacketHandler(IHeuristic distanceCalculator, ILogger logger, IClock clock,
+    public class WalkPacketHandler(IHeuristic distanceCalculator, ILogger<WalkPacketHandler> logger, IClock clock,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, IMessageBus messageBus)
         : PacketHandler<WalkPacket>, IWorldPacketHandler
     {
@@ -41,7 +41,7 @@ namespace NosCore.PacketHandlers.Movement
             if ((walkPacket.XCoordinate + walkPacket.YCoordinate) % 3 % 2 != walkPacket.CheckSum)
             {
                 await session.DisconnectAsync();
-                logger.Error(logLanguage[LogLanguageKey.WALK_CHECKSUM_INVALID], session.Character.VisualId);
+                logger.LogError(logLanguage[LogLanguageKey.WALK_CHECKSUM_INVALID], session.Character.VisualId);
                 return;
             }
 
@@ -49,7 +49,7 @@ namespace NosCore.PacketHandlers.Movement
             if (travelTime > 1000 * (_speedDiffAllowed + 1))
             {
                 await session.DisconnectAsync();
-                logger.Error(logLanguage[LogLanguageKey.SPEED_INVALID], session.Character.VisualId);
+                logger.LogError(logLanguage[LogLanguageKey.SPEED_INVALID], session.Character.VisualId);
                 return;
             }
 

--- a/src/NosCore.PacketHandlers/Shops/BuyPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Shops/BuyPacketHandler.cs
@@ -17,12 +17,12 @@ using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Shops
 {
-    public class BuyPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
+    public class BuyPacketHandler(ILogger<BuyPacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             ISessionRegistry sessionRegistry, IOptions<WorldConfiguration> worldConfiguration,
             IItemGenerationService itemProvider, IGameLanguageLocalizer gameLanguageLocalizer)
         : PacketHandler<BuyPacket>, IWorldPacketHandler
@@ -40,7 +40,7 @@ namespace NosCore.PacketHandlers.Shops
                     break;
 
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
                         buyPacket.VisualType);
                     return Task.CompletedTask;
             }
@@ -50,7 +50,7 @@ namespace NosCore.PacketHandlers.Shops
                 return clientSession.Character.BuyAsync(aliveEntity.Shop!, buyPacket.Slot, buyPacket.Amount, worldConfiguration, itemProvider, gameLanguageLocalizer);
             }
 
-            logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
+            logger.LogError(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
             return Task.CompletedTask;
 
         }

--- a/src/NosCore.PacketHandlers/Shops/NrunPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Shops/NrunPacketHandler.cs
@@ -16,12 +16,12 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.Packets.ClientPackets.Npcs;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.PacketHandlers.Shops
 {
     public class NrunPacketHandler(
-            ILogger logger,
+            ILogger<NrunPacketHandler> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             ISessionRegistry sessionRegistry,
             IEnumerable<INrunEventHandler> handlers)
@@ -32,7 +32,7 @@ namespace NosCore.PacketHandlers.Shops
             var handler = handlers.FirstOrDefault(h => h.Runner == packet.Runner);
             if (handler is null)
             {
-                logger.Debug("Unhandled n_run runner {Runner}", packet.Runner);
+                logger.LogDebug("Unhandled n_run runner {Runner}", packet.Runner);
                 return Task.CompletedTask;
             }
 
@@ -49,7 +49,7 @@ namespace NosCore.PacketHandlers.Shops
                     target = null;
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN], packet.Type);
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN], packet.Type);
                     return Task.CompletedTask;
             }
 

--- a/src/NosCore.PacketHandlers/Shops/RequestNpcPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Shops/RequestNpcPacketHandler.cs
@@ -11,12 +11,12 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.Packets.ClientPackets.Npcs;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Shops
 {
-    public class RequestNpcPacketHandler(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry)
+    public class RequestNpcPacketHandler(ILogger<RequestNpcPacketHandler> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry)
         : PacketHandler<RequestNpcPacket>, IWorldPacketHandler
     {
         public override Task ExecuteAsync(RequestNpcPacket requestNpcPacket, ClientSession clientSession)
@@ -39,11 +39,11 @@ namespace NosCore.PacketHandlers.Shops
                     }
                     break;
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN], requestNpcPacket.Type);
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN], requestNpcPacket.Type);
                     return Task.CompletedTask;
             }
 
-            logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
+            logger.LogError(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
             return Task.CompletedTask;
         }
     }

--- a/src/NosCore.PacketHandlers/Shops/ShoppingPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Shops/ShoppingPacketHandler.cs
@@ -14,12 +14,12 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Shops
 {
-    public class ShoppingPacketHandler(ILogger logger, IDignityService dignityService,
+    public class ShoppingPacketHandler(ILogger<ShoppingPacketHandler> logger, IDignityService dignityService,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, ISessionRegistry sessionRegistry)
         : PacketHandler<ShoppingPacket>, IWorldPacketHandler
     {
@@ -47,14 +47,14 @@ namespace NosCore.PacketHandlers.Shops
                     break;
 
                 default:
-                    logger.Error(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
+                    logger.LogError(logLanguage[LogLanguageKey.VISUALTYPE_UNKNOWN],
                         shoppingPacket.VisualType);
                     return;
             }
 
             if (aliveEntity == null)
             {
-                logger.Error(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
+                logger.LogError(logLanguage[LogLanguageKey.VISUALENTITY_DOES_NOT_EXIST]);
                 return;
             }
 

--- a/src/NosCore.PacketHandlers/Upgrades/UpgradePacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Upgrades/UpgradePacketHandler.cs
@@ -13,7 +13,7 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.UpgradeService;
 using NosCore.Packets.ClientPackets.Player;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.PacketHandlers.Upgrades
 {
@@ -22,7 +22,7 @@ namespace NosCore.PacketHandlers.Upgrades
     // another IUpgradeOperation with DI.
     public sealed class UpgradePacketHandler(
         IEnumerable<IUpgradeOperation> operations,
-        ILogger logger,
+        ILogger<UpgradePacketHandler> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         : PacketHandler<UpgradePacket>, IWorldPacketHandler
     {
@@ -31,7 +31,7 @@ namespace NosCore.PacketHandlers.Upgrades
             var operation = operations.FirstOrDefault(o => o.Kind == packet.UpgradeType);
             if (operation == null)
             {
-                logger.Warning(logLanguage[LogLanguageKey.UNHANDLED_UPGRADE_TYPE], packet.UpgradeType);
+                logger.LogWarning(logLanguage[LogLanguageKey.UNHANDLED_UPGRADE_TYPE], packet.UpgradeType);
                 return;
             }
 

--- a/src/NosCore.Parser/ImportFactory.cs
+++ b/src/NosCore.Parser/ImportFactory.cs
@@ -12,7 +12,7 @@ using NosCore.Data.I18N;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -33,7 +33,7 @@ namespace NosCore.Parser
         IDao<I18NNpcMonsterDto, int> i18NNpcMonsterDao, IDao<I18NMapPointDataDto, int> i18NMapPointDataDao,
         IDao<I18NMapIdDataDto, int> i18NMapIdDataDao,
         IDao<I18NItemDto, int> i18NItemDao, IDao<I18NBCardDto, int> i18NbCardDao,
-        IDao<I18NCardDto, int> i18NCardDao, IDao<I18NActDescDto, int> i18NActDescDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        IDao<I18NCardDto, int> i18NCardDao, IDao<I18NActDescDto, int> i18NActDescDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         private readonly List<string[]> _packetList = new();
         private readonly string _password = new Sha512Hasher().Hash("test");
@@ -162,16 +162,16 @@ namespace NosCore.Parser
 
         public async Task ImportI18NAsync()
         {
-            await new I18NParser<I18NActDescDto, int>(i18NActDescDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_act_desc.txt", LogLanguageKey.I18N_ACTDESC_PARSED);
-            await new I18NParser<I18NBCardDto, int>(i18NbCardDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_BCard.txt", LogLanguageKey.I18N_BCARD_PARSED);
-            await new I18NParser<I18NCardDto, int>(i18NCardDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_Card.txt", LogLanguageKey.I18N_CARD_PARSED);
-            await new I18NParser<I18NItemDto, int>(i18NItemDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_Item.txt", LogLanguageKey.I18N_ITEM_PARSED);
-            await new I18NParser<I18NMapIdDataDto, int>(i18NMapIdDataDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_MapIDData.txt", LogLanguageKey.I18N_MAPIDDATA_PARSED);
-            await new I18NParser<I18NMapPointDataDto, int>(i18NMapPointDataDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_MapPointData.txt", LogLanguageKey.I18N_MAPPOINTDATA_PARSED);
-            await new I18NParser<I18NNpcMonsterDto, int>(i18NNpcMonsterDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_monster.txt", LogLanguageKey.I18N_MPCMONSTER_PARSED);
-            await new I18NParser<I18NQuestDto, int>(i18NQuestDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_quest.txt", LogLanguageKey.I18N_QUEST_PARSED);
-            await new I18NParser<I18NSkillDto, int>(i18NSkillDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_Skill.txt", LogLanguageKey.I18N_SKILL_PARSED);
-            await new I18NParser<I18NNpcMonsterTalkDto, int>(i18NNpcMonsterTalkDao, logger, logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_npctalk.txt", LogLanguageKey.I18N_NPCMONSTERTALK_PARSED);
+            await new I18NParser<I18NActDescDto, int>(i18NActDescDao, loggerFactory.CreateLogger<I18NParser<I18NActDescDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_act_desc.txt", LogLanguageKey.I18N_ACTDESC_PARSED);
+            await new I18NParser<I18NBCardDto, int>(i18NbCardDao, loggerFactory.CreateLogger<I18NParser<I18NBCardDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_BCard.txt", LogLanguageKey.I18N_BCARD_PARSED);
+            await new I18NParser<I18NCardDto, int>(i18NCardDao, loggerFactory.CreateLogger<I18NParser<I18NCardDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_Card.txt", LogLanguageKey.I18N_CARD_PARSED);
+            await new I18NParser<I18NItemDto, int>(i18NItemDao, loggerFactory.CreateLogger<I18NParser<I18NItemDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_Item.txt", LogLanguageKey.I18N_ITEM_PARSED);
+            await new I18NParser<I18NMapIdDataDto, int>(i18NMapIdDataDao, loggerFactory.CreateLogger<I18NParser<I18NMapIdDataDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_MapIDData.txt", LogLanguageKey.I18N_MAPIDDATA_PARSED);
+            await new I18NParser<I18NMapPointDataDto, int>(i18NMapPointDataDao, loggerFactory.CreateLogger<I18NParser<I18NMapPointDataDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_MapPointData.txt", LogLanguageKey.I18N_MAPPOINTDATA_PARSED);
+            await new I18NParser<I18NNpcMonsterDto, int>(i18NNpcMonsterDao, loggerFactory.CreateLogger<I18NParser<I18NNpcMonsterDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_monster.txt", LogLanguageKey.I18N_MPCMONSTER_PARSED);
+            await new I18NParser<I18NQuestDto, int>(i18NQuestDao, loggerFactory.CreateLogger<I18NParser<I18NQuestDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_quest.txt", LogLanguageKey.I18N_QUEST_PARSED);
+            await new I18NParser<I18NSkillDto, int>(i18NSkillDao, loggerFactory.CreateLogger<I18NParser<I18NSkillDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_Skill.txt", LogLanguageKey.I18N_SKILL_PARSED);
+            await new I18NParser<I18NNpcMonsterTalkDto, int>(i18NNpcMonsterTalkDao, loggerFactory.CreateLogger<I18NParser<I18NNpcMonsterTalkDto, int>>(), logLanguage).InsertI18NAsync(_folder + Path.DirectorySeparatorChar + "_code_{0}_npctalk.txt", LogLanguageKey.I18N_NPCMONSTERTALK_PARSED);
         }
 
         public Task ImportItemsAsync()

--- a/src/NosCore.Parser/Parser.cs
+++ b/src/NosCore.Parser/Parser.cs
@@ -7,7 +7,7 @@
 using Microsoft.Extensions.Hosting;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading;
@@ -17,7 +17,7 @@ namespace NosCore.Parser
 {
     public class Parser(
         ImportFactory factory,
-        ILogger logger,
+        ILogger<Parser> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
         ParserCliOptions cli,
         IHostApplicationLifetime lifetime)
@@ -36,11 +36,11 @@ namespace NosCore.Parser
                     await RunInteractiveAsync(stoppingToken).ConfigureAwait(false);
                 }
 
-                logger.Information(logLanguage[LogLanguageKey.DONE]);
+                logger.LogInformation(logLanguage[LogLanguageKey.DONE]);
             }
             catch (FileNotFoundException)
             {
-                logger.Error(logLanguage[LogLanguageKey.AT_LEAST_ONE_FILE_MISSING]);
+                logger.LogError(logLanguage[LogLanguageKey.AT_LEAST_ONE_FILE_MISSING]);
                 throw;
             }
             finally
@@ -58,7 +58,7 @@ namespace NosCore.Parser
             {
                 throw new DirectoryNotFoundException($"Folder not found: {folder}");
             }
-            logger.Information("Parsing non-interactively from {Folder}", folder);
+            logger.LogInformation("Parsing non-interactively from {Folder}", folder);
             factory.SetFolder(folder);
             await factory.ImportPacketsAsync().ConfigureAwait(false);
             await RunFullImportAsync().ConfigureAwait(false);
@@ -66,10 +66,10 @@ namespace NosCore.Parser
 
         private async Task RunInteractiveAsync(CancellationToken stoppingToken)
         {
-            logger.Warning(logLanguage[LogLanguageKey.ENTER_PATH]);
+            logger.LogWarning(logLanguage[LogLanguageKey.ENTER_PATH]);
             var folder = Console.ReadLine();
             var inputRedirected = Console.IsInputRedirected;
-            logger.Information(
+            logger.LogInformation(
                 $"{logLanguage[LogLanguageKey.PARSE_ALL]} [Y/n]");
             var key = default(ConsoleKeyInfo);
             if (!inputRedirected)
@@ -117,11 +117,11 @@ namespace NosCore.Parser
         {
             ConsoleKeyInfo key;
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_MAPS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_MAPS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportMapsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_MAPTYPES]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_MAPTYPES]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n')
             {
@@ -130,74 +130,74 @@ namespace NosCore.Parser
                 await factory.ImportMapTypeMapAsync().ConfigureAwait(false);
             }
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_ACCOUNTS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_ACCOUNTS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportAccountsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_PORTALS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_PORTALS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportPortalsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_I18N]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_I18N]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportI18NAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_TIMESPACES]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_TIMESPACES]} [Y/n]");
             Console.ReadKey(true);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_ITEMS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_ITEMS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportItemsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_NPCMONSTERS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_NPCMONSTERS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportNpcMonstersAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_DROPS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_DROPS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportDropsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_NPCMONSTERDATA]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_NPCMONSTERDATA]} [Y/n]");
             Console.ReadKey(true);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_CARDS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_CARDS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportCardsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_SKILLS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_SKILLS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportSkillsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_MAPNPCS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_MAPNPCS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportMapNpcsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_MONSTERS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_MONSTERS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportMapMonstersAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_SHOPS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_SHOPS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportShopsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_TELEPORTERS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_TELEPORTERS]} [Y/n]");
             Console.ReadKey(true);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_SHOPITEMS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_SHOPITEMS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportShopItemsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_SHOPSKILLS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_SHOPSKILLS]} [Y/n]");
             Console.ReadKey(true);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_RECIPES]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_RECIPES]} [Y/n]");
             Console.ReadKey(true);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_SCRIPTS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_SCRIPTS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportScriptsAsync().ConfigureAwait(false);
 
-            logger.Information($"{logLanguage[LogLanguageKey.PARSE_QUESTS]} [Y/n]");
+            logger.LogInformation($"{logLanguage[LogLanguageKey.PARSE_QUESTS]} [Y/n]");
             key = Console.ReadKey(true);
             if (key.KeyChar != 'n') await factory.ImportQuestsAsync().ConfigureAwait(false);
         }

--- a/src/NosCore.Parser/ParserBootstrap.cs
+++ b/src/NosCore.Parser/ParserBootstrap.cs
@@ -74,7 +74,6 @@ namespace NosCore.Parser
         {
             containerBuilder.RegisterType<NosCoreContext>().As<DbContext>()
                 .OnActivated(c => c.Instance.Database.Migrate());
-            containerBuilder.Register(_ => Log.Logger).As<Serilog.ILogger>().SingleInstance();
             containerBuilder.RegisterAssemblyTypes(typeof(CardParser).Assembly)
                 .Where(t => t.Name.EndsWith("Parser") && !t.IsGenericType)
                 .AsSelf();

--- a/src/NosCore.Parser/Parsers/ActParser.cs
+++ b/src/NosCore.Parser/Parsers/ActParser.cs
@@ -8,7 +8,7 @@ using NosCore.Dao.Interfaces;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -45,7 +45,7 @@ namespace NosCore.Parser.Parsers
     //A   {ActId}	{Name}
     //~
 
-    public class ActParser(IDao<ActDto, byte> actDao, IDao<ActPartDto, byte> actDescDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class ActParser(IDao<ActDto, byte> actDao, IDao<ActPartDto, byte> actDescDao, ILogger<ActParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         private readonly string _fileQuestDat = $"{Path.DirectorySeparatorChar}act_desc.dat";
 
@@ -84,7 +84,7 @@ namespace NosCore.Parser.Parsers
 
             await actDao.TryInsertOrUpdateAsync(acts);
             await actDescDao.TryInsertOrUpdateAsync(actParts);
-            logger.Information(logLanguage[LogLanguageKey.ACTS_PARTS_PARSED], actParts.Count);
+            logger.LogInformation(logLanguage[LogLanguageKey.ACTS_PARTS_PARSED], actParts.Count);
         }
     }
 }

--- a/src/NosCore.Parser/Parsers/CardParser.cs
+++ b/src/NosCore.Parser/Parsers/CardParser.cs
@@ -10,7 +10,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class CardParser(IDao<CardDto, short> cardDao, IDao<BCardDto, short> bcardDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class CardParser(IDao<CardDto, short> cardDao, IDao<BCardDto, short> bcardDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         //  VNUM	CardId
         //  NAME    Name
@@ -53,14 +53,16 @@ namespace NosCore.Parser.Parsers
                     source: "1ST + 2ST (5 groups of 6)", description: "Up to 5 BCards, first 3 from 1ST then 2 from 2ST");
         }
 
+        private readonly ILogger<CardParser> _logger = loggerFactory.CreateLogger<CardParser>();
+
         public async Task InsertCardsAsync(string folder)
         {
-            var parser = BuildParser(folder).Build(logger, logLanguage);
+            var parser = BuildParser(folder).Build(loggerFactory, logLanguage);
             var cards = (await parser.GetDtosAsync()).GroupBy(p => p.CardId).Select(g => g.First()).ToList();
             await cardDao.TryInsertOrUpdateAsync(cards);
             await bcardDao.TryInsertOrUpdateAsync(cards.Where(s => s.BCards != null).SelectMany(s => s.BCards));
 
-            logger.Information(logLanguage[LogLanguageKey.CARDS_PARSED], cards.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.CARDS_PARSED], cards.Count);
         }
 
         public List<BCardDto> AddBCards(Dictionary<string, string[][]> chunks)

--- a/src/NosCore.Parser/Parsers/Generic/FluentParserBuilder.cs
+++ b/src/NosCore.Parser/Parsers/Generic/FluentParserBuilder.cs
@@ -6,7 +6,7 @@
 
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -154,9 +154,9 @@ namespace NosCore.Parser.Parsers.Generic
             return this;
         }
 
-        public FluentParser<T> Build(ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        public FluentParser<T> Build(ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         {
-            return new FluentParser<T>(_fileAddress, _endPattern, _firstIndex, _actionList, _splitter, logger, logLanguage);
+            return new FluentParser<T>(_fileAddress, _endPattern, _firstIndex, _actionList, _splitter, loggerFactory, logLanguage);
         }
 
         private static string GetPropertyName<TProperty>(Expression<Func<T, TProperty>> expression)
@@ -203,10 +203,11 @@ namespace NosCore.Parser.Parsers.Generic
             int firstIndex,
             Dictionary<string, Func<Dictionary<string, string[][]>, object?>> actionList,
             string splitter,
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         {
-            _parser = new GenericParser<T>(fileAddress, endPattern, firstIndex, actionList, logger, logLanguage);
+            _parser = new GenericParser<T>(fileAddress, endPattern, firstIndex, actionList,
+                loggerFactory.CreateLogger<GenericParser<T>>(), logLanguage);
             _splitter = splitter;
         }
 

--- a/src/NosCore.Parser/Parsers/Generic/GenericParser.cs
+++ b/src/NosCore.Parser/Parsers/Generic/GenericParser.cs
@@ -7,7 +7,7 @@
 using FastMember;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ namespace NosCore.Parser.Parsers.Generic
 {
 
     public class GenericParser<T>(string fileAddress, string endPattern, int firstIndex,
-        Dictionary<string, Func<Dictionary<string, string[][]>, object?>> actionList, ILogger logger,
+        Dictionary<string, Func<Dictionary<string, string[][]>, object?>> actionList, ILogger<GenericParser<T>> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     where T : new()
     {
@@ -71,7 +71,7 @@ namespace NosCore.Parser.Parsers.Generic
                 }
                 catch (Exception ex)
                 {
-                    logger.Verbose(logLanguage[LogLanguageKey.CHUNK_FORMAT_INVALID], lines, ex);
+                    logger.LogTrace(logLanguage[LogLanguageKey.CHUNK_FORMAT_INVALID], lines, ex);
                 }
             })));
             return resultCollection.ToList();

--- a/src/NosCore.Parser/Parsers/I18NParser.cs
+++ b/src/NosCore.Parser/Parsers/I18NParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Dto;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class I18NParser<TDto, TPk>(IDao<TDto, TPk> dao, ILogger logger,
+    public class I18NParser<TDto, TPk>(IDao<TDto, TPk> dao, ILogger<I18NParser<TDto, TPk>> logger,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     where TDto : II18NDto, new()
     where TPk : struct
@@ -62,14 +62,14 @@ namespace NosCore.Parser.Parsers
                     }
                     await dao.TryInsertOrUpdateAsync(dtos.Values);
 
-                    logger.Information(
+                    logger.LogInformation(
                         logLanguage[logLanguageKey],
                         dtos.Count,
                         region);
                 }
                 catch (FileNotFoundException)
                 {
-                    logger.Warning(logLanguage[LogLanguageKey.LANGUAGE_MISSING]);
+                    logger.LogWarning(logLanguage[LogLanguageKey.LANGUAGE_MISSING]);
                 }
             }));
         }

--- a/src/NosCore.Parser/Parsers/ItemParser.cs
+++ b/src/NosCore.Parser/Parsers/ItemParser.cs
@@ -12,7 +12,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.Packets.Enumerations;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -21,8 +21,9 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class ItemParser(IDao<ItemDto, short> itemDao, IDao<BCardDto, short> bCardDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class ItemParser(IDao<ItemDto, short> itemDao, IDao<BCardDto, short> bCardDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
+        private readonly ILogger<ItemParser> _logger = loggerFactory.CreateLogger<ItemParser>();
         //  VNUM	{VNum}	{Price}
         //	NAME {Name}
 
@@ -153,7 +154,7 @@ namespace NosCore.Parser.Parsers
 
         public async Task ParseAsync(string folder)
         {
-            var parser = BuildParser(folder).Build(logger, logLanguage);
+            var parser = BuildParser(folder).Build(loggerFactory, logLanguage);
             var items = (await parser.GetDtosAsync()).GroupBy(p => p.VNum).Select(g => g.First()).ToList();
             foreach (var item in items)
             {
@@ -192,7 +193,7 @@ namespace NosCore.Parser.Parsers
             await itemDao.TryInsertOrUpdateAsync(items);
             await bCardDao.TryInsertOrUpdateAsync(items.Where(s => s.BCards != null).SelectMany(s => s.BCards));
 
-            logger.Information(logLanguage[LogLanguageKey.ITEMS_PARSED], items.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.ITEMS_PARSED], items.Count);
         }
 
 

--- a/src/NosCore.Parser/Parsers/MapMonsterParser.cs
+++ b/src/NosCore.Parser/Parsers/MapMonsterParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Dto;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 namespace NosCore.Parser.Parsers
 {
     public class MapMonsterParser(IDao<MapMonsterDto, int> mapMonsterDao, IDao<NpcMonsterDto, short> npcMonsterDao,
-        ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        ILogger<MapMonsterParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         public async Task InsertMapMonsterAsync(List<string[]> packetList)
         {
@@ -62,7 +62,7 @@ namespace NosCore.Parser.Parsers
             }
 
             await mapMonsterDao.TryInsertOrUpdateAsync(monsters);
-            logger.Information(logLanguage[LogLanguageKey.MONSTERS_PARSED],
+            logger.LogInformation(logLanguage[LogLanguageKey.MONSTERS_PARSED],
                 monsters.Count);
         }
     }

--- a/src/NosCore.Parser/Parsers/MapNpcParser.cs
+++ b/src/NosCore.Parser/Parsers/MapNpcParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Dto;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 namespace NosCore.Parser.Parsers
 {
     public class MapNpcParser(IDao<MapNpcDto, int> mapNpcDao, IDao<NpcMonsterDto, short> npcMonsterDao, IDao<NpcTalkDto, short> npcTalkDao,
-        ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        ILogger<MapNpcParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         public async Task InsertMapNpcsAsync(List<string[]> packetList)
         {
@@ -72,7 +72,7 @@ namespace NosCore.Parser.Parsers
             }
 
             await mapNpcDao.TryInsertOrUpdateAsync(npcs);
-            logger.Information(logLanguage[LogLanguageKey.NPCS_PARSED], npcCounter);
+            logger.LogInformation(logLanguage[LogLanguageKey.NPCS_PARSED], npcCounter);
         }
     }
 }

--- a/src/NosCore.Parser/Parsers/MapParser.cs
+++ b/src/NosCore.Parser/Parsers/MapParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,11 +18,12 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class MapParser(IDao<MapDto, short> mapDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class MapParser(IDao<MapDto, short> mapDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         //{ID} {ID} {MapPoint} {MapPoint} {Name}
         //DATA 0
 
+        private readonly ILogger<MapParser> _logger = loggerFactory.CreateLogger<MapParser>();
         private readonly string _fileMapIdDat = $"{Path.DirectorySeparatorChar}MapIDData.dat";
         private readonly string _folderMap = $"{Path.DirectorySeparatorChar}map";
 
@@ -33,7 +34,8 @@ namespace NosCore.Parser.Parsers
                 {nameof(MapDto.MapId), chunk => Convert.ToInt16(chunk.First(s=>char.IsDigit(s.Key.FirstOrDefault())).Value[0][0])},
                 {nameof(MapDto.NameI18NKey), chunk => chunk.First(s=>char.IsDigit(s.Key.FirstOrDefault())).Value[0][4]}
             };
-            var genericParser = new GenericParser<MapDto>(folder + _fileMapIdDat, "DATA 0", 0, actionList, logger, logLanguage);
+            var genericParser = new GenericParser<MapDto>(folder + _fileMapIdDat, "DATA 0", 0, actionList,
+                loggerFactory.CreateLogger<GenericParser<MapDto>>(), logLanguage);
             return genericParser.GetDtosAsync(" ");
         }
 
@@ -54,7 +56,7 @@ namespace NosCore.Parser.Parsers
             }).ToList();
 
             await mapDao.TryInsertOrUpdateAsync(maps);
-            logger.Information(logLanguage[LogLanguageKey.MAPS_PARSED], maps.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.MAPS_PARSED], maps.Count);
         }
     }
 }

--- a/src/NosCore.Parser/Parsers/MapTypeParser.cs
+++ b/src/NosCore.Parser/Parsers/MapTypeParser.cs
@@ -10,13 +10,13 @@ using NosCore.Data.Enumerations.Interaction;
 using NosCore.Data.Enumerations.Map;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class MapTypeParser(IDao<MapTypeDto, short> dropDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class MapTypeParser(IDao<MapTypeDto, short> dropDao, ILogger<MapTypeParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         internal async Task InsertMapTypesAsync()
         {
@@ -208,7 +208,7 @@ namespace NosCore.Parser.Parsers
                 }
             };
             await dropDao.TryInsertOrUpdateAsync(mts);
-            logger.Information(logLanguage[LogLanguageKey.MAPTYPES_PARSED]);
+            logger.LogInformation(logLanguage[LogLanguageKey.MAPTYPES_PARSED]);
         }
     }
 }

--- a/src/NosCore.Parser/Parsers/NpcMonsterParser.cs
+++ b/src/NosCore.Parser/Parsers/NpcMonsterParser.cs
@@ -10,7 +10,7 @@ using NosCore.Data.Enumerations.Map;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -50,7 +50,8 @@ namespace NosCore.Parser.Parsers
         private readonly string _fileNpcId = $"{Path.DirectorySeparatorChar}monster.dat";
         private readonly IDao<BCardDto, short> _bCardDao;
         private readonly IDao<DropDto, short> _dropDao;
-        private readonly ILogger _logger;
+        private readonly ILogger<NpcMonsterParser> _logger;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly IDao<NpcMonsterDto, short> _npcMonsterDao;
         private readonly IDao<NpcMonsterSkillDto, long> _npcMonsterSkillDao;
         private readonly IDao<SkillDto, short> _skillDao;
@@ -63,14 +64,15 @@ namespace NosCore.Parser.Parsers
 
         public NpcMonsterParser(IDao<SkillDto, short> skillDao, IDao<BCardDto, short> bCardDao,
             IDao<DropDto, short> dropDao, IDao<NpcMonsterSkillDto, long> npcMonsterSkillDao,
-            IDao<NpcMonsterDto, short> npcMonsterDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+            IDao<NpcMonsterDto, short> npcMonsterDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
         {
             _skillDao = skillDao;
             _bCardDao = bCardDao;
             _dropDao = dropDao;
             _npcMonsterSkillDao = npcMonsterSkillDao;
             _npcMonsterDao = npcMonsterDao;
-            _logger = logger;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<NpcMonsterParser>();
             _logLanguage = logLanguage;
             InitStats();
         }
@@ -276,13 +278,13 @@ namespace NosCore.Parser.Parsers
         {
             _skilldb = _skillDao.LoadAll().ToDictionary(x => x.SkillVNum, x => x);
             _dropdb = _dropDao.LoadAll().Where(x => x.MonsterVNum != null).GroupBy(x => x.MonsterVNum).ToDictionary(x => x.Key ?? 0, x => x.ToList());
-            var parser = BuildParser(folder).Build(_logger, _logLanguage);
+            var parser = BuildParser(folder).Build(_loggerFactory, _logLanguage);
             var monsters = (await parser.GetDtosAsync()).GroupBy(p => p.NpcMonsterVNum).Select(g => g.First()).ToList();
             await _npcMonsterDao.TryInsertOrUpdateAsync(monsters);
             await _bCardDao.TryInsertOrUpdateAsync(monsters.Where(s => s.BCards != null).SelectMany(s => s.BCards));
             await _dropDao.TryInsertOrUpdateAsync(monsters.Where(s => s.Drop != null).SelectMany(s => s.Drop));
             await _npcMonsterSkillDao.TryInsertOrUpdateAsync(monsters.Where(s => s.NpcMonsterSkill != null).SelectMany(s => s.NpcMonsterSkill));
-            _logger.Information(_logLanguage[LogLanguageKey.NPCMONSTERS_PARSED], monsters.Count);
+            _logger.LogInformation(_logLanguage[LogLanguageKey.NPCMONSTERS_PARSED], monsters.Count);
         }
 
         private int ImportJxp(Dictionary<string, string[][]> chunk)

--- a/src/NosCore.Parser/Parsers/NpcTalkParser.cs
+++ b/src/NosCore.Parser/Parsers/NpcTalkParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -31,8 +31,9 @@ namespace NosCore.Parser.Parsers
     //b zts16038e  . n_talk 7 0&@
     //b zts4759e  . n_run 3000 0
     //b zts4760e  . n_talk 100 0
-    public class NpcTalkParser(IDao<NpcTalkDto, short> npcTalkDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class NpcTalkParser(IDao<NpcTalkDto, short> npcTalkDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
+        private readonly ILogger<NpcTalkParser> _logger = loggerFactory.CreateLogger<NpcTalkParser>();
         private readonly string _fileNpcTalkDat = $"{Path.DirectorySeparatorChar}npctalk.dat";
 
 
@@ -45,12 +46,12 @@ namespace NosCore.Parser.Parsers
             };
 
             var genericParser = new GenericParser<NpcTalkDto>(folder + _fileNpcTalkDat,
-                "%", 0, actionList, logger, logLanguage);
+                "%", 0, actionList, loggerFactory.CreateLogger<GenericParser<NpcTalkDto>>(), logLanguage);
             var npcTalks = (await genericParser.GetDtosAsync(" ")).ToList();
             npcTalks.Add(new NpcTalkDto { DialogId = 99, NameI18NKey = "" });
             await npcTalkDao.TryInsertOrUpdateAsync(npcTalks);
 
-            logger.Information(logLanguage[LogLanguageKey.NPCTALKS_PARSED], npcTalks.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.NPCTALKS_PARSED], npcTalks.Count);
         }
 
     }

--- a/src/NosCore.Parser/Parsers/PortalParser.cs
+++ b/src/NosCore.Parser/Parsers/PortalParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class PortalParser(ILogger logger, IDao<MapDto, short> mapDao, IDao<PortalDto, int> portalDao, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class PortalParser(ILogger<PortalParser> logger, IDao<MapDto, short> mapDao, IDao<PortalDto, int> portalDao, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         private readonly List<PortalDto> _listPortals2 = new();
         private List<PortalDto> _listPortals1 = new();
@@ -170,7 +170,7 @@ namespace NosCore.Parser.Parsers
                         && (s.SourceY == portal.SourceY))).ToList();
             await portalDao.TryInsertOrUpdateAsync(portalsDtos);
 
-            logger.Information(logLanguage[LogLanguageKey.PORTALS_PARSED],
+            logger.LogInformation(logLanguage[LogLanguageKey.PORTALS_PARSED],
                 portalsDtos.Count + portalCounter);
         }
     }

--- a/src/NosCore.Parser/Parsers/QuestParser.cs
+++ b/src/NosCore.Parser/Parsers/QuestParser.cs
@@ -10,7 +10,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.Packets.Enumerations;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -36,8 +36,9 @@ namespace NosCore.Parser.Parsers
     //#=======
 
     public class QuestParser(IDao<QuestDto, short> questDao, IDao<QuestObjectiveDto, Guid> questObjectiveDao,
-        IDao<QuestRewardDto, short> questRewardDao, IDao<QuestQuestRewardDto, Guid> questQuestRewardDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        IDao<QuestRewardDto, short> questRewardDao, IDao<QuestQuestRewardDto, Guid> questQuestRewardDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
+        private readonly ILogger<QuestParser> _logger = loggerFactory.CreateLogger<QuestParser>();
         private readonly string _fileQuestDat = $"{Path.DirectorySeparatorChar}quest.dat";
         private Dictionary<short, QuestRewardDto>? _questRewards;
 
@@ -67,14 +68,14 @@ namespace NosCore.Parser.Parsers
 
         public async Task ImportQuestsAsync(string folder)
         {
-            var parser = BuildParser(folder).Build(logger, logLanguage);
+            var parser = BuildParser(folder).Build(loggerFactory, logLanguage);
             var quests = await parser.GetDtosAsync();
 
             await questDao.TryInsertOrUpdateAsync(quests);
             await questQuestRewardDao.TryInsertOrUpdateAsync(quests.Where(s => s.QuestQuestReward != null).SelectMany(s => s.QuestQuestReward));
             await questObjectiveDao.TryInsertOrUpdateAsync(quests.Where(s => s.QuestObjective != null).SelectMany(s => s.QuestObjective));
 
-            logger.Information(logLanguage[LogLanguageKey.QUESTS_PARSED], quests.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.QUESTS_PARSED], quests.Count);
         }
 
         private List<QuestQuestRewardDto> ImportQuestQuestRewards(Dictionary<string, string[][]> chunk)

--- a/src/NosCore.Parser/Parsers/QuestPrizeParser.cs
+++ b/src/NosCore.Parser/Parsers/QuestPrizeParser.cs
@@ -10,7 +10,7 @@ using NosCore.Data.Enumerations.Quest;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,8 +25,9 @@ namespace NosCore.Parser.Parsers
     //DATA	10	-1	-1	-1	-1
     //END
 
-    public class QuestPrizeParser(IDao<QuestRewardDto, short> questRewardDtoDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class QuestPrizeParser(IDao<QuestRewardDto, short> questRewardDtoDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
+        private readonly ILogger<QuestPrizeParser> _logger = loggerFactory.CreateLogger<QuestPrizeParser>();
         private readonly string _fileQuestPrizeDat = $"{Path.DirectorySeparatorChar}qstprize.dat";
 
 
@@ -39,10 +40,11 @@ namespace NosCore.Parser.Parsers
                 {nameof(QuestRewardDto.Data), chunk => ImportData(chunk)},
                 {nameof(QuestRewardDto.Amount), chunk => ImportAmount(chunk)},
             };
-            var genericParser = new GenericParser<QuestRewardDto>(folder + _fileQuestPrizeDat, "END", 0, actionList, logger, logLanguage);
+            var genericParser = new GenericParser<QuestRewardDto>(folder + _fileQuestPrizeDat, "END", 0, actionList,
+                loggerFactory.CreateLogger<GenericParser<QuestRewardDto>>(), logLanguage);
             var questRewardDtos = await genericParser.GetDtosAsync();
             await questRewardDtoDao.TryInsertOrUpdateAsync(questRewardDtos);
-            logger.Information(logLanguage[LogLanguageKey.QUEST_PRIZES_PARSED], questRewardDtos.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.QUEST_PRIZES_PARSED], questRewardDtos.Count);
         }
 
         private int ImportData(Dictionary<string, string[][]> chunk)

--- a/src/NosCore.Parser/Parsers/RespawnMapTypeParser.cs
+++ b/src/NosCore.Parser/Parsers/RespawnMapTypeParser.cs
@@ -9,14 +9,14 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.Enumerations.Interaction;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class RespawnMapTypeParser(IDao<RespawnMapTypeDto, long> respawnMapTypeDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class RespawnMapTypeParser(IDao<RespawnMapTypeDto, long> respawnMapTypeDao, ILogger<RespawnMapTypeParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         internal async Task InsertRespawnMapTypeAsync()
         {
@@ -80,7 +80,7 @@ namespace NosCore.Parser.Parsers
                 }
             };
             await respawnMapTypeDao.TryInsertOrUpdateAsync(respawnmaptypemaps);
-            logger.Information(logLanguage[LogLanguageKey.RESPAWNTYPE_PARSED],
+            logger.LogInformation(logLanguage[LogLanguageKey.RESPAWNTYPE_PARSED],
                 respawnmaptypemaps.Count());
         }
     }

--- a/src/NosCore.Parser/Parsers/ScriptParser.cs
+++ b/src/NosCore.Parser/Parsers/ScriptParser.cs
@@ -8,7 +8,7 @@ using NosCore.Dao.Interfaces;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class ScriptParser(IDao<ScriptDto, Guid> scriptDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class ScriptParser(IDao<ScriptDto, Guid> scriptDao, ILogger<ScriptParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         //script {ScriptId}	
         //{ScriptStepId}	{StepType} {Argument}
@@ -61,7 +61,7 @@ namespace NosCore.Parser.Parsers
             }
 
             await scriptDao.TryInsertOrUpdateAsync(scripts);
-            logger.Information(logLanguage[LogLanguageKey.SCRIPTS_PARSED], scripts.Count);
+            logger.LogInformation(logLanguage[LogLanguageKey.SCRIPTS_PARSED], scripts.Count);
         }
     }
 }

--- a/src/NosCore.Parser/Parsers/ShopItemParser.cs
+++ b/src/NosCore.Parser/Parsers/ShopItemParser.cs
@@ -8,14 +8,14 @@ using NosCore.Dao.Interfaces;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class ShopItemParser(IDao<ShopItemDto, int> shopItemDao, IDao<ShopDto, int> shopDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class ShopItemParser(IDao<ShopItemDto, int> shopItemDao, IDao<ShopDto, int> shopDao, ILogger<ShopItemParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         public async Task InsertShopItemsAsync(List<string[]> packetList)
         {
@@ -87,7 +87,7 @@ namespace NosCore.Parser.Parsers
             }
 
             await shopItemDao.TryInsertOrUpdateAsync(shopListItemDtos);
-            logger.Information(logLanguage[LogLanguageKey.SHOPITEMS_PARSED],
+            logger.LogInformation(logLanguage[LogLanguageKey.SHOPITEMS_PARSED],
                 itemCounter);
         }
     }

--- a/src/NosCore.Parser/Parsers/ShopParser.cs
+++ b/src/NosCore.Parser/Parsers/ShopParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Dto;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace NosCore.Parser.Parsers
 {
-    public class ShopParser(IDao<ShopDto, int> shopDao, IDao<MapNpcDto, int> mapNpcDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+    public class ShopParser(IDao<ShopDto, int> shopDao, IDao<MapNpcDto, int> mapNpcDao, ILogger<ShopParser> logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
         public async Task InsertShopsAsync(List<string[]> packetList)
         {
@@ -64,7 +64,7 @@ namespace NosCore.Parser.Parsers
             }
 
             await shopDao.TryInsertOrUpdateAsync(shops);
-            logger.Information(logLanguage[LogLanguageKey.SHOPS_PARSED],
+            logger.LogInformation(logLanguage[LogLanguageKey.SHOPS_PARSED],
                 shopCounter);
         }
     }

--- a/src/NosCore.Parser/Parsers/SkillParser.cs
+++ b/src/NosCore.Parser/Parsers/SkillParser.cs
@@ -9,7 +9,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -19,9 +19,10 @@ using System.Threading.Tasks;
 namespace NosCore.Parser.Parsers
 {
     public class SkillParser(IDao<BCardDto, short> bCardDao, IDao<ComboDto, int> comboDao,
-        IDao<SkillDto, short> skillDao, ILogger logger, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
+        IDao<SkillDto, short> skillDao, ILoggerFactory loggerFactory, ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     {
-        //  VNUM    {VNum}  
+        private readonly ILogger<SkillParser> _logger = loggerFactory.CreateLogger<SkillParser>();
+        //  VNUM    {VNum}
         //	NAME    {Name}
 
         //  TYPE	0	0	0	0	0	0
@@ -79,7 +80,7 @@ namespace NosCore.Parser.Parsers
 
         public async Task InsertSkillsAsync(string folder)
         {
-            var parser = BuildParser(folder).Build(logger, logLanguage);
+            var parser = BuildParser(folder).Build(loggerFactory, logLanguage);
             var skills = await parser.GetDtosAsync();
 
             foreach (var skill in skills.Where(s => s.Class > 31))
@@ -111,7 +112,7 @@ namespace NosCore.Parser.Parsers
             await comboDao.TryInsertOrUpdateAsync(skills.Where(s => s.Combo != null).SelectMany(s => s.Combo));
             await bCardDao.TryInsertOrUpdateAsync(skills.Where(s => s.BCards != null).SelectMany(s => s.BCards));
 
-            logger.Information(logLanguage[LogLanguageKey.SKILLS_PARSED], skills.Count);
+            _logger.LogInformation(logLanguage[LogLanguageKey.SKILLS_PARSED], skills.Count);
         }
 
         private List<BCardDto> AddBCards(Dictionary<string, string[][]> chunks)

--- a/src/NosCore.WebApi/WebApiBootstrap.cs
+++ b/src/NosCore.WebApi/WebApiBootstrap.cs
@@ -66,7 +66,6 @@ namespace NosCore.WebApi
                     containerBuilder.RegisterType<NosCore.GameObject.InterChannelCommunication.HubConnectionFactory>();
                     containerBuilder.RegisterType<AuthHubClient>().AsImplementedInterfaces();
                     containerBuilder.RegisterType<NosCoreContext>().As<DbContext>();
-                    containerBuilder.Register(_ => Log.Logger).As<Serilog.ILogger>().SingleInstance();
                     containerBuilder.RegisterType<Dao<Account, AccountDto, long>>().As<IDao<AccountDto, long>>().SingleInstance();
 
                     containerBuilder.Register<IHasher>(o => o.Resolve<IOptions<WebApiConfiguration>>().Value.HashingType switch

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -80,7 +80,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using ILogger = Serilog.ILogger;
 
 namespace NosCore.WorldServer
 {
@@ -249,11 +248,8 @@ namespace NosCore.WorldServer
                         x => new LogLanguageLocalizer<LanguageKey, LocalizedResources>(
                             x.GetRequiredService<IStringLocalizer<LocalizedResources>>()));
 
-                    // Cross-cutting singletons that don't belong to any module. Logger is
-                    // wired here because it needs a captured Log.Logger reference; IClock
-                    // because SystemClock is an external NodaTime type with no container-
-                    // friendly constructor.
-                    services.AddSingleton<Serilog.ILogger>(_ => Log.Logger);
+                    // IClock is wired as a singleton here because SystemClock is an external
+                    // NodaTime type with no container-friendly constructor.
                     services.AddSingleton<IClock>(_ => SystemClock.Instance);
 
                     // ID services, session/map registries, hub clients, pathfinder and the

--- a/test/NosCore.GameObject.Tests/Messaging/Handlers/Battle/MonsterRespawnHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Messaging/Handlers/Battle/MonsterRespawnHandlerTests.cs
@@ -11,7 +11,7 @@ using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Messaging.Events;
 using NosCore.GameObject.Messaging.Handlers.Battle;
 using NosCore.GameObject.Services.BattleService;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Tests.Messaging.Handlers.Battle
 {
@@ -25,7 +25,7 @@ namespace NosCore.GameObject.Tests.Messaging.Handlers.Battle
             // Passing a non-monster victim should be a no-op (no aggro clear either,
             // since the player doesn't own monster aggro state).
             var aggro = new Mock<IAggroService>();
-            var handler = new MonsterRespawnHandler(aggro.Object, new Mock<ILogger>().Object);
+            var handler = new MonsterRespawnHandler(aggro.Object, new Mock<ILogger<MonsterRespawnHandler>>().Object);
 
             var playerVictim = new Mock<IAliveEntity>().Object;
             var killer = new Mock<IAliveEntity>().Object;

--- a/test/NosCore.GameObject.Tests/Messaging/Handlers/Battle/PlayerRevivalHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Messaging/Handlers/Battle/PlayerRevivalHandlerTests.cs
@@ -17,7 +17,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 
 namespace NosCore.GameObject.Tests.Messaging.Handlers.Battle
@@ -36,7 +36,7 @@ namespace NosCore.GameObject.Tests.Messaging.Handlers.Battle
             await TestHelpers.ResetAsync();
             _session = await TestHelpers.Instance.GenerateSessionAsync();
             _killerSession = await TestHelpers.Instance.GenerateSessionAsync();
-            _handler = new PlayerRevivalHandler(new Mock<ILogger>().Object);
+            _handler = new PlayerRevivalHandler(new Mock<ILogger<PlayerRevivalHandler>>().Object);
         }
 
         [TestMethod]

--- a/test/NosCore.GameObject.Tests/Messaging/Handlers/UseItem/WearHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Messaging/Handlers/UseItem/WearHandlerTests.cs
@@ -25,7 +25,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 
 namespace NosCore.GameObject.Tests.Messaging.Handlers.UseItem
@@ -46,7 +46,7 @@ namespace NosCore.GameObject.Tests.Messaging.Handlers.UseItem
             _session = await TestHelpers.Instance.GenerateSessionAsync();
             _session.Character.MapInstance = TestHelpers.Instance.MapInstanceAccessorService.GetBaseMapById(1)!;
             _handler = new WearHandler(
-                new Mock<ILogger>().Object,
+                new Mock<ILogger<WearHandler>>().Object,
                 TestHelpers.Instance.Clock,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.WorldConfiguration);

--- a/test/NosCore.GameObject.Tests/Messaging/WolverineHandlerResolutionTests.cs
+++ b/test/NosCore.GameObject.Tests/Messaging/WolverineHandlerResolutionTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NodaTime;
 using NosCore.Algorithm.ExperienceService;
@@ -102,7 +103,6 @@ namespace NosCore.GameObject.Tests.Messaging
             var services = new ServiceCollection();
 
             // Mirrors WorldServerBootstrap.ConfigureServices ordering.
-            services.AddSingleton<Serilog.ILogger>(_ => Serilog.Log.Logger);
             services.AddSingleton<IClock>(_ => SystemClock.Instance);
             services.AddTransient<NosCore.Core.I18N.IGameLanguageLocalizer, NosCore.Core.I18N.GameLanguageLocalizer>();
 

--- a/test/NosCore.GameObject.Tests/Services/BattleService/BattleServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/BattleServiceTests.cs
@@ -21,7 +21,8 @@ using NosCore.GameObject.Services.BattleService.Model;
 using NosCore.GameObject.Services.ShopService;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Wolverine;
 
 namespace NosCore.GameObject.Tests.Services.BattleService
@@ -48,7 +49,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
                 _hitQueue.Object,
                 _bus.Object,
                 new Mock<GameObject.Services.BroadcastService.ISessionRegistry>().Object,
-                new Mock<ILogger>().Object);
+                NullLogger<NosCore.GameObject.Services.BattleService.BattleService>.Instance);
         }
 
         [TestMethod]

--- a/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
@@ -20,7 +20,7 @@ using NosCore.GameObject.Services.BattleService;
 using NosCore.GameObject.Services.BattleService.Model;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Tests.Services.BattleService
 {
@@ -96,7 +96,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
 
-            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<ILogger>().Object);
+            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
             var skill = MakeSkill() with
             {
                 SkillVnum = 7,
@@ -122,7 +122,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
 
-            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<ILogger>().Object);
+            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
             var skill = MakeSkill() with { Duration = 100, BCards = new[] { new BCardDto { Type = 3 } } };
 
             await queue.EnqueueAsync(Request(attacker, target) with { Skill = skill });
@@ -163,7 +163,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
 
-            return new HitQueue(calc.Object, stats.Object, new Mock<IBuffService>().Object, new Mock<IRegenerationService>().Object, new Mock<ILogger>().Object);
+            return new HitQueue(calc.Object, stats.Object, new Mock<IBuffService>().Object, new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
         }
 
         private class MutableDamage

--- a/test/NosCore.GameObject.Tests/Services/BattleService/MonsterAiTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/MonsterAiTests.cs
@@ -16,7 +16,7 @@ using NosCore.GameObject.Services.BattleService;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.PathfindingService;
 using NosCore.PathFinder.Interfaces;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Tests.Services.BattleService
 {
@@ -40,7 +40,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
                 new Mock<IRandomProvider>().Object,
                 new FakeClock(Instant.FromUtc(2026, 1, 1, 0, 0)),
                 new Dictionary<short, SkillDto>(),
-                new Mock<ILogger>().Object);
+                new Mock<ILogger<MonsterAi>>().Object);
 
             Assert.IsNotNull(ai);
             Assert.IsInstanceOfType(ai, typeof(IMonsterAi));

--- a/test/NosCore.GameObject.Tests/Services/BroadcastService/SessionRegistryTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BroadcastService/SessionRegistryTests.cs
@@ -7,7 +7,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NosCore.GameObject.Services.BroadcastService;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Linq;
@@ -19,12 +19,12 @@ namespace NosCore.GameObject.Tests.Services.BroadcastService
     public class SessionRegistryTests
     {
         private ISessionRegistry Registry = null!;
-        private Mock<ILogger> MockLogger = null!;
+        private Mock<ILogger<SessionRegistry>> MockLogger = null!;
 
         [TestInitialize]
         public void Setup()
         {
-            MockLogger = new Mock<ILogger>();
+            MockLogger = new Mock<ILogger<SessionRegistry>>();
             Registry = new SessionRegistry(MockLogger.Object);
         }
 

--- a/test/NosCore.GameObject.Tests/Services/ChannelCommunicationService/Handlers/PostedPacketMessageHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/ChannelCommunicationService/Handlers/PostedPacketMessageHandlerTests.cs
@@ -18,7 +18,7 @@ using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Shared.I18N;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -31,7 +31,7 @@ namespace NosCore.GameObject.Tests.Services.ChannelCommunicationService.Handlers
         private ClientSession Session = null!;
         private Mock<ISessionRegistry> SessionRegistry = null!;
         private Mock<IDeserializer> Deserializer = null!;
-        private Mock<ILogger> Logger = null!;
+        private Mock<ILogger<PostedPacketMessageChannelCommunicationMessageHandler>> Logger = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> LogLanguage = null!;
 
         [TestInitialize]
@@ -42,7 +42,7 @@ namespace NosCore.GameObject.Tests.Services.ChannelCommunicationService.Handlers
             Session = await TestHelpers.Instance.GenerateSessionAsync();
             SessionRegistry = new Mock<ISessionRegistry>();
             Deserializer = new Mock<IDeserializer>();
-            Logger = new Mock<ILogger>();
+            Logger = new Mock<ILogger<PostedPacketMessageChannelCommunicationMessageHandler>>();
             LogLanguage = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             Handler = new PostedPacketMessageChannelCommunicationMessageHandler(Logger.Object, Deserializer.Object, LogLanguage.Object, SessionRegistry.Object);
         }
@@ -185,7 +185,13 @@ namespace NosCore.GameObject.Tests.Services.ChannelCommunicationService.Handlers
 
         private void ShouldLogError()
         {
-            Logger.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+            Logger.Verify(x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => true),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
     }
 }

--- a/test/NosCore.GameObject.Tests/Services/ChannelCommunicationService/Handlers/StatDataMessageHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/ChannelCommunicationService/Handlers/StatDataMessageHandlerTests.cs
@@ -21,7 +21,7 @@ using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.ChannelCommunicationService.Handlers;
 using NosCore.Shared.I18N;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -33,7 +33,7 @@ namespace NosCore.GameObject.Tests.Services.ChannelCommunicationService.Handlers
         private StatDataMessageChannelCommunicationMessageHandler Handler = null!;
         private ClientSession Session = null!;
         private Mock<ISessionRegistry> SessionRegistry = null!;
-        private Mock<ILogger> Logger = null!;
+        private Mock<ILogger<StatDataMessageChannelCommunicationMessageHandler>> Logger = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> LogLanguage = null!;
         private IOptions<WorldConfiguration> WorldConfig = null!;
         private Mock<IExperienceService> ExperienceService = null!;
@@ -47,7 +47,7 @@ namespace NosCore.GameObject.Tests.Services.ChannelCommunicationService.Handlers
             Broadcaster.Reset();
             Session = await TestHelpers.Instance.GenerateSessionAsync();
             SessionRegistry = new Mock<ISessionRegistry>();
-            Logger = new Mock<ILogger>();
+            Logger = new Mock<ILogger<StatDataMessageChannelCommunicationMessageHandler>>();
             LogLanguage = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             WorldConfig = Options.Create(new WorldConfiguration { MaxGoldAmount = 999999999 });
             ExperienceService = new Mock<IExperienceService>();
@@ -135,7 +135,13 @@ namespace NosCore.GameObject.Tests.Services.ChannelCommunicationService.Handlers
 
         private void ShouldLogError()
         {
-            Logger.Verify(x => x.Error(It.IsAny<string>()), Times.Once);
+            Logger.Verify(x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => true),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
     }
 }

--- a/test/NosCore.GameObject.Tests/Services/CharacterService/CharacterInitializationServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/CharacterService/CharacterInitializationServiceTests.cs
@@ -14,7 +14,7 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.CharacterService;
 using NosCore.GameObject.Services.MinilandService;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -24,7 +24,7 @@ namespace NosCore.GameObject.Tests.Services.CharacterService
     [TestClass]
     public class CharacterInitializationServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<CharacterInitializationServiceTests> Logger = new Mock<ILogger<CharacterInitializationServiceTests>>().Object;
         private ICharacterInitializationService Service = null!;
         private IMinilandService MinilandService = null!;
         private ClientSession Session = null!;

--- a/test/NosCore.GameObject.Tests/Services/ExchangeService/ExchangeServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/ExchangeService/ExchangeServiceTests.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -34,7 +34,6 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
     [TestClass]
     public class ExchangeServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private GameObject.Services.ExchangeService.ExchangeService? ExchangeProvider;
         private GameObject.Services.ItemGenerationService.ItemGenerationService? ItemProvider;
         private IOptions<WorldConfiguration>? WorldConfiguration;
@@ -56,8 +55,8 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
                 new Item {Type = NoscorePocketType.Main, VNum = 1013}
             };
 
-            ItemProvider = new GameObject.Services.ItemGenerationService.ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
-            ExchangeProvider = new GameObject.Services.ExchangeService.ExchangeService(ItemProvider, WorldConfiguration, Logger, new ExchangeRequestRegistry(), TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer);
+            ItemProvider = new GameObject.Services.ItemGenerationService.ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
+            ExchangeProvider = new GameObject.Services.ExchangeService.ExchangeService(ItemProvider, WorldConfiguration, NullLogger<NosCore.GameObject.Services.ExchangeService.ExchangeService>.Instance, new ExchangeRequestRegistry(), TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer);
         }
 
         [TestMethod]
@@ -184,7 +183,7 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
             _sessionA = await TestHelpers.Instance.GenerateSessionAsync();
             _sessionB = await TestHelpers.Instance.GenerateSessionAsync();
             _realExchange = new GameObject.Services.ExchangeService.ExchangeService(
-                ItemProvider!, WorldConfiguration!, Logger, new ExchangeRequestRegistry(),
+                ItemProvider!, WorldConfiguration!, NullLogger<NosCore.GameObject.Services.ExchangeService.ExchangeService>.Instance, new ExchangeRequestRegistry(),
                 TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer);
             _realExchange.OpenExchange(_sessionA.Character.CharacterId, _sessionB.Character.VisualId);
         }
@@ -319,10 +318,10 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
         {
             IInventoryService inventory1 =
                 new GameObject.Services.InventoryService.InventoryService(new List<ItemDto> { new Item { VNum = 1012, Type = NoscorePocketType.Main } },
-                    WorldConfiguration!, Logger);
+                    WorldConfiguration!, NullLogger<NosCore.GameObject.Services.InventoryService.InventoryService>.Instance);
             IInventoryService inventory2 =
                 new GameObject.Services.InventoryService.InventoryService(new List<ItemDto> { new Item { VNum = 1013, Type = NoscorePocketType.Main } },
-                    WorldConfiguration!, Logger);
+                    WorldConfiguration!, NullLogger<NosCore.GameObject.Services.InventoryService.InventoryService>.Instance);
             var item1 = inventory1.AddItemToPocket(InventoryItemInstance.Create(ItemProvider!.Create(1012, 1), 0))!
                 .First();
             var item2 = inventory2.AddItemToPocket(InventoryItemInstance.Create(ItemProvider.Create(1013, 1), 0))!

--- a/test/NosCore.GameObject.Tests/Services/FriendService/FriendServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/FriendService/FriendServiceTests.cs
@@ -16,7 +16,7 @@ using NosCore.GameObject.Services.FriendService;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -28,7 +28,7 @@ namespace NosCore.GameObject.Tests.Services.FriendService
     [TestClass]
     public class FriendServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NosCore.GameObject.Services.FriendService.FriendService> Logger = new Mock<ILogger<NosCore.GameObject.Services.FriendService.FriendService>>().Object;
         private IFriendService Service = null!;
         private IFriendRequestRegistry FriendRequestHolder = null!;
         private Mock<IPubSubHub> PubSubHub = null!;

--- a/test/NosCore.GameObject.Tests/Services/InventoryService/InventoryServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/InventoryService/InventoryServiceTests.cs
@@ -6,7 +6,6 @@
 
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Core.Configuration;
 using NosCore.Data.Enumerations;
 using NosCore.Data.Enumerations.Items;
@@ -18,7 +17,7 @@ using NosCore.GameObject.Services.ItemGenerationService.Item;
 using NosCore.Packets.ClientPackets.Inventory;
 using NosCore.Packets.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -29,7 +28,6 @@ namespace NosCore.GameObject.Tests.Services.InventoryService
     [TestClass]
     public class InventoryServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private GameObject.Services.ItemGenerationService.ItemGenerationService? ItemProvider;
         private IInventoryService? Inventory { get; set; }
 
@@ -45,9 +43,9 @@ namespace NosCore.GameObject.Tests.Services.InventoryService
                 new Item {Type = NoscorePocketType.Equipment, VNum = 912, ItemType = ItemType.Specialist},
                 new Item {Type = NoscorePocketType.Equipment, VNum = 924, ItemType = ItemType.Fashion}
             };
-            ItemProvider = new GameObject.Services.ItemGenerationService.ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            ItemProvider = new GameObject.Services.ItemGenerationService.ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
             Inventory = new GameObject.Services.InventoryService.InventoryService(items, Options.Create(new WorldConfiguration { BackpackSize = 3, MaxItemAmount = 999 }),
-                Logger);
+                NullLogger<NosCore.GameObject.Services.InventoryService.InventoryService>.Instance);
         }
 
         [TestMethod]

--- a/test/NosCore.GameObject.Tests/Services/MapChangeService/MapChangeServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/MapChangeService/MapChangeServiceTests.cs
@@ -13,7 +13,7 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.MapChangeService;
 using NosCore.GameObject.Services.MinilandService;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -22,7 +22,7 @@ namespace NosCore.GameObject.Tests.Services.MapChangeService
     [TestClass]
     public class MapChangeServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NosCore.GameObject.Services.MapChangeService.MapChangeService> Logger = new Mock<ILogger<NosCore.GameObject.Services.MapChangeService.MapChangeService>>().Object;
         private IMapChangeService Service = null!;
         private ClientSession Session = null!;
 

--- a/test/NosCore.GameObject.Tests/Services/MinilandService/MinilandServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/MinilandService/MinilandServiceTests.cs
@@ -17,7 +17,7 @@ using NosCore.GameObject.Services.MapInstanceGenerationService;
 using NosCore.GameObject.Services.MinilandService;
 using NosCore.Packets.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -167,7 +167,7 @@ namespace NosCore.GameObject.Tests.Services.MinilandService
             var mapMiniland = new NosCore.GameObject.Map.Map { MapId = 20001, NameI18NKey = "miniland", Data = new byte[] { } };
 
             var clock = TestHelpers.Instance.Clock;
-            var logger = new Mock<ILogger>().Object;
+            var logger = new Mock<ILogger<MapInstance>>().Object;
             var sessionGroupFactory = TestHelpers.Instance.SessionGroupFactory;
             var mapItemProvider = TestHelpers.Instance.MapItemProvider!;
             var mapChangeService = new Mock<GameObject.Services.MapChangeService.IMapChangeService>().Object;

--- a/test/NosCore.GameObject.Tests/Services/QuestService/QuestServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/QuestService/QuestServiceTests.cs
@@ -12,7 +12,7 @@ using NosCore.GameObject.Services.QuestService;
 using NosCore.GameObject.Services.QuestService.Handlers;
 using NosCore.Packets.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Concurrent;
@@ -25,7 +25,6 @@ namespace NosCore.GameObject.Tests.Services.QuestService
     [TestClass]
     public class QuestServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private GameObject.Services.QuestService.QuestService Service = null!;
         private ClientSession Session = null!;
         private List<ScriptDto> Scripts = null!;
@@ -108,13 +107,13 @@ namespace NosCore.GameObject.Tests.Services.QuestService
                 TestHelpers.Instance.WorldConfiguration,
                 Quests,
                 QuestObjectives,
-                Logger,
+                NullLogger<NosCore.GameObject.Services.QuestService.QuestService>.Instance,
                 TestHelpers.Instance.Clock,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 new IQuestTypeHandler[]
                 {
-                    new HuntQuestHandler(Logger),
-                    new NumberOfKillQuestHandler(Logger),
+                    new HuntQuestHandler(NullLogger<HuntQuestHandler>.Instance),
+                    new NumberOfKillQuestHandler(NullLogger<NumberOfKillQuestHandler>.Instance),
                     new GoToQuestHandler(),
                 },
                 new Mock<Wolverine.IMessageBus>().Object,

--- a/test/NosCore.GameObject.Tests/Services/SaveService/SaveServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/SaveService/SaveServiceTests.cs
@@ -19,7 +19,7 @@ using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.GameObject.Services.MinilandService;
 using NosCore.GameObject.Services.SaveService;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Concurrent;
@@ -32,7 +32,6 @@ namespace NosCore.GameObject.Tests.Services.SaveService
     [TestClass]
     public class SaveServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private ClientSession Session = null!;
         private ISaveService Service = null!;
         private IItemGenerationService ItemProvider = null!;
@@ -49,15 +48,15 @@ namespace NosCore.GameObject.Tests.Services.SaveService
                 Guid.NewGuid().ToString());
             NosCoreContext ContextBuilder() => new NosCoreContext(optionsBuilder.Options);
 
-            var itemInstanceDao = new Dao<ItemInstance, IItemInstanceDto?, Guid>(Logger, ContextBuilder);
-            var inventoryItemInstanceDao = new Dao<Database.Entities.InventoryItemInstance, InventoryItemInstanceDto, Guid>(Logger, ContextBuilder);
-            var staticBonusDao = new Dao<StaticBonus, StaticBonusDto, long>(Logger, ContextBuilder);
-            var quicklistEntriesDao = new Dao<QuicklistEntry, QuicklistEntryDto, Guid>(Logger, ContextBuilder);
-            var titleDao = new Dao<Title, TitleDto, Guid>(Logger, ContextBuilder);
-            var characterQuestDao = new Dao<Database.Entities.CharacterQuest, CharacterQuestDto, Guid>(Logger, ContextBuilder);
-            var characterQuestObjectiveDao = new Dao<Database.Entities.CharacterQuestObjective, CharacterQuestObjectiveDto, Guid>(Logger, ContextBuilder);
+            var itemInstanceDao = new Dao<ItemInstance, IItemInstanceDto?, Guid>(NullLogger<Dao<ItemInstance, IItemInstanceDto?, Guid>>.Instance, ContextBuilder);
+            var inventoryItemInstanceDao = new Dao<Database.Entities.InventoryItemInstance, InventoryItemInstanceDto, Guid>(NullLogger<Dao<Database.Entities.InventoryItemInstance, InventoryItemInstanceDto, Guid>>.Instance, ContextBuilder);
+            var staticBonusDao = new Dao<StaticBonus, StaticBonusDto, long>(NullLogger<Dao<StaticBonus, StaticBonusDto, long>>.Instance, ContextBuilder);
+            var quicklistEntriesDao = new Dao<QuicklistEntry, QuicklistEntryDto, Guid>(NullLogger<Dao<QuicklistEntry, QuicklistEntryDto, Guid>>.Instance, ContextBuilder);
+            var titleDao = new Dao<Title, TitleDto, Guid>(NullLogger<Dao<Title, TitleDto, Guid>>.Instance, ContextBuilder);
+            var characterQuestDao = new Dao<Database.Entities.CharacterQuest, CharacterQuestDto, Guid>(NullLogger<Dao<Database.Entities.CharacterQuest, CharacterQuestDto, Guid>>.Instance, ContextBuilder);
+            var characterQuestObjectiveDao = new Dao<Database.Entities.CharacterQuestObjective, CharacterQuestObjectiveDto, Guid>(NullLogger<Dao<Database.Entities.CharacterQuestObjective, CharacterQuestObjectiveDto, Guid>>.Instance, ContextBuilder);
             CharacterQuestObjectiveDao = characterQuestObjectiveDao;
-            var respawnDao = new Dao<Database.Entities.Respawn, RespawnDto, long>(Logger, ContextBuilder);
+            var respawnDao = new Dao<Database.Entities.Respawn, RespawnDto, long>(NullLogger<Dao<Database.Entities.Respawn, RespawnDto, long>>.Instance, ContextBuilder);
 
             var minilandService = new Mock<IMinilandService>();
             minilandService.Setup(s => s.GetMiniland(It.IsAny<long>()))
@@ -76,7 +75,7 @@ namespace NosCore.GameObject.Tests.Services.SaveService
                 characterQuestDao,
                 characterQuestObjectiveDao,
                 respawnDao,
-                Logger,
+                NullLogger<NosCore.GameObject.Services.SaveService.SaveService>.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
         }
 

--- a/test/NosCore.GameObject.Tests/Services/SkillService/SkillServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/SkillService/SkillServiceTests.cs
@@ -12,7 +12,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.SkillService;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -23,7 +23,7 @@ namespace NosCore.GameObject.Tests.Services.SkillService
     [TestClass]
     public class SkillServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<SkillServiceTests> Logger = new Mock<ILogger<SkillServiceTests>>().Object;
         private ISkillService Service = null!;
         private Mock<IDao<CharacterSkillDto, Guid>> CharacterSkillDao = null!;
         private List<SkillDto> Skills = null!;

--- a/test/NosCore.GameObject.Tests/Services/TransformationService/TransformationServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/TransformationService/TransformationServiceTests.cs
@@ -12,7 +12,7 @@ using NosCore.Algorithm.JobExperienceService;
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.TransformationService;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -21,7 +21,7 @@ namespace NosCore.GameObject.Tests.Services.TransformationService
     [TestClass]
     public class TransformationServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NosCore.GameObject.Services.TransformationService.TransformationService> Logger = new Mock<ILogger<NosCore.GameObject.Services.TransformationService.TransformationService>>().Object;
         private ITransformationService Service = null!;
         private ClientSession Session = null!;
 

--- a/test/NosCore.GameObject.Tests/Services/UpgradeService/EquipmentUpgradeOperationTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/UpgradeService/EquipmentUpgradeOperationTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NosCore.Data.Enumerations;
@@ -238,7 +239,7 @@ namespace NosCore.GameObject.Tests.Services.UpgradeService
         private void PlaceWearable(byte upgrade, sbyte rare)
         {
             var item = new Item { VNum = ArmorVNum, Type = NoscorePocketType.Equipment, ItemType = ItemType.Armor };
-            var wearable = new WearableInstance(item, new Mock<Serilog.ILogger>().Object,
+            var wearable = new WearableInstance(item, new Mock<ILogger<WearableInstance>>().Object,
                 TestHelpers.Instance.LogLanguageLocalizer)
             {
                 Upgrade = upgrade,

--- a/test/NosCore.GameObject.Tests/Services/UpgradeService/RarifyOperationTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/UpgradeService/RarifyOperationTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NosCore.Data.Enumerations;
@@ -170,7 +171,7 @@ namespace NosCore.GameObject.Tests.Services.UpgradeService
                 ItemType = ItemType.Armor,
                 EquipmentSlot = EquipmentType.Armor,
             };
-            var wearable = new WearableInstance(item, new Mock<Serilog.ILogger>().Object,
+            var wearable = new WearableInstance(item, new Mock<ILogger<WearableInstance>>().Object,
                 TestHelpers.Instance.LogLanguageLocalizer)
             {
                 Rare = rare,

--- a/test/NosCore.GameObject.Tests/Services/UpgradeService/SumUpgradeOperationTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/UpgradeService/SumUpgradeOperationTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NosCore.Data.Enumerations;
@@ -280,7 +281,7 @@ namespace NosCore.GameObject.Tests.Services.UpgradeService
                 ItemType = ItemType.Armor,
                 EquipmentSlot = equipmentSlot,
             };
-            var wearable = new WearableInstance(item, new Mock<Serilog.ILogger>().Object,
+            var wearable = new WearableInstance(item, new Mock<ILogger<WearableInstance>>().Object,
                 TestHelpers.Instance.LogLanguageLocalizer)
             {
                 Upgrade = upgrade,

--- a/test/NosCore.GameObject.Tests/Services/WarehouseService/WarehouseServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/WarehouseService/WarehouseServiceTests.cs
@@ -6,7 +6,6 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Dao;
 using NosCore.Dao.Interfaces;
 using NosCore.Data.Dto;
@@ -14,7 +13,7 @@ using NosCore.Data.Enumerations.Miniland;
 using NosCore.Database;
 using NosCore.GameObject.Services.WarehouseService;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Linq;
@@ -25,7 +24,6 @@ namespace NosCore.GameObject.Tests.Services.WarehouseService
     [TestClass]
     public class WarehouseServiceTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private IWarehouseService Service = null!;
         private IDao<WarehouseItemDto, Guid> WarehouseItemDao = null!;
         private IDao<WarehouseDto, Guid> WarehouseDao = null!;
@@ -41,9 +39,9 @@ namespace NosCore.GameObject.Tests.Services.WarehouseService
                 Guid.NewGuid().ToString());
             NosCoreContext ContextBuilder() => new NosCoreContext(optionsBuilder.Options);
 
-            WarehouseItemDao = new Dao<Database.Entities.WarehouseItem, WarehouseItemDto, Guid>(Logger, ContextBuilder);
-            WarehouseDao = new Dao<Database.Entities.Warehouse, WarehouseDto, Guid>(Logger, ContextBuilder);
-            ItemInstanceDao = new Dao<Database.Entities.ItemInstance, IItemInstanceDto?, Guid>(Logger, ContextBuilder);
+            WarehouseItemDao = new Dao<Database.Entities.WarehouseItem, WarehouseItemDto, Guid>(NullLogger<Dao<Database.Entities.WarehouseItem, WarehouseItemDto, Guid>>.Instance, ContextBuilder);
+            WarehouseDao = new Dao<Database.Entities.Warehouse, WarehouseDto, Guid>(NullLogger<Dao<Database.Entities.Warehouse, WarehouseDto, Guid>>.Instance, ContextBuilder);
+            ItemInstanceDao = new Dao<Database.Entities.ItemInstance, IItemInstanceDto?, Guid>(NullLogger<Dao<Database.Entities.ItemInstance, IItemInstanceDto?, Guid>>.Instance, ContextBuilder);
 
             Service = new GameObject.Services.WarehouseService.WarehouseService(
                 WarehouseItemDao,

--- a/test/NosCore.GameObject.Tests/ShopTests.cs
+++ b/test/NosCore.GameObject.Tests/ShopTests.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NosCore.Data.Enumerations;
 using NosCore.Data.StaticEntities;
@@ -182,7 +183,7 @@ namespace NosCore.GameObject.Tests
                 new Item { Type = NoscorePocketType.Etc, VNum = 1, IsSoldable = true, Price = price, ReputPrice = reputPrice }
             };
             return new ItemGenerationService(items,
-                Logger,
+                NullLoggerFactory.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
         }
 

--- a/test/NosCore.PacketHandlers.Tests/Battle/RevivalPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Battle/RevivalPacketHandlerTests.cs
@@ -24,7 +24,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 
 namespace NosCore.PacketHandlers.Tests.Battle
@@ -52,7 +52,7 @@ namespace NosCore.PacketHandlers.Tests.Battle
                 .Returns(((short)1, (short)50, (short)60));
 
             _handler = new RevivalPacketHandler(
-                new Mock<ILogger>().Object,
+                new Mock<ILogger<RevivalPacketHandler>>().Object,
                 _mapChangeService.Object,
                 _respawnService.Object);
         }

--- a/test/NosCore.PacketHandlers.Tests/Battle/UseSkillPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Battle/UseSkillPacketHandlerTests.cs
@@ -15,7 +15,7 @@ using NosCore.Packets.ClientPackets.Battle;
 using NosCore.Packets.ServerPackets.Battle;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Concurrent;
@@ -31,7 +31,7 @@ namespace NosCore.PacketHandlers.Tests.Battle
         private ClientSession Session = null!;
         private ClientSession TargetSession = null!;
         private Mock<IBattleService> BattleService = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<UseSkillPacketHandler> Logger = new Mock<ILogger<UseSkillPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Bazaar/CBuyPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Bazaar/CBuyPacketHandlerTests.cs
@@ -23,7 +23,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -35,7 +35,7 @@ namespace NosCore.PacketHandlers.Tests.Bazaar
     [TestClass]
     public class CBuyPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<CBuyPacketHandler> Logger = new Mock<ILogger<CBuyPacketHandler>>().Object;
         private Mock<IBazaarHub> BazaarHttpClient = null!;
         private CBuyPacketHandler CbuyPacketHandler = null!;
         private Mock<IDao<IItemInstanceDto?, Guid>> ItemInstanceDao = null!;

--- a/test/NosCore.PacketHandlers.Tests/Bazaar/CModPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Bazaar/CModPacketHandlerTests.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +30,7 @@ namespace NosCore.PacketHandlers.Tests.Bazaar
     [TestClass]
     public class CModPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<CModPacketHandler> Logger = new Mock<ILogger<CModPacketHandler>>().Object;
         private Mock<IBazaarHub> BazaarHttpClient = null!;
         private CModPacketHandler CmodPacketHandler = null!;
         private ClientSession Session = null!;

--- a/test/NosCore.PacketHandlers.Tests/Bazaar/CScalcPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Bazaar/CScalcPacketHandlerTests.cs
@@ -22,7 +22,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Bazaar;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -35,7 +35,7 @@ namespace NosCore.PacketHandlers.Tests.Bazaar
     [TestClass]
     public class CScalcPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<CScalcPacketHandler> Logger = new Mock<ILogger<CScalcPacketHandler>>().Object;
         private Mock<IBazaarHub> BazaarHttpClient = null!;
         private CScalcPacketHandler CScalcPacketHandler = null!;
         private Mock<IDao<IItemInstanceDto?, Guid>> ItemInstanceDao = null!;

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/CharNewPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/CharNewPacketHandlerTests.cs
@@ -25,7 +25,7 @@ using NosCore.PacketHandlers.CharacterScreen;
 using NosCore.Packets.ClientPackets.CharacterSelectionScreen;
 using NosCore.Packets.ClientPackets.Drops;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -37,7 +37,6 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
     [TestClass]
     public class CharNewPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private CharNewPacketHandler CharNewPacketHandler = null!;
         private ClientSession Session = null!;
         private Mock<IMapChangeService> MapChangeService = null!;
@@ -49,7 +48,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
             await TestHelpers.ResetAsync();
             CharNewPacketHandler =
                 new CharNewPacketHandler(TestHelpers.Instance.CharacterDao, new Mock<IItemGenerationService>().Object, new Mock<IDao<QuicklistEntryDto, Guid>>().Object,
-                    new Mock<IDao<IItemInstanceDto?, Guid>>().Object, new Mock<IDao<InventoryItemInstanceDto, Guid>>().Object, new HpService(), new MpService(), TestHelpers.Instance.WorldConfiguration, new Mock<IDao<CharacterSkillDto, Guid>>().Object, TestHelpers.Instance.ItemList, new Mock<ILogger>().Object);
+                    new Mock<IDao<IItemInstanceDto?, Guid>>().Object, new Mock<IDao<InventoryItemInstanceDto, Guid>>().Object, new HpService(), new MpService(), TestHelpers.Instance.WorldConfiguration, new Mock<IDao<CharacterSkillDto, Guid>>().Object, TestHelpers.Instance.ItemList, NullLoggerFactory.Instance);
             Session = await TestHelpers.Instance.GenerateSessionAsync(new List<IPacketHandler> { CharNewPacketHandler });
             MapChangeService = new Mock<IMapChangeService>();
             Session.ClearPlayerEntity();

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/CharRenPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/CharRenPacketHandlerTests.cs
@@ -20,7 +20,7 @@ using NosCore.PacketHandlers.CharacterScreen;
 using NosCore.Packets.ClientPackets.CharacterSelectionScreen;
 using NosCore.Packets.ClientPackets.Drops;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -31,7 +31,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
     [TestClass]
     public class CharRenPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<CharRenPacketHandlerTests> Logger = new Mock<ILogger<CharRenPacketHandlerTests>>().Object;
         private CharRenPacketHandler CharRenPacketHandler = null!;
         private ClientSession Session = null!;
         private Data.Dto.CharacterDto ExistingCharacter = null!;

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/DacPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/DacPacketHandlerTests.cs
@@ -17,7 +17,7 @@ using NosCore.Networking.SessionRef;
 using NosCore.PacketHandlers.CharacterScreen;
 using NosCore.Packets.ClientPackets.Infrastructure;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -27,7 +27,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
     [TestClass]
     public class DacPacketHandlerTests
     {
-        private static readonly Mock<ILogger> Logger = new();
+        private static readonly Mock<ILogger<DacPacketHandler>> Logger = new();
         private DacPacketHandler DacPacketHandler = null!;
         private ClientSession Session = null!;
         private Mock<IAuthHub> AuthHttpClient = null!;
@@ -141,17 +141,38 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
 
         private void AlreadyConnectedErrorShouldBeLogged()
         {
-            Logger.Verify(o => o.Error(It.Is<string>(s => s == TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.ALREADY_CONNECTED]), It.Is<It.IsAnyType>((v, t) => true)), Times.Once);
+            var expected = (string)TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.ALREADY_CONNECTED];
+            Logger.Verify(o => o.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v != null && v.ToString()!.Contains(expected)),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
 
         private void InvalidAccountErrorShouldBeLogged()
         {
-            Logger.Verify(o => o.Error(It.Is<string>(s => s == TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_ACCOUNT]), It.Is<It.IsAnyType>((v, t) => true)), Times.Once);
+            var expected = (string)TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_ACCOUNT];
+            Logger.Verify(o => o.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v != null && v.ToString()!.Contains(expected)),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
 
         private void InvalidPasswordErrorShouldBeLogged()
         {
-            Logger.Verify(o => o.Error(It.Is<string>(s => s == TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_PASSWORD]), It.Is<It.IsAnyType>((v, t) => true)), Times.Once);
+            var expected = (string)TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_PASSWORD];
+            Logger.Verify(o => o.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v != null && v.ToString()!.Contains(expected)),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
 
         private void AccountShouldBeNull()

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/EntryPointPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/EntryPointPacketHandlerTests.cs
@@ -15,7 +15,7 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.Networking.SessionRef;
 using NosCore.PacketHandlers.CharacterScreen;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
     [TestClass]
     public class EntryPointPacketHandlerTests
     {
-        private static readonly Mock<ILogger> Logger = new();
+        private static readonly Mock<ILogger<EntryPointPacketHandler>> Logger = new();
         private EntryPointPacketHandler EntryPointPacketHandler = null!;
         private ClientSession Session = null!;
         private Mock<IAuthHub> AuthHttpClient = null!;
@@ -208,23 +208,38 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
 
         private void AlreadyConnectedErrorShouldBeLogged()
         {
-            Logger.Verify(o => o.Error(
-                It.Is<string>(s => s == TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.ALREADY_CONNECTED]),
-                It.Is<It.IsAnyType>((v, t) => true)), Times.Once);
+            var expected = (string)TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.ALREADY_CONNECTED];
+            Logger.Verify(o => o.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v != null && v.ToString()!.Contains(expected)),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
 
         private void InvalidAccountErrorShouldBeLogged()
         {
-            Logger.Verify(o => o.Error(
-                It.Is<string>(s => s == TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_ACCOUNT]),
-                It.Is<It.IsAnyType>((v, t) => true)), Times.Once);
+            var expected = (string)TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_ACCOUNT];
+            Logger.Verify(o => o.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v != null && v.ToString()!.Contains(expected)),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
 
         private void InvalidPasswordErrorShouldBeLogged()
         {
-            Logger.Verify(o => o.Error(
-                It.Is<string>(s => s == TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_PASSWORD]),
-                It.Is<It.IsAnyType>((v, t) => true)), Times.Once);
+            var expected = (string)TestHelpers.Instance.LogLanguageLocalizer[LogLanguageKey.INVALID_PASSWORD];
+            Logger.Verify(o => o.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v != null && v.ToString()!.Contains(expected)),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.Once);
         }
 
         private void AccountShouldBeNull()

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
@@ -20,7 +20,8 @@ using NosCore.PacketHandlers.CharacterScreen;
 using NosCore.Packets.ClientPackets.CharacterSelectionScreen;
 using NosCore.Networking.SessionGroup;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
     [TestClass]
     public class SelectPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<SelectPacketHandler> Logger = new Mock<ILogger<SelectPacketHandler>>().Object;
         private SelectPacketHandler SelectPacketHandler = null!;
         private ClientSession Session = null!;
 
@@ -44,6 +45,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
             SelectPacketHandler = new SelectPacketHandler(
                 TestHelpers.Instance.CharacterDao,
                 Logger,
+                NullLoggerFactory.Instance,
                 new Mock<IItemGenerationService>().Object,
                 TestHelpers.Instance.MapInstanceAccessorService,
                 new Mock<IDao<IItemInstanceDto?, Guid>>().Object,

--- a/test/NosCore.PacketHandlers.Tests/Chat/BtkPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Chat/BtkPacketHandlerTests.cs
@@ -20,7 +20,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,7 +38,7 @@ namespace NosCore.PacketHandlers.Tests.Chat
         private Mock<IPubSubHub> PubSubHub = null!;
         private Mock<ISerializer> Serializer = null!;
         private Mock<ISessionRegistry> SessionRegistry = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<BtkPacketHandler> Logger = new Mock<ILogger<BtkPacketHandler>>().Object;
         private const long OfflineFriendId = 99998;
         private const long DifferentChannelFriendId = 99997;
 

--- a/test/NosCore.PacketHandlers.Tests/Chat/WhisperPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Chat/WhisperPacketHandlerTests.cs
@@ -18,7 +18,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +35,7 @@ namespace NosCore.PacketHandlers.Tests.Chat
         private Mock<IBlacklistHub> BlacklistHub = null!;
         private Mock<IPubSubHub> PubSubHub = null!;
         private Mock<ISerializer> Serializer = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<WhisperPacketHandler> Logger = new Mock<ILogger<WhisperPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Command/CreateItemPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Command/CreateItemPacketHandlerTests.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,7 +34,7 @@ namespace NosCore.PacketHandlers.Tests.Command
         private ClientSession Session = null!;
         private List<ItemDto> Items = null!;
         private Mock<IItemGenerationService> ItemProvider = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<CreateItemPackettHandler> Logger = new Mock<ILogger<CreateItemPackettHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Command/SizePacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Command/SizePacketHandlerTests.cs
@@ -14,7 +14,7 @@ using NosCore.PacketHandlers.Command;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -25,7 +25,7 @@ namespace NosCore.PacketHandlers.Tests.Command
     {
         private SizePacketHandler Handler = null!;
         private ClientSession Session = null!;
-        private Mock<ILogger> Logger = null!;
+        private Mock<ILogger<SizePacketHandler>> Logger = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> LogLanguage = null!;
 
         [TestInitialize]
@@ -34,7 +34,7 @@ namespace NosCore.PacketHandlers.Tests.Command
             await TestHelpers.ResetAsync();
             Broadcaster.Reset();
             Session = await TestHelpers.Instance.GenerateSessionAsync();
-            Logger = new Mock<ILogger>();
+            Logger = new Mock<ILogger<SizePacketHandler>>();
             LogLanguage = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             Handler = new SizePacketHandler(Logger.Object, LogLanguage.Object);
         }
@@ -112,7 +112,13 @@ namespace NosCore.PacketHandlers.Tests.Command
 
         private void ShouldLogError()
         {
-            Logger.Verify(x => x.Error(It.IsAny<string>(), It.IsAny<VisualType>()), Times.AtLeastOnce);
+            Logger.Verify(x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => true),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.AtLeastOnce);
         }
     }
 }

--- a/test/NosCore.PacketHandlers.Tests/Command/TeleportPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Command/TeleportPacketHandlerTests.cs
@@ -12,7 +12,7 @@ using NosCore.GameObject.Networking.ClientSession;
 using NosCore.GameObject.Services.MapChangeService;
 using NosCore.PacketHandlers.Command;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -25,7 +25,7 @@ namespace NosCore.PacketHandlers.Tests.Command
         private ClientSession Session = null!;
         private ClientSession TargetSession = null!;
         private Mock<IMapChangeService> MapChangeService = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<TeleportPacketHandler> Logger = new Mock<ILogger<TeleportPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Exchange/ExcListPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Exchange/ExcListPacketHandlerTests.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.ClientPackets.Inventory;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Exchanges;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -37,7 +37,6 @@ namespace NosCore.PacketHandlers.Tests.Exchange
         private ClientSession TargetSession = null!;
         private Mock<IExchangeService> ExchangeService = null!;
         private ItemGenerationService ItemProvider = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()
@@ -54,11 +53,11 @@ namespace NosCore.PacketHandlers.Tests.Exchange
                 new Item { Type = NoscorePocketType.Main, VNum = 1013, IsTradable = false }
             };
             ItemProvider = new ItemGenerationService(items,
-                Logger, TestHelpers.Instance.LogLanguageLocalizer);
+                NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Handler = new ExcListPacketHandler(
                 ExchangeService.Object,
-                Logger,
+                NullLogger<ExcListPacketHandler>.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.SessionRegistry);
         }

--- a/test/NosCore.PacketHandlers.Tests/Exchange/ExchangeRequestPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Exchange/ExchangeRequestPacketHandlerTests.cs
@@ -18,7 +18,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.Exchanges;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,7 +34,7 @@ namespace NosCore.PacketHandlers.Tests.Exchange
         private ClientSession TargetSession = null!;
         private Mock<IExchangeService> ExchangeService = null!;
         private Mock<IBlacklistHub> BlacklistHub = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<ExchangeRequestPackettHandler> Logger = new Mock<ILogger<ExchangeRequestPackettHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Friend/BlDelPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Friend/BlDelPacketHandlerTests.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.ClientPackets.Relations;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -34,7 +34,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
     [TestClass]
     public class BlDelPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<BlDelPacketHandlerTests> Logger = new Mock<ILogger<BlDelPacketHandlerTests>>().Object;
         private BlacklistService BlackListController = null!;
         private Mock<IBlacklistHub> BlackListHttpClient = null!;
         private BlDelPacketHandler BlDelPacketHandler = null!;

--- a/test/NosCore.PacketHandlers.Tests/Friend/BlInsPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Friend/BlInsPacketHandlerTests.cs
@@ -16,7 +16,7 @@ using NosCore.Packets.ClientPackets.Relations;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -27,7 +27,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
     [TestClass]
     public class BlInsPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<BlInsPackettHandler> Logger = new Mock<ILogger<BlInsPackettHandler>>().Object;
         private BlInsPackettHandler BlInsPacketHandler = null!;
         private ClientSession Session = null!;
 

--- a/test/NosCore.PacketHandlers.Tests/Friend/BlPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Friend/BlPacketHandlerTests.cs
@@ -18,7 +18,7 @@ using NosCore.Packets.ClientPackets.Relations;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -30,7 +30,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
     [TestClass]
     public class BlPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry> Logger = new Mock<ILogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry>>().Object;
         private BlPacketHandler BlPacketHandler = null!;
         private IDao<CharacterRelationDto, Guid> CharacterRelationDao = null!;
         private ClientSession Session = null!;

--- a/test/NosCore.PacketHandlers.Tests/Friend/FinsPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Friend/FinsPacketHandlerTests.cs
@@ -24,7 +24,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
 using NosCore.Tests.Shared.AutoFixture;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -37,7 +37,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
     [TestClass]
     public class FinsPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry> Logger = new Mock<ILogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry>>().Object;
         private NosCoreFixture Fixture = null!;
         private readonly Mock<IChannelHub> ChannelHttpClient = TestHelpers.Instance.ChannelHttpClient;
         private IDao<CharacterRelationDto, Guid> CharacterRelationDao = null!;
@@ -89,7 +89,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
         private FriendService CreateFriendService()
         {
             return new FriendService(
-                new Mock<ILogger>().Object,
+                new Mock<ILogger<FriendService>>().Object,
                 CharacterRelationDao,
                 TestHelpers.Instance.CharacterDao,
                 FriendRequestHolder,

--- a/test/NosCore.PacketHandlers.Tests/Friend/FlPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Friend/FlPacketHandlerTests.cs
@@ -18,7 +18,7 @@ using NosCore.PacketHandlers.Friend;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -30,7 +30,6 @@ namespace NosCore.PacketHandlers.Tests.Friend
     [TestClass]
     public class FlPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private IDao<CharacterRelationDto, Guid> CharacterRelationDao = null!;
         private FlCommandPacketHandler FlPacketHandler = null!;
         private ClientSession Session = null!;
@@ -50,7 +49,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
                     }
                 });
             Session = await TestHelpers.Instance.GenerateSessionAsync();
-            FlPacketHandler = new FlCommandPacketHandler(new NosCore.GameObject.Services.BroadcastService.SessionRegistry(Logger));
+            FlPacketHandler = new FlCommandPacketHandler(new NosCore.GameObject.Services.BroadcastService.SessionRegistry(NullLogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry>.Instance));
         }
 
         [TestMethod]
@@ -82,7 +81,7 @@ namespace NosCore.PacketHandlers.Tests.Friend
                         ChannelId = 1, ConnectedCharacter = new Character { Id = Session.Character.CharacterId }
                     }
                 });
-            var friend = new FriendService(Logger, CharacterRelationDao, TestHelpers.Instance.CharacterDao,
+            var friend = new FriendService(NullLogger<FriendService>.Instance, CharacterRelationDao, TestHelpers.Instance.CharacterDao,
                 friendRequestHolder, TestHelpers.Instance.PubSubHub.Object, TestHelpers.Instance.ChannelHub.Object, TestHelpers.Instance.LogLanguageLocalizer);
             TestHelpers.Instance.FriendHttpClient.Setup(s => s.AddFriendAsync(It.IsAny<FriendShipRequest>()))
                 .Returns(friend.AddFriendAsync(Session.Character.CharacterId,

--- a/test/NosCore.PacketHandlers.Tests/Friend/fDelPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Friend/fDelPacketHandlerTests.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.ClientPackets.Relations;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -35,7 +35,6 @@ namespace NosCore.PacketHandlers.Tests.Friend
     [TestClass]
     public class FDelPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private Mock<IChannelHub> ChannelHttpClient = null!;
         private Mock<IDao<CharacterDto, long>> CharacterDao = null!;
         private IDao<CharacterRelationDto, Guid> CharacterRelationDao = null!;
@@ -65,9 +64,9 @@ namespace NosCore.PacketHandlers.Tests.Friend
                 });
             FriendHttpClient = TestHelpers.Instance.FriendHttpClient;
             FDelPacketHandler = new FdelPacketHandler(FriendHttpClient.Object, ChannelHttpClient.Object,
-                TestHelpers.Instance.PubSubHub.Object, TestHelpers.Instance.GameLanguageLocalizer, new NosCore.GameObject.Services.BroadcastService.SessionRegistry(Logger));
+                TestHelpers.Instance.PubSubHub.Object, TestHelpers.Instance.GameLanguageLocalizer, new NosCore.GameObject.Services.BroadcastService.SessionRegistry(NullLogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry>.Instance));
             CharacterDao = new Mock<IDao<CharacterDto, long>>();
-            FriendController = new FriendService(Logger, CharacterRelationDao, CharacterDao.Object,
+            FriendController = new FriendService(NullLogger<FriendService>.Instance, CharacterRelationDao, CharacterDao.Object,
                 new FriendRequestRegistry(), ConnectedAccountHttpClient.Object, ChannelHub.Object, TestHelpers.Instance.LogLanguageLocalizer);
             FriendHttpClient.Setup(s => s.GetFriendsAsync(It.IsAny<long>()))
                 .Returns((long id) => FriendController.GetFriendsAsync(id));

--- a/test/NosCore.PacketHandlers.Tests/Game/NcifPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Game/NcifPacketHandlerTests.cs
@@ -16,7 +16,7 @@ using NosCore.Packets.ClientPackets.Battle;
 using NosCore.Packets.ServerPackets.Entities;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,7 +37,7 @@ namespace NosCore.PacketHandlers.Tests.Game
             Broadcaster.Reset();
             Session = await TestHelpers.Instance.GenerateSessionAsync();
 
-            var logger = new Mock<ILogger>().Object;
+            var logger = new Mock<ILogger<NcifPacketHandler>>().Object;
             Handler = new NcifPacketHandler(
                 logger,
                 TestHelpers.Instance.LogLanguageLocalizer,

--- a/test/NosCore.PacketHandlers.Tests/Game/ReqInfoPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Game/ReqInfoPacketHandlerTests.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.ServerPackets.Inventory;
 using NosCore.Packets.ServerPackets.Player;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 
 namespace NosCore.PacketHandlers.Tests.Game
@@ -63,7 +63,7 @@ namespace NosCore.PacketHandlers.Tests.Game
             };
 
             Handler = new ReqInfoPacketHandler(
-                new Mock<ILogger>().Object,
+                new Mock<ILogger<ReqInfoPacketHandler>>().Object,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.SessionRegistry,
                 NpcMonsters);

--- a/test/NosCore.PacketHandlers.Tests/Group/GroupTalkPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Group/GroupTalkPacketHandlerTests.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.Groups;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -31,7 +31,7 @@ namespace NosCore.PacketHandlers.Tests.Group
     [TestClass]
     public class GroupTalkPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<PjoinPacketHandler> Logger = new Mock<ILogger<PjoinPacketHandler>>().Object;
         private readonly Dictionary<int, ClientSession> _sessions = new();
         private GroupTalkPacketHandler _groupTalkPacketHandler = null!;
         private PjoinPacketHandler _pJoinPacketHandler = null!;

--- a/test/NosCore.PacketHandlers.Tests/Group/PJoinPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Group/PJoinPacketHandlerTests.cs
@@ -17,7 +17,7 @@ using NosCore.PacketHandlers.Group;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Groups;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -28,7 +28,7 @@ namespace NosCore.PacketHandlers.Tests.Group
     [TestClass]
     public class PJoinPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<PjoinPacketHandler> Logger = new Mock<ILogger<PjoinPacketHandler>>().Object;
         private readonly Dictionary<int, ClientSession> Sessions = new();
         private PjoinPacketHandler PJoinPacketHandler = null!;
 

--- a/test/NosCore.PacketHandlers.Tests/Group/PleavePacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Group/PleavePacketHandlerTests.cs
@@ -18,7 +18,7 @@ using NosCore.Packets.ClientPackets.Groups;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Groups;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -29,7 +29,7 @@ namespace NosCore.PacketHandlers.Tests.Group
     [TestClass]
     public class PleavePacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<PjoinPacketHandler> Logger = new Mock<ILogger<PjoinPacketHandler>>().Object;
         private readonly Dictionary<int, ClientSession> Sessions = new();
         private PjoinPacketHandler PJoinPacketHandler = null!;
         private PleavePacketHandler PLeavePacketHandler = null!;

--- a/test/NosCore.PacketHandlers.Tests/Inventory/BiPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Inventory/BiPacketHandlerTests.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NosCore.PacketHandlers.Inventory;
 using NosCore.Packets.ClientPackets.Inventory;
@@ -26,7 +27,7 @@ namespace NosCore.PacketHandlers.Tests.Inventory
         public override async Task SetupAsync()
         {
             await base.SetupAsync();
-            BiPacketHandler = new BiPacketHandler(Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            BiPacketHandler = new BiPacketHandler(NullLogger<BiPacketHandler>.Instance, TestHelpers.Instance.LogLanguageLocalizer);
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Inventory/SpTransformPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Inventory/SpTransformPacketHandlerTests.cs
@@ -22,7 +22,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Linq;
 using System.Threading.Tasks;
@@ -47,7 +47,7 @@ namespace NosCore.PacketHandlers.Tests.Inventory
             SpTransformPacketHandler = new SpTransformPacketHandler(TestHelpers.Instance.Clock,
                 new TransformationService(TestHelpers.Instance.Clock, new Mock<IExperienceService>().Object,
                     new Mock<IJobExperienceService>().Object, new Mock<IHeroExperienceService>().Object,
-                    new Mock<ILogger>().Object, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration),
+                    new Mock<ILogger<TransformationService>>().Object, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration),
                 TestHelpers.Instance.GameLanguageLocalizer);
         }
 

--- a/test/NosCore.PacketHandlers.Tests/Login/NoS0575PacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Login/NoS0575PacketHandlerTests.cs
@@ -24,7 +24,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Login;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +35,7 @@ namespace NosCore.PacketHandlers.Tests.Login
     [TestClass]
     public class NoS0575PacketHandlerSpecs
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NoS0575PacketHandler> Logger = new Mock<ILogger<NoS0575PacketHandler>>().Object;
         private string Password = null!;
         private Mock<IAuthHub> AuthHttpClient = null!;
         private Mock<IPubSubHub> PubSubHub = null!;

--- a/test/NosCore.PacketHandlers.Tests/Miniland/AddobjPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/AddobjPacketHandlerTests.cs
@@ -6,7 +6,6 @@
 
 using Mapster;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Data.Dto;
 using NosCore.Data.Enumerations;
 using NosCore.Data.Enumerations.Items;
@@ -24,7 +23,7 @@ using NosCore.Packets.ClientPackets.Miniland;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -36,7 +35,6 @@ namespace NosCore.PacketHandlers.Tests.Miniland
     [TestClass]
     public class AddobjPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private AddobjPacketHandler _addobjPacketHandler = null!;
         private ClientSession _session = null!;
         private IMinilandService _minilandProvider = null!;
@@ -74,7 +72,7 @@ namespace NosCore.PacketHandlers.Tests.Miniland
             _addobjPacketHandler = new AddobjPacketHandler(_minilandProvider);
             _itemProvider = new ItemGenerationService(
                 MinilandItems,
-                Logger,
+                NullLoggerFactory.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
         }
 

--- a/test/NosCore.PacketHandlers.Tests/Miniland/MJoinPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MJoinPacketHandlerTests.cs
@@ -21,7 +21,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,7 +33,7 @@ namespace NosCore.PacketHandlers.Tests.Miniland
     [TestClass]
     public class MJoinPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<MJoinPacketHandlerTests> Logger = new Mock<ILogger<MJoinPacketHandlerTests>>().Object;
         private readonly Mock<IPubSubHub> ConnectedAccountHttpClient = TestHelpers.Instance.PubSubHub;
         private readonly Mock<IFriendHub> FriendHttpClient = TestHelpers.Instance.FriendHttpClient;
         private Mock<IMinilandService> MinilandProvider = null!;

--- a/test/NosCore.PacketHandlers.Tests/Miniland/MinilandObjects/MgPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MinilandObjects/MgPacketHandlerTests.cs
@@ -6,7 +6,6 @@
 
 using Mapster;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Data.Dto;
 using NosCore.Data.Enumerations;
 using NosCore.Data.Enumerations.Items;
@@ -26,7 +25,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.Miniland;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -38,7 +37,6 @@ namespace NosCore.PacketHandlers.Tests.Miniland.MinilandObjects
     [TestClass]
     public class MgPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private MgPacketHandler _mgPacketHandler = null!;
         private ClientSession _session = null!;
         private IMinilandService _minilandProvider = null!;
@@ -76,7 +74,7 @@ namespace NosCore.PacketHandlers.Tests.Miniland.MinilandObjects
             _session.Character.MapInstance = mapInstance;
             _itemProvider = new ItemGenerationService(
                 MinilandItems,
-                Logger,
+                NullLoggerFactory.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
             _mgPacketHandler = new MgPacketHandler(_minilandProvider, _itemProvider);
         }

--- a/test/NosCore.PacketHandlers.Tests/Miniland/MinilandObjects/UseobjPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MinilandObjects/UseobjPacketHandlerTests.cs
@@ -28,7 +28,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Miniland;
 using NosCore.Packets.ServerPackets.Warehouse;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -41,7 +41,6 @@ namespace NosCore.PacketHandlers.Tests.Miniland.MinilandObjects
     [TestClass]
     public class UseobjPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private UseobjPacketHandler _useobjPacketHandler = null!;
         private ClientSession _session = null!;
         private IMinilandService _minilandProvider = null!;
@@ -83,7 +82,7 @@ namespace NosCore.PacketHandlers.Tests.Miniland.MinilandObjects
             _itemInstanceDaoMock = new Mock<IDao<IItemInstanceDto?, Guid>>();
             _itemProvider = new ItemGenerationService(
                 MinilandItems,
-                Logger,
+                NullLoggerFactory.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
             _useobjPacketHandler = new UseobjPacketHandler(_minilandProvider, _warehouseHubMock.Object, _itemInstanceDaoMock.Object, _itemProvider);
         }

--- a/test/NosCore.PacketHandlers.Tests/Miniland/MlEditPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MlEditPacketHandlerTests.cs
@@ -19,7 +19,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Miniland;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -31,7 +31,7 @@ namespace NosCore.PacketHandlers.Tests.Miniland
     [TestClass]
     public class MlEditPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<MlEditPacketHandlerTests> Logger = new Mock<ILogger<MlEditPacketHandlerTests>>().Object;
         private MlEditPacketHandler MlEditPacketHandler = null!;
         private ClientSession Session = null!;
         private IMinilandService MinilandProvider = null!;

--- a/test/NosCore.PacketHandlers.Tests/Miniland/RmvobjPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/RmvobjPacketHandlerTests.cs
@@ -6,7 +6,6 @@
 
 using Mapster;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Data.Dto;
 using NosCore.Data.Enumerations;
 using NosCore.Data.Enumerations.Items;
@@ -24,7 +23,7 @@ using NosCore.Packets.ClientPackets.Miniland;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -36,7 +35,6 @@ namespace NosCore.PacketHandlers.Tests.Miniland
     [TestClass]
     public class RmvobjPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private RmvobjPacketHandler _rmvobjPacketHandler = null!;
         private ClientSession _session = null!;
         private IMinilandService _minilandProvider = null!;
@@ -74,7 +72,7 @@ namespace NosCore.PacketHandlers.Tests.Miniland
             _rmvobjPacketHandler = new RmvobjPacketHandler(_minilandProvider);
             _itemProvider = new ItemGenerationService(
                 MinilandItems,
-                Logger,
+                NullLoggerFactory.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
         }
 

--- a/test/NosCore.PacketHandlers.Tests/Movement/ClientDirPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Movement/ClientDirPacketHandlerTests.cs
@@ -12,7 +12,7 @@ using NosCore.PacketHandlers.Movement;
 using NosCore.Packets.ClientPackets.Movement;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -23,7 +23,7 @@ namespace NosCore.PacketHandlers.Tests.Movement
     {
         private ClientDirPacketHandler Handler = null!;
         private ClientSession Session = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<ClientDirPacketHandler> Logger = new Mock<ILogger<ClientDirPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Movement/SitPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Movement/SitPacketHandlerTests.cs
@@ -12,7 +12,7 @@ using NosCore.PacketHandlers.Movement;
 using NosCore.Packets.ClientPackets.Movement;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace NosCore.PacketHandlers.Tests.Movement
         private SitPacketHandler Handler = null!;
         private ClientSession Session = null!;
         private ClientSession OtherSession = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<SitPacketHandler> Logger = new Mock<ILogger<SitPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Movement/WalkPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Movement/WalkPacketHandlerTests.cs
@@ -13,7 +13,7 @@ using NosCore.PacketHandlers.Movement;
 using NosCore.Packets.ClientPackets.Movement;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -25,7 +25,7 @@ namespace NosCore.PacketHandlers.Tests.Movement
         private WalkPacketHandler Handler = null!;
         private ClientSession Session = null!;
         private Mock<IHeuristic> DistanceCalculator = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<WalkPacketHandler> Logger = new Mock<ILogger<WalkPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Shops/BuyPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/BuyPacketHandlerTests.cs
@@ -12,7 +12,7 @@ using NosCore.PacketHandlers.Shops;
 using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -23,7 +23,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
     {
         private BuyPacketHandler Handler = null!;
         private ClientSession Session = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<BuyPacketHandler> Logger = new Mock<ILogger<BuyPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Shops/MShopPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/MShopPacketHandlerTests.cs
@@ -26,7 +26,7 @@ using NosCore.Packets.ServerPackets.Chats;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -40,7 +40,6 @@ namespace NosCore.PacketHandlers.Tests.Shops
     [TestClass]
     public class MShopPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private readonly MShopPacket ShopPacket = new()
         {
             Type = CreateShopPacketType.Open,
@@ -203,7 +202,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1 }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Session.Character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(itemBuilder.Create(1, 1), 0));
             Session.Character.MapInstance = TestHelpers.Instance.MapInstanceAccessorService.GetBaseMapById(1)!;
@@ -215,7 +214,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1 }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Session.Character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(itemBuilder.Create(1, (short)value), 0),
                 NoscorePocketType.Etc, 0);
@@ -233,7 +232,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1, IsTradable = true }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Session.Character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(itemBuilder.Create(1, 1), 0),
                 NoscorePocketType.Etc, 0);

--- a/test/NosCore.PacketHandlers.Tests/Shops/NrunPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/NrunPacketHandlerTests.cs
@@ -17,7 +17,7 @@ using NosCore.Packets.ClientPackets.Npcs;
 using NosCore.Packets.Enumerations;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -27,7 +27,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
     [TestClass]
     public class NrunPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
+        private static readonly ILogger<NrunPacketHandler> Logger = new Mock<ILogger<NrunPacketHandler>>().Object;
         private NrunPacketHandler _nrunPacketHandler = null!;
         private ClientSession _session = null!;
         private Mock<INrunEventHandler> _fakeHandlerMock = null!;

--- a/test/NosCore.PacketHandlers.Tests/Shops/RequestNpcPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/RequestNpcPacketHandlerTests.cs
@@ -24,7 +24,7 @@ using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.Shop;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 
 namespace NosCore.PacketHandlers.Tests.Shops
@@ -32,7 +32,6 @@ namespace NosCore.PacketHandlers.Tests.Shops
     [TestClass]
     public class RequestNpcPacketHandlerTests
     {
-        private static readonly ILogger Logger = new Mock<ILogger>().Object;
         private RequestNpcPacketHandler _requestNpcPacketHandler = null!;
         private ClientSession _session = null!;
 
@@ -44,13 +43,13 @@ namespace NosCore.PacketHandlers.Tests.Shops
             // Register ShoppingPacketHandler so the shop-no-dialog branch can dispatch
             // a ShoppingPacket through HandlePacketsAsync and we can observe the n_inv.
             var shoppingHandler = new ShoppingPacketHandler(
-                Logger,
+                NullLogger<ShoppingPacketHandler>.Instance,
                 new Mock<IDignityService>().Object,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.SessionRegistry);
             _session = await TestHelpers.Instance.GenerateSessionAsync(new List<IPacketHandler> { shoppingHandler });
             _requestNpcPacketHandler = new RequestNpcPacketHandler(
-                Logger,
+                NullLogger<RequestNpcPacketHandler>.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.SessionRegistry);
         }

--- a/test/NosCore.PacketHandlers.Tests/Shops/SellPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/SellPacketHandlerTests.cs
@@ -5,7 +5,6 @@
 //
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Data.Enumerations;
 using NosCore.Data.Enumerations.Items;
 using NosCore.Data.StaticEntities;
@@ -22,7 +21,7 @@ using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.ServerPackets.Shop;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using SpecLight;
 using System;
 using System.Collections.Generic;
@@ -37,7 +36,6 @@ namespace NosCore.PacketHandlers.Tests.Shops
         private MapInstanceAccessorService InstanceProvider = null!;
         private SellPacketHandler SellPacketHandler = null!;
         private ClientSession Session = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()
@@ -113,7 +111,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1, IsSoldable = true, ItemType = ItemType.Sell, Price = long.MaxValue }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
             Session.Character.InventoryService.AddItemToPocket(
                 InventoryItemInstance.Create(itemBuilder.Create(1, 5), 0),
                 NoscorePocketType.Etc, 0);
@@ -150,7 +148,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1, IsTradable = true }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Session.Character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(itemBuilder.Create(1, 1), 0),
                 NoscorePocketType.Etc, 0);
@@ -168,7 +166,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1, IsSoldable = false }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Session.Character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(itemBuilder.Create(1, 1), 0),
                 NoscorePocketType.Etc, 0);
@@ -186,7 +184,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
             {
                 new Item { Type = NoscorePocketType.Etc, VNum = 1, IsSoldable = true, Price = 500000 }
             };
-            var itemBuilder = new ItemGenerationService(items, Logger, TestHelpers.Instance.LogLanguageLocalizer);
+            var itemBuilder = new ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
 
             Session.Character.InventoryService.AddItemToPocket(InventoryItemInstance.Create(itemBuilder.Create(1, 1), 0),
                 NoscorePocketType.Etc, 0);

--- a/test/NosCore.PacketHandlers.Tests/Shops/ShoppingPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Shops/ShoppingPacketHandlerTests.cs
@@ -13,7 +13,7 @@ using NosCore.PacketHandlers.Shops;
 using NosCore.Packets.ClientPackets.Shops;
 using NosCore.Shared.Enumerations;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 using System.Threading.Tasks;
 
@@ -25,7 +25,7 @@ namespace NosCore.PacketHandlers.Tests.Shops
         private ShoppingPacketHandler Handler = null!;
         private ClientSession Session = null!;
         private Mock<IDignityService> DignityService = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
+        private readonly ILogger<ShoppingPacketHandler> Logger = new Mock<ILogger<ShoppingPacketHandler>>().Object;
 
         [TestInitialize]
         public async Task SetupAsync()

--- a/test/NosCore.PacketHandlers.Tests/Upgrades/UpgradePacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Upgrades/UpgradePacketHandlerTests.cs
@@ -16,7 +16,7 @@ using NosCore.Packets.ClientPackets.Player;
 using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Tests.Shared;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using SpecLight;
 
 namespace NosCore.PacketHandlers.Tests.Upgrades
@@ -27,7 +27,7 @@ namespace NosCore.PacketHandlers.Tests.Upgrades
         private ClientSession _session = null!;
         private Mock<IUpgradeOperation> _matchingOperation = null!;
         private Mock<IUpgradeOperation> _otherOperation = null!;
-        private Mock<ILogger> _logger = null!;
+        private Mock<ILogger<UpgradePacketHandler>> _logger = null!;
         private UpgradePacketHandler _handler = null!;
 
         [TestInitialize]
@@ -42,7 +42,7 @@ namespace NosCore.PacketHandlers.Tests.Upgrades
                 .ReturnsAsync((IReadOnlyList<IPacket>)new IPacket[0]);
             _otherOperation = new Mock<IUpgradeOperation>();
             _otherOperation.Setup(o => o.Kind).Returns(UpgradePacketType.RarifyItem);
-            _logger = new Mock<ILogger>();
+            _logger = new Mock<ILogger<UpgradePacketHandler>>();
             _handler = new UpgradePacketHandler(
                 new[] { _otherOperation.Object, _matchingOperation.Object },
                 _logger.Object,
@@ -102,6 +102,12 @@ namespace NosCore.PacketHandlers.Tests.Upgrades
         }
 
         private void WarningShouldHaveBeenLogged() =>
-            _logger.Verify(l => l.Warning(It.IsAny<string>(), It.IsAny<UpgradePacketType>()), Times.AtLeastOnce);
+            _logger.Verify(l => l.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => true),
+                    It.IsAny<System.Exception?>(),
+                    It.IsAny<System.Func<It.IsAnyType, System.Exception?, string>>()),
+                Times.AtLeastOnce);
     }
 }

--- a/test/NosCore.Parser.Tests/ActParserTests.cs
+++ b/test/NosCore.Parser.Tests/ActParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,7 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class ActParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
+        private Mock<ILogger<ActParser>> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<ActDto, byte>> _actDaoMock = null!;
         private Mock<IDao<ActPartDto, byte>> _actPartDaoMock = null!;
@@ -34,7 +34,7 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
+            _loggerMock = new Mock<ILogger<ActParser>>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _actDaoMock = new Mock<IDao<ActDto, byte>>();
             _actPartDaoMock = new Mock<IDao<ActPartDto, byte>>();

--- a/test/NosCore.Parser.Tests/CardParserTests.cs
+++ b/test/NosCore.Parser.Tests/CardParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,6 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class CardParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<CardDto, short>> _cardDaoMock = null!;
         private Mock<IDao<BCardDto, short>> _bCardDaoMock = null!;
@@ -34,7 +33,6 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _cardDaoMock = new Mock<IDao<CardDto, short>>();
             _bCardDaoMock = new Mock<IDao<BCardDto, short>>();
@@ -99,7 +97,7 @@ namespace NosCore.Parser.Tests
             var content = CreateCardData(cardId: 1, name: "Buff1", level: 5, duration: 100);
             CreateTestFile(content);
 
-            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertCardsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedCards.Count);
@@ -117,7 +115,7 @@ namespace NosCore.Parser.Tests
                           CreateCardData(cardId: 3, name: "Buff3");
             CreateTestFile(content);
 
-            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertCardsAsync(_tempFolder);
 
             Assert.AreEqual(3, _savedCards.Count);
@@ -130,7 +128,7 @@ namespace NosCore.Parser.Tests
                           CreateCardData(cardId: 1, name: "Buff1Duplicate");
             CreateTestFile(content);
 
-            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertCardsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedCards.Count);
@@ -142,7 +140,7 @@ namespace NosCore.Parser.Tests
             var content = CreateCardData(cardId: 1, delay: 500);
             CreateTestFile(content);
 
-            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertCardsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedCards.Count);
@@ -154,7 +152,7 @@ namespace NosCore.Parser.Tests
         {
             CreateTestFile("");
 
-            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new CardParser(_cardDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertCardsAsync(_tempFolder);
 
             Assert.AreEqual(0, _savedCards.Count);

--- a/test/NosCore.Parser.Tests/DatDocumentationSnapshotTests.cs
+++ b/test/NosCore.Parser.Tests/DatDocumentationSnapshotTests.cs
@@ -14,7 +14,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace NosCore.Parser.Tests
 {
@@ -25,22 +25,22 @@ namespace NosCore.Parser.Tests
     public class DatDocumentationSnapshotTests
     {
         [TestMethod] public void Item() => RegenerateFor(new ItemParser(
-            Mock<ItemDto, short>(), Mock<BCardDto, short>(), Logger(), LogLang()).BuildParser("."));
+            Mock<ItemDto, short>(), Mock<BCardDto, short>(), NullLoggerFactory.Instance, LogLang()).BuildParser("."));
 
         [TestMethod] public void Card() => RegenerateFor(new CardParser(
-            Mock<CardDto, short>(), Mock<BCardDto, short>(), Logger(), LogLang()).BuildParser("."));
+            Mock<CardDto, short>(), Mock<BCardDto, short>(), NullLoggerFactory.Instance, LogLang()).BuildParser("."));
 
         [TestMethod] public void Skill() => RegenerateFor(new SkillParser(
-            Mock<BCardDto, short>(), Mock<ComboDto, int>(), Mock<SkillDto, short>(), Logger(), LogLang()).BuildParser("."));
+            Mock<BCardDto, short>(), Mock<ComboDto, int>(), Mock<SkillDto, short>(), NullLoggerFactory.Instance, LogLang()).BuildParser("."));
 
         [TestMethod] public void NpcMonster() => RegenerateFor(new NpcMonsterParser(
             Mock<SkillDto, short>(), Mock<BCardDto, short>(), Mock<DropDto, short>(),
-            Mock<NpcMonsterSkillDto, long>(), Mock<NpcMonsterDto, short>(), Logger(), LogLang())
+            Mock<NpcMonsterSkillDto, long>(), Mock<NpcMonsterDto, short>(), NullLoggerFactory.Instance, LogLang())
             .BuildParser("."));
 
         [TestMethod] public void Quest() => RegenerateFor(new QuestParser(
             Mock<QuestDto, short>(), Mock<QuestObjectiveDto, Guid>(),
-            Mock<QuestRewardDto, short>(), Mock<QuestQuestRewardDto, Guid>(), Logger(), LogLang())
+            Mock<QuestRewardDto, short>(), Mock<QuestQuestRewardDto, Guid>(), NullLoggerFactory.Instance, LogLang())
             .BuildParser("."));
 
         private static void RegenerateFor<T>(FluentParserBuilder<T> builder) where T : new()
@@ -63,7 +63,6 @@ namespace NosCore.Parser.Tests
         private static string Normalize(string text) => text.Replace("\r\n", "\n");
 
         private static IDao<TDto, TKey> Mock<TDto, TKey>() where TDto : class => new Mock<IDao<TDto, TKey>>().Object;
-        private static ILogger Logger() => new Mock<ILogger>().Object;
         private static ILogLanguageLocalizer<LogLanguageKey> LogLang() => new Mock<ILogLanguageLocalizer<LogLanguageKey>>().Object;
     }
 

--- a/test/NosCore.Parser.Tests/FluentParserBuilderTests.cs
+++ b/test/NosCore.Parser.Tests/FluentParserBuilderTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,14 +20,12 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class FluentParserBuilderTests
     {
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private string _tempFolder = null!;
 
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(_tempFolder);
@@ -59,7 +57,7 @@ namespace NosCore.Parser.Tests
                 .Field(x => x.Id, chunk => Convert.ToInt32(chunk["VNUM"][0][1]))
                 .Field(x => x.Price, chunk => Convert.ToInt64(chunk["VNUM"][0][2]))
                 .Field(x => x.Name, chunk => chunk["NAME"][0][1])
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -78,7 +76,7 @@ namespace NosCore.Parser.Tests
             var parser = FluentParserBuilder<TestDto>.Create(filePath, "END", 0)
                 .Field(x => x.Id, "VNUM", 0, 1)
                 .Field(x => x.Price, "VNUM", 0, 2)
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -95,7 +93,7 @@ namespace NosCore.Parser.Tests
 
             var parser = FluentParserBuilder<TestDto>.Create(filePath, "END", 0)
                 .Field(x => x.Name, "DATA", 0, 1, s => s.Replace("_", " "))
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -113,7 +111,7 @@ namespace NosCore.Parser.Tests
                 .WithSplitter(" ")
                 .Field(x => x.Id, "VNUM", 0, 1)
                 .Field(x => x.Price, "VNUM", 0, 2)
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -130,7 +128,7 @@ namespace NosCore.Parser.Tests
 
             var parser = FluentParserBuilder<TestDtoWithBool>.Create(filePath, "END", 0)
                 .Field(x => x.IsActive, "DATA", 0, 1)
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -146,7 +144,7 @@ namespace NosCore.Parser.Tests
 
             var parser = FluentParserBuilder<TestDtoWithEnum>.Create(filePath, "END", 0)
                 .Field(x => x.Status, "DATA", 0, 1)
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -162,7 +160,7 @@ namespace NosCore.Parser.Tests
 
             var parser = FluentParserBuilder<TestDto>.Create(filePath, "END", 0)
                 .Field(x => x.Id, "VNUM", 0, 1)
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 
@@ -177,7 +175,7 @@ namespace NosCore.Parser.Tests
 
             var parser = FluentParserBuilder<TestDto>.Create(filePath, "END", 0)
                 .Field(x => x.Id, CalculateSum)
-                .Build(_loggerMock.Object, _logLanguageMock.Object);
+                .Build(NullLoggerFactory.Instance, _logLanguageMock.Object);
 
             var results = await parser.GetDtosAsync();
 

--- a/test/NosCore.Parser.Tests/GenericParserTests.cs
+++ b/test/NosCore.Parser.Tests/GenericParserTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Parser.Parsers.Generic;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,14 +20,14 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class GenericParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
+        private Mock<ILogger<GenericParser<TestDto>>> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private string _tempFolder = null!;
 
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
+            _loggerMock = new Mock<ILogger<GenericParser<TestDto>>>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(_tempFolder);

--- a/test/NosCore.Parser.Tests/ItemParserTests.cs
+++ b/test/NosCore.Parser.Tests/ItemParserTests.cs
@@ -14,7 +14,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.Packets.Enumerations;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -26,7 +26,6 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class ItemParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<ItemDto, short>> _itemDaoMock = null!;
         private Mock<IDao<BCardDto, short>> _bCardDaoMock = null!;
@@ -37,7 +36,6 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _itemDaoMock = new Mock<IDao<ItemDto, short>>();
             _bCardDaoMock = new Mock<IDao<BCardDto, short>>();
@@ -106,7 +104,7 @@ namespace NosCore.Parser.Tests
             var content = CreateItemData(vnum: 1, price: 500, name: "Sword");
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -123,7 +121,7 @@ namespace NosCore.Parser.Tests
                           CreateItemData(vnum: 3, name: "Item3");
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(3, _savedItems.Count);
@@ -136,7 +134,7 @@ namespace NosCore.Parser.Tests
                           CreateItemData(vnum: 1, name: "Item1Duplicate");
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -157,7 +155,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -180,7 +178,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -199,7 +197,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -215,7 +213,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -233,7 +231,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -245,7 +243,7 @@ namespace NosCore.Parser.Tests
         {
             CreateTestFile("");
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(0, _savedItems.Count);
@@ -261,7 +259,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -281,7 +279,7 @@ namespace NosCore.Parser.Tests
             );
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -301,7 +299,7 @@ namespace NosCore.Parser.Tests
                 data: "15\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0");
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -322,7 +320,7 @@ namespace NosCore.Parser.Tests
                 data: "42\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0");
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -336,7 +334,7 @@ namespace NosCore.Parser.Tests
             var content = CreateItemData(vnum: 5119);
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);
@@ -351,7 +349,7 @@ namespace NosCore.Parser.Tests
                           CreateItemData(vnum: 181);
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(3, _savedItems.Count);
@@ -371,7 +369,7 @@ namespace NosCore.Parser.Tests
                           CreateItemData(vnum: 4105, indexType: 4, equipmentSlot: 11);
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(2, _savedItems.Count);
@@ -393,7 +391,7 @@ namespace NosCore.Parser.Tests
                 data: "0\t0\t99\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0");
             CreateTestFile(content);
 
-            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedItems.Count);

--- a/test/NosCore.Parser.Tests/MapMonsterParserTests.cs
+++ b/test/NosCore.Parser.Tests/MapMonsterParserTests.cs
@@ -12,7 +12,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,7 +22,7 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class MapMonsterParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
+        private Mock<ILogger<MapMonsterParser>> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<MapMonsterDto, int>> _mapMonsterDaoMock = null!;
         private Mock<IDao<NpcMonsterDto, short>> _npcMonsterDaoMock = null!;
@@ -31,7 +31,7 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
+            _loggerMock = new Mock<ILogger<MapMonsterParser>>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _mapMonsterDaoMock = new Mock<IDao<MapMonsterDto, int>>();
             _npcMonsterDaoMock = new Mock<IDao<NpcMonsterDto, short>>();

--- a/test/NosCore.Parser.Tests/MapNpcParserTests.cs
+++ b/test/NosCore.Parser.Tests/MapNpcParserTests.cs
@@ -12,7 +12,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,7 +22,7 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class MapNpcParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
+        private Mock<ILogger<MapNpcParser>> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<MapNpcDto, int>> _mapNpcDaoMock = null!;
         private Mock<IDao<NpcMonsterDto, short>> _npcMonsterDaoMock = null!;
@@ -32,7 +32,7 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
+            _loggerMock = new Mock<ILogger<MapNpcParser>>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _mapNpcDaoMock = new Mock<IDao<MapNpcDto, int>>();
             _npcMonsterDaoMock = new Mock<IDao<NpcMonsterDto, short>>();

--- a/test/NosCore.Parser.Tests/MapParserTests.cs
+++ b/test/NosCore.Parser.Tests/MapParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
 using System.Linq;
@@ -23,14 +23,12 @@ namespace NosCore.Parser.Tests
     public class MapParserTests
     {
         private Mock<IDao<MapDto, short>> _daoMock = null!;
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private string _tempFolder = null!;
 
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _daoMock = new Mock<IDao<MapDto, short>>();
             _tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -53,7 +51,7 @@ namespace NosCore.Parser.Tests
         public async Task MapParser_ParsesSingleEntry()
         {
             WriteMapIdDat("1 1 0 0 nosvillage\r\nDATA 0\r\n");
-            var parser = new MapParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new MapParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             var result = await parser.ParseDatAsync(_tempFolder);
 
             Assert.AreEqual(1, result.Count);
@@ -68,7 +66,7 @@ namespace NosCore.Parser.Tests
                 "1 1 0 0 nosvillage\r\nDATA 0\r\n" +
                 "2 1 0 0 alveus\r\nDATA 0\r\n" +
                 "145 1 0 0 oldnosville\r\nDATA 0\r\n");
-            var parser = new MapParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new MapParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             var result = await parser.ParseDatAsync(_tempFolder);
 
             Assert.AreEqual(3, result.Count);
@@ -81,7 +79,7 @@ namespace NosCore.Parser.Tests
         public async Task MapParser_EmptyFileReturnsEmptyList()
         {
             WriteMapIdDat("");
-            var parser = new MapParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new MapParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             var result = await parser.ParseDatAsync(_tempFolder);
 
             Assert.AreEqual(0, result.Count);

--- a/test/NosCore.Parser.Tests/NpcMonsterParserTests.cs
+++ b/test/NosCore.Parser.Tests/NpcMonsterParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,6 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class NpcMonsterParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<SkillDto, short>> _skillDaoMock = null!;
         private Mock<IDao<BCardDto, short>> _bCardDaoMock = null!;
@@ -36,7 +35,6 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _skillDaoMock = new Mock<IDao<SkillDto, short>>();
             _bCardDaoMock = new Mock<IDao<BCardDto, short>>();
@@ -109,7 +107,7 @@ namespace NosCore.Parser.Tests
         {
             File.WriteAllText(Path.Combine(_tempFolder, "monster.dat"), BuildMonster(1, "testmob", 1));
             var parser = new NpcMonsterParser(_skillDaoMock.Object, _bCardDaoMock.Object, _dropDaoMock.Object,
-                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertNpcMonstersAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedMonsters.Count);
@@ -123,7 +121,7 @@ namespace NosCore.Parser.Tests
             File.WriteAllText(Path.Combine(_tempFolder, "monster.dat"),
                 BuildMonster(5, "first", 1) + BuildMonster(5, "duplicate", 1));
             var parser = new NpcMonsterParser(_skillDaoMock.Object, _bCardDaoMock.Object, _dropDaoMock.Object,
-                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertNpcMonstersAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedMonsters.Count);
@@ -134,7 +132,7 @@ namespace NosCore.Parser.Tests
         {
             File.WriteAllText(Path.Combine(_tempFolder, "monster.dat"), BuildMonster(10, "leveltest", 42));
             var parser = new NpcMonsterParser(_skillDaoMock.Object, _bCardDaoMock.Object, _dropDaoMock.Object,
-                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertNpcMonstersAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedMonsters.Count);
@@ -146,7 +144,7 @@ namespace NosCore.Parser.Tests
         {
             File.WriteAllText(Path.Combine(_tempFolder, "monster.dat"), BuildMonster(20, "armortest", 1, armorLvl: 5));
             var parser = new NpcMonsterParser(_skillDaoMock.Object, _bCardDaoMock.Object, _dropDaoMock.Object,
-                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+                _npcMonsterSkillDaoMock.Object, _npcMonsterDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertNpcMonstersAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedMonsters.Count);

--- a/test/NosCore.Parser.Tests/PortalParserTests.cs
+++ b/test/NosCore.Parser.Tests/PortalParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,7 +21,7 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class PortalParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
+        private Mock<ILogger<PortalParser>> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<PortalDto, int>> _portalDaoMock = null!;
         private Mock<IDao<MapDto, short>> _mapDaoMock = null!;
@@ -30,7 +30,7 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
+            _loggerMock = new Mock<ILogger<PortalParser>>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _portalDaoMock = new Mock<IDao<PortalDto, int>>();
             _mapDaoMock = new Mock<IDao<MapDto, short>>();

--- a/test/NosCore.Parser.Tests/QuestParserTests.cs
+++ b/test/NosCore.Parser.Tests/QuestParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,6 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class QuestParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<QuestDto, short>> _questDaoMock = null!;
         private Mock<IDao<QuestObjectiveDto, Guid>> _questObjectiveDaoMock = null!;
@@ -37,7 +36,6 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _questDaoMock = new Mock<IDao<QuestDto, short>>();
             _questObjectiveDaoMock = new Mock<IDao<QuestObjectiveDto, Guid>>();
@@ -121,7 +119,7 @@ namespace NosCore.Parser.Tests
             var content = CreateQuestData(questId: 1, title: "FirstQuest", levelMin: 10, levelMax: 50);
             CreateTestFile(content);
 
-            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedQuests.Count);
@@ -139,7 +137,7 @@ namespace NosCore.Parser.Tests
                           CreateQuestData(questId: 3, title: "Quest3");
             CreateTestFile(content);
 
-            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestsAsync(_tempFolder);
 
             Assert.AreEqual(3, _savedQuests.Count);
@@ -151,7 +149,7 @@ namespace NosCore.Parser.Tests
             var content = CreateQuestData(questId: 1, autoFinish: true);
             CreateTestFile(content);
 
-            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedQuests.Count);
@@ -164,7 +162,7 @@ namespace NosCore.Parser.Tests
             var content = CreateQuestData(questId: 1, isDaily: true);
             CreateTestFile(content);
 
-            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedQuests.Count);
@@ -177,7 +175,7 @@ namespace NosCore.Parser.Tests
             var content = CreateQuestData(questId: 1, nextQuestId: 2);
             CreateTestFile(content);
 
-            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedQuests.Count);
@@ -189,7 +187,7 @@ namespace NosCore.Parser.Tests
         {
             CreateTestFile("");
 
-            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestParser(_questDaoMock.Object, _questObjectiveDaoMock.Object, _questRewardDaoMock.Object, _questQuestRewardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestsAsync(_tempFolder);
 
             Assert.AreEqual(0, _savedQuests.Count);

--- a/test/NosCore.Parser.Tests/QuestPrizeParserTests.cs
+++ b/test/NosCore.Parser.Tests/QuestPrizeParserTests.cs
@@ -12,7 +12,7 @@ using NosCore.Data.Enumerations.Quest;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +25,6 @@ namespace NosCore.Parser.Tests
     public class QuestPrizeParserTests
     {
         private Mock<IDao<QuestRewardDto, short>> _daoMock = null!;
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private List<QuestRewardDto> _saved = null!;
         private string _tempFolder = null!;
@@ -33,7 +32,6 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _daoMock = new Mock<IDao<QuestRewardDto, short>>();
             _saved = [];
@@ -65,7 +63,7 @@ namespace NosCore.Parser.Tests
         public async Task QuestPrizeParser_GoldRewardParsesAmountFromFirstDataField()
         {
             WriteFile(Entry(100, (byte)QuestRewardType.Gold, "500\t-1\t-1\t-1\t-1"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(1, _saved.Count);
@@ -79,7 +77,7 @@ namespace NosCore.Parser.Tests
         public async Task QuestPrizeParser_ExpRewardParsesAmountAndData()
         {
             WriteFile(Entry(200, (byte)QuestRewardType.Exp, "1000\t5000\t-1\t-1\t-1"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(1, _saved.Count);
@@ -92,7 +90,7 @@ namespace NosCore.Parser.Tests
         public async Task QuestPrizeParser_ExpRewardWithMinusOneDataYieldsZero()
         {
             WriteFile(Entry(201, (byte)QuestRewardType.Exp, "1000\t-1\t-1\t-1\t-1"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(1, _saved.Count);
@@ -104,7 +102,7 @@ namespace NosCore.Parser.Tests
         public async Task QuestPrizeParser_WearItemRewardStoresVnumAndAmountOne()
         {
             WriteFile(Entry(300, (byte)QuestRewardType.WearItem, "2000\t-1\t-1\t-1\t-1"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(1, _saved.Count);
@@ -116,7 +114,7 @@ namespace NosCore.Parser.Tests
         public async Task QuestPrizeParser_EtcMainItemUsesDataFieldFiveForAmount()
         {
             WriteFile(Entry(400, (byte)QuestRewardType.EtcMainItem, "1012\t-1\t-1\t-1\t10"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(1, _saved.Count);
@@ -128,7 +126,7 @@ namespace NosCore.Parser.Tests
         public async Task QuestPrizeParser_EtcMainItemMinusOneAmountFallsBackToOne()
         {
             WriteFile(Entry(401, (byte)QuestRewardType.EtcMainItem, "1013\t-1\t-1\t-1\t-1"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(1, _saved.Count);
@@ -143,7 +141,7 @@ namespace NosCore.Parser.Tests
                 Entry(1, (byte)QuestRewardType.Gold, "100\t-1\t-1\t-1\t-1") +
                 Entry(2, (byte)QuestRewardType.Exp, "500\t1000\t-1\t-1\t-1") +
                 Entry(3, (byte)QuestRewardType.WearItem, "2000\t-1\t-1\t-1\t-1"));
-            var parser = new QuestPrizeParser(_daoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new QuestPrizeParser(_daoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ImportQuestPrizesAsync(_tempFolder);
 
             Assert.AreEqual(3, _saved.Count);

--- a/test/NosCore.Parser.Tests/ShopParserTests.cs
+++ b/test/NosCore.Parser.Tests/ShopParserTests.cs
@@ -12,7 +12,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,7 +22,7 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class ShopParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
+        private Mock<ILogger<ShopParser>> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<ShopDto, int>> _shopDaoMock = null!;
         private Mock<IDao<MapNpcDto, int>> _mapNpcDaoMock = null!;
@@ -31,7 +31,7 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
+            _loggerMock = new Mock<ILogger<ShopParser>>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _shopDaoMock = new Mock<IDao<ShopDto, int>>();
             _mapNpcDaoMock = new Mock<IDao<MapNpcDto, int>>();

--- a/test/NosCore.Parser.Tests/SkillParserTests.cs
+++ b/test/NosCore.Parser.Tests/SkillParserTests.cs
@@ -11,7 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Data.StaticEntities;
 using NosCore.Parser.Parsers;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +23,6 @@ namespace NosCore.Parser.Tests
     [TestClass]
     public class SkillParserTests
     {
-        private Mock<ILogger> _loggerMock = null!;
         private Mock<ILogLanguageLocalizer<LogLanguageKey>> _logLanguageMock = null!;
         private Mock<IDao<SkillDto, short>> _skillDaoMock = null!;
         private Mock<IDao<BCardDto, short>> _bCardDaoMock = null!;
@@ -36,7 +35,6 @@ namespace NosCore.Parser.Tests
         [TestInitialize]
         public void Setup()
         {
-            _loggerMock = new Mock<ILogger>();
             _logLanguageMock = new Mock<ILogLanguageLocalizer<LogLanguageKey>>();
             _skillDaoMock = new Mock<IDao<SkillDto, short>>();
             _bCardDaoMock = new Mock<IDao<BCardDto, short>>();
@@ -129,7 +127,7 @@ namespace NosCore.Parser.Tests
             var content = CreateSkillData(skillVNum: 1, name: "Fireball", mpCost: 50, cooldown: 10);
             CreateTestFile(content);
 
-            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertSkillsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedSkills.Count);
@@ -147,7 +145,7 @@ namespace NosCore.Parser.Tests
                           CreateSkillData(skillVNum: 3, name: "Skill3");
             CreateTestFile(content);
 
-            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertSkillsAsync(_tempFolder);
 
             Assert.AreEqual(3, _savedSkills.Count);
@@ -159,7 +157,7 @@ namespace NosCore.Parser.Tests
             var content = CreateSkillData(skillVNum: 1, targetType: 1, hitType: 2, range: 5, targetRange: 3);
             CreateTestFile(content);
 
-            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertSkillsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedSkills.Count);
@@ -175,7 +173,7 @@ namespace NosCore.Parser.Tests
             var content = CreateSkillData(skillVNum: 1, element: 2);
             CreateTestFile(content);
 
-            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertSkillsAsync(_tempFolder);
 
             Assert.AreEqual(1, _savedSkills.Count);
@@ -187,7 +185,7 @@ namespace NosCore.Parser.Tests
         {
             CreateTestFile("");
 
-            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, _loggerMock.Object, _logLanguageMock.Object);
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object, _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.InsertSkillsAsync(_tempFolder);
 
             Assert.AreEqual(0, _savedSkills.Count);

--- a/test/NosCore.Tests.Shared/BDD/SpecBase.cs
+++ b/test/NosCore.Tests.Shared/BDD/SpecBase.cs
@@ -5,7 +5,6 @@
 //
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using NosCore.Data.Dto;
 using NosCore.Data.Enumerations;
 using NosCore.Data.Enumerations.Buff;
@@ -22,7 +21,7 @@ using NosCore.Packets.Enumerations;
 using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.UI;
 using NosCore.Tests.Shared.AutoFixture;
-using Serilog;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,7 +33,6 @@ namespace NosCore.Tests.Shared.BDD
         protected NosCoreFixture Fixture { get; private set; } = null!;
         protected ClientSession Session { get; set; } = null!;
         protected ItemGenerationService ItemProvider { get; set; } = null!;
-        protected ILogger Logger { get; } = new Mock<ILogger>().Object;
 
         protected List<ItemDto> DefaultItems { get; } = new()
         {
@@ -56,7 +54,7 @@ namespace NosCore.Tests.Shared.BDD
             Session.Character.StaticBonusList = new List<StaticBonusDto>();
             ItemProvider = new ItemGenerationService(
                 DefaultItems,
-                Logger,
+                NullLoggerFactory.Instance,
                 TestHelpers.Instance.LogLanguageLocalizer);
         }
 

--- a/test/NosCore.Tests.Shared/TestHelpers.cs
+++ b/test/NosCore.Tests.Shared/TestHelpers.cs
@@ -74,7 +74,8 @@ using NosCore.PathFinder.Heuristic;
 using NosCore.PathFinder.Interfaces;
 using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
-using Serilog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -99,7 +100,6 @@ namespace NosCore.Tests.Shared
 
         private IDao<InventoryItemInstanceDto, Guid> InventoryItemInstanceDao = null!;
         private IDao<IItemInstanceDto?, Guid> ItemInstanceDao = null!;
-        private readonly ILogger Logger = new Mock<ILogger>().Object;
         private IDao<MapMonsterDto, int> MapMonsterDao = null!;
         private IDao<MapNpcDto, int> MapNpcDao = null!;
         private IDao<PortalDto, int> PortalDao = null!;
@@ -110,7 +110,7 @@ namespace NosCore.Tests.Shared
         public Mock<IChannelHub> ChannelHttpClient = new();
         public Mock<IPubSubHub> PubSubHub = new();
         public Mock<IFriendHub> FriendHttpClient = new();
-        public NosCore.GameObject.Services.BroadcastService.SessionRegistry SessionRegistry = new(new Mock<ILogger>().Object);
+        public NosCore.GameObject.Services.BroadcastService.SessionRegistry SessionRegistry = new(NullLogger<NosCore.GameObject.Services.BroadcastService.SessionRegistry>.Instance);
         public FakeClock Clock = new(Instant.FromUtc(2021, 01, 01, 01, 01, 01));
         public ISessionGroupFactory SessionGroupFactory { get; private set; } = null!;
         private TestHelpers()
@@ -246,25 +246,25 @@ namespace NosCore.Tests.Shared
             var minilandServiceMock = new Mock<IMinilandService>();
             minilandServiceMock.Setup(s => s.GetMinilandPortals(It.IsAny<long>())).Returns(new List<GameObject.Map.Portal>());
             MapChangeService = new MapChangeService(new Mock<IExperienceService>().Object, new Mock<IJobExperienceService>().Object, new Mock<IHeroExperienceService>().Object,
-                MapInstanceAccessorService, Instance.Clock, Instance.LogLanguageLocalizer, minilandServiceMock.Object, Logger, Instance.LogLanguageLocalizer, Instance.GameLanguageLocalizer, SessionRegistry, new Mock<Wolverine.IMessageBus>().Object);
+                MapInstanceAccessorService, Instance.Clock, Instance.LogLanguageLocalizer, minilandServiceMock.Object, NullLogger<MapChangeService>.Instance, Instance.LogLanguageLocalizer, Instance.GameLanguageLocalizer, SessionRegistry, new Mock<Wolverine.IMessageBus>().Object);
             var mapChangeService = MapChangeService;
             var instanceGeneratorService = new MapInstanceGeneratorService(new List<MapDto> { map, mapShop, miniland }, new List<NpcMonsterDto>(), new List<NpcTalkDto>(), new List<ShopDto>(),
                 MapItemProvider,
                 MapNpcDao,
-                MapMonsterDao, PortalDao, ShopItemDao, Logger,
+                MapMonsterDao, PortalDao, ShopItemDao, NullLoggerFactory.Instance,
                 mapInstanceRegistry, MapInstanceAccessorService, Instance.Clock, Instance.LogLanguageLocalizer, mapChangeService, SessionGroupFactory, SessionRegistry, GenerateItemProvider(), Instance.DistanceCalculator,
                 new Mock<NosCore.GameObject.Services.BattleService.IMonsterAi>().Object,
                 new Mock<NosCore.GameObject.Services.BattleService.IBuffService>().Object,
                 new Mock<NosCore.GameObject.Services.BattleService.IRegenerationService>().Object);
             await instanceGeneratorService.InitializeAsync();
             await instanceGeneratorService.AddMapInstanceAsync(new MapInstance(miniland, MinilandId, false,
-                MapInstanceType.NormalInstance, MapItemProvider, Logger, Clock, mapChangeService, SessionGroupFactory, SessionRegistry, Instance.DistanceCalculator));
+                MapInstanceType.NormalInstance, MapItemProvider, NullLogger<MapInstance>.Instance, Clock, mapChangeService, SessionGroupFactory, SessionRegistry, Instance.DistanceCalculator));
             MapInstanceGeneratorService = instanceGeneratorService;
         }
 
         public IItemGenerationService GenerateItemProvider()
         {
-            return new ItemGenerationService(ItemList, Logger, Instance.LogLanguageLocalizer);
+            return new ItemGenerationService(ItemList, NullLoggerFactory.Instance, Instance.LogLanguageLocalizer);
         }
 
         public void InitDatabase()
@@ -272,19 +272,19 @@ namespace NosCore.Tests.Shared
             var optionsBuilder = new DbContextOptionsBuilder<NosCoreContext>().UseInMemoryDatabase(
                 Guid.NewGuid().ToString());
             DbContext ContextBuilder() => new NosCoreContext(optionsBuilder.Options);
-            CharacterRelationDao = new Dao<Database.Entities.CharacterRelation, CharacterRelationDto, Guid>(Logger, ContextBuilder);
-            AccountDao = new Dao<Account, AccountDto, long>(Logger, ContextBuilder);
-            MateDao = new Dao<Mate, MateDto, long>(Logger, ContextBuilder);
-            PortalDao = new Dao<Portal, PortalDto, int>(Logger, ContextBuilder);
-            MapMonsterDao = new Dao<MapMonster, MapMonsterDto, int>(Logger, ContextBuilder);
-            MapNpcDao = new Dao<MapNpc, MapNpcDto, int>(Logger, ContextBuilder);
-            MinilandDao = new Dao<Miniland, MinilandDto, Guid>(Logger, ContextBuilder);
-            MinilandObjectDao = new Dao<MinilandObject, MinilandObjectDto, Guid>(Logger, ContextBuilder);
-            ShopItemDao = new Dao<ShopItem, ShopItemDto, int>(Logger, ContextBuilder);
-            CharacterDao = new Dao<Character, CharacterDto, long>(Logger, ContextBuilder);
-            ItemInstanceDao = new Dao<ItemInstance, IItemInstanceDto?, Guid>(Logger, ContextBuilder);
-            InventoryItemInstanceDao = new Dao<InventoryItemInstance, InventoryItemInstanceDto, Guid>(Logger, ContextBuilder);
-            StaticBonusDao = new Dao<StaticBonus, StaticBonusDto, long>(Logger, ContextBuilder);
+            CharacterRelationDao = new Dao<Database.Entities.CharacterRelation, CharacterRelationDto, Guid>(NullLogger<Dao<Database.Entities.CharacterRelation, CharacterRelationDto, Guid>>.Instance, ContextBuilder);
+            AccountDao = new Dao<Account, AccountDto, long>(NullLogger<Dao<Account, AccountDto, long>>.Instance, ContextBuilder);
+            MateDao = new Dao<Mate, MateDto, long>(NullLogger<Dao<Mate, MateDto, long>>.Instance, ContextBuilder);
+            PortalDao = new Dao<Portal, PortalDto, int>(NullLogger<Dao<Portal, PortalDto, int>>.Instance, ContextBuilder);
+            MapMonsterDao = new Dao<MapMonster, MapMonsterDto, int>(NullLogger<Dao<MapMonster, MapMonsterDto, int>>.Instance, ContextBuilder);
+            MapNpcDao = new Dao<MapNpc, MapNpcDto, int>(NullLogger<Dao<MapNpc, MapNpcDto, int>>.Instance, ContextBuilder);
+            MinilandDao = new Dao<Miniland, MinilandDto, Guid>(NullLogger<Dao<Miniland, MinilandDto, Guid>>.Instance, ContextBuilder);
+            MinilandObjectDao = new Dao<MinilandObject, MinilandObjectDto, Guid>(NullLogger<Dao<MinilandObject, MinilandObjectDto, Guid>>.Instance, ContextBuilder);
+            ShopItemDao = new Dao<ShopItem, ShopItemDto, int>(NullLogger<Dao<ShopItem, ShopItemDto, int>>.Instance, ContextBuilder);
+            CharacterDao = new Dao<Character, CharacterDto, long>(NullLogger<Dao<Character, CharacterDto, long>>.Instance, ContextBuilder);
+            ItemInstanceDao = new Dao<ItemInstance, IItemInstanceDto?, Guid>(NullLogger<Dao<ItemInstance, IItemInstanceDto?, Guid>>.Instance, ContextBuilder);
+            InventoryItemInstanceDao = new Dao<InventoryItemInstance, InventoryItemInstanceDto, Guid>(NullLogger<Dao<InventoryItemInstance, InventoryItemInstanceDto, Guid>>.Instance, ContextBuilder);
+            StaticBonusDao = new Dao<StaticBonus, StaticBonusDto, long>(NullLogger<Dao<StaticBonus, StaticBonusDto, long>>.Instance, ContextBuilder);
             TypeAdapterConfig.GlobalSettings.AllowImplicitSourceInheritance = false;
             TypeAdapterConfig.GlobalSettings.ForDestinationType<IPacket>().Ignore(s => s.ValidationResult);
         }
@@ -299,28 +299,28 @@ namespace NosCore.Tests.Shared
             var handlers = packetHandlers ?? new List<IPacketHandler>
             {
                 new CharNewPacketHandler(CharacterDao, new Mock<IItemGenerationService>().Object, new Mock<IDao<QuicklistEntryDto, Guid>>().Object,
-                        new Mock<IDao<IItemInstanceDto?, Guid>>().Object, new Mock<IDao<InventoryItemInstanceDto, Guid>>().Object, new HpService(), new MpService(), WorldConfiguration, new Mock<IDao<CharacterSkillDto, Guid>>().Object, ItemList, Logger),
-                new BlInsPackettHandler(BlacklistHttpClient.Object, Logger, Instance.LogLanguageLocalizer),
+                        new Mock<IDao<IItemInstanceDto?, Guid>>().Object, new Mock<IDao<InventoryItemInstanceDto, Guid>>().Object, new HpService(), new MpService(), WorldConfiguration, new Mock<IDao<CharacterSkillDto, Guid>>().Object, ItemList, NullLoggerFactory.Instance),
+                new BlInsPackettHandler(BlacklistHttpClient.Object, NullLogger<BlInsPackettHandler>.Instance, Instance.LogLanguageLocalizer),
                 new UseItemPacketHandler(new Mock<Wolverine.IMessageBus>().Object),
                 new FinsPacketHandler(FriendHttpClient.Object, ChannelHttpClient.Object, TestHelpers.Instance.PubSubHub.Object, Instance.SessionRegistry),
-                new SelectPacketHandler(CharacterDao, Logger, new Mock<IItemGenerationService>().Object, MapInstanceAccessorService,
+                new SelectPacketHandler(CharacterDao, NullLogger<SelectPacketHandler>.Instance, NullLoggerFactory.Instance, new Mock<IItemGenerationService>().Object, MapInstanceAccessorService,
                     ItemInstanceDao, InventoryItemInstanceDao, StaticBonusDao, new Mock<IDao<QuicklistEntryDto, Guid>>().Object, new Mock<IDao<TitleDto, Guid>>().Object, new Mock<IDao<CharacterQuestDto, Guid>>().Object,
                     new Mock<IDao<CharacterQuestObjectiveDto, Guid>>().Object,
                     new Mock<IDao<RespawnDto, long>>().Object, new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, Instance.Clock, ItemList, new HpService(), new MpService(), SessionGroupFactory, new CharacterInitializationService(), new Mock<Wolverine.IMessageBus>().Object),
                 new CSkillPacketHandler(Instance.Clock),
-                new CBuyPacketHandler(new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, Logger, ItemInstanceDao, Instance.LogLanguageLocalizer),
+                new CBuyPacketHandler(new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, NullLogger<CBuyPacketHandler>.Instance, ItemInstanceDao, Instance.LogLanguageLocalizer),
                 new CRegPacketHandler(WorldConfiguration, new Mock<IBazaarHub>().Object, ItemInstanceDao, InventoryItemInstanceDao),
-                new CScalcPacketHandler(WorldConfiguration, new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, Logger, ItemInstanceDao, Instance.LogLanguageLocalizer)
+                new CScalcPacketHandler(WorldConfiguration, new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, NullLogger<CScalcPacketHandler>.Instance, ItemInstanceDao, Instance.LogLanguageLocalizer)
             };
             var packetHandlerRegistry = new NosCore.GameObject.Services.PacketHandlerService.PacketHandlerRegistry(handlers);
             var session = new ClientSession(
-                Logger,
+                NullLogger<ClientSession>.Instance,
                 packetHandlerRegistry,
                 new Mock<ILogLanguageLocalizer<NosCore.Networking.Resource.LogLanguageKey>>().Object,
                 Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.PubSubHub.Object,
                 new Mock<IEncoder>().Object,
-                new WorldPacketHandlingStrategy(Logger, Instance.LogLanguageLocalizer, sessionRefHolder),
+                new WorldPacketHandlingStrategy(NullLogger<WorldPacketHandlingStrategy>.Instance, Instance.LogLanguageLocalizer, sessionRefHolder),
                 new List<ISessionDisconnectHandler>(),
                 Instance.SessionRegistry,
                 Instance.GameLanguageLocalizer)
@@ -392,7 +392,7 @@ namespace NosCore.Tests.Shared
 
             var now = Instance.Clock.GetCurrentInstant();
             var group = new GameObject.Services.GroupService.Group(NosCore.Data.Enumerations.Group.GroupType.Group, SessionGroupFactory);
-            var inventoryService = new InventoryService(ItemList, WorldConfiguration, Logger);
+            var inventoryService = new InventoryService(ItemList, WorldConfiguration, NullLogger<InventoryService>.Instance);
             var playerStateComponent = new GameObject.Ecs.Components.PlayerStateComponent(
                 characterDto,
                 acc,


### PR DESCRIPTION
## Summary

Replaces non-generic `Serilog.ILogger` injection with `Microsoft.Extensions.Logging.ILogger<T>` across NosCore. Closes #1607.

## What changed

- **Type system**: `ILogger` → `ILogger<ContainingClass>` on fields, ctor params and primary-ctor params wherever a logger is owned by a specific type.
- **Method calls**: `.Information/.Warning/.Error/.Debug/.Verbose/.Fatal` → `.LogInformation/.LogWarning/.LogError/.LogDebug/.LogTrace/.LogCritical`.
- **Abstract bases** (`BaseHubClient`, `NetworkClient`) keep non-generic `ILogger` so derived classes pass their own `ILogger<Derived>` through inheritance (MEL `ILogger<T>` extends `ILogger`).
- **Classes that `new` inner classes requiring typed loggers** (`ItemGenerationService` → `WearableInstance`, `MapInstanceGeneratorService` → `MapInstance`, the parsers → `GenericParser<T>` / `FluentParser<T>` / `I18NParser<T,PK>`, `ImportFactory` → 10× `I18NParser<…>`) now inject `ILoggerFactory` and call `CreateLogger<Inner>()` at the construction site.
- **Autofac**: the four bootstraps dropped their `Register(_ => Log.Logger).As<Serilog.ILogger>().SingleInstance()` bindings. `ILogger<T>` auto-wires through Microsoft DI into Autofac via `AutofacServiceProviderFactory`. Serilog stays as the backend provider via `UseSerilog()` — no log output changes.
- **MasterServerBootstrap** and the Database `PersistenceModule` resolve a string-categorized logger via `ILoggerFactory.CreateLogger(nameof(…))` because `MasterServerBootstrap` is `static` and can't be a type arg.

## Dependencies (already published)

- `NosCore.Dao` **5.0.0** — breaking: `Dao<TEntity, TDto, TPk>` now takes `ILogger<Dao<TEntity, TDto, TPk>>`.
- `NosCore.Networking` **8.0.0** — breaking: `NetworkClient` now takes `Microsoft.Extensions.Logging.ILogger`.

`Directory.Packages.props` bumped to consume both.

## Testing

- `dotnet build` — green (0 errors, 0 warnings).
- `dotnet test` — **924/924 passing** across all suites (Core, Database, Parser, WebApi, GameObject, PacketHandlers).

Moq `.Verify` calls targeting extension methods (`LogError`, `LogWarning` etc.) were rewritten to verify the underlying `Log(LogLevel, EventId, TState, Exception?, Func<TState, Exception?, string>)` interface method, since extension methods can't be intercepted by Moq.

## Test plan

- [x] Build green.
- [x] Full test suite green.
- [ ] Smoke test server startup (runtime Autofac resolution for `ILogger<T>` via MEL→Serilog).

Generated with [Claude Code](https://claude.com/claude-code)