### PR TITLE
fix: bind useobj handler to client packet so minigames respond again

### DIFF
--- a/src/NosCore.PacketHandlers/Miniland/MinilandObjects/UseobjPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Miniland/MinilandObjects/UseobjPacketHandler.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using UseObjPacket = NosCore.Packets.ClientPackets.Miniland.UseObjPacket;
 
 namespace NosCore.PacketHandlers.Miniland.MinilandObjects
 {
@@ -33,7 +34,7 @@ namespace NosCore.PacketHandlers.Miniland.MinilandObjects
             var miniland = minilandProvider.GetMiniland(clientSession.Character.CharacterId);
             var minilandObject =
                 clientSession.Character.MapInstance.MapDesignObjects.Values.FirstOrDefault(s =>
-                    s.Slot == useobjPacket.ObjectId);
+                    s.Slot == useobjPacket.Slot);
             if (minilandObject == null)
             {
                 return;
@@ -50,7 +51,7 @@ namespace NosCore.PacketHandlers.Miniland.MinilandObjects
                 {
                     IsOwner = miniland.MapInstanceId == clientSession.Character.MapInstanceId,
                     ObjectVNum = minilandObject.InventoryItemInstance.ItemInstance.ItemVNum,
-                    Slot = (byte)useobjPacket.ObjectId,
+                    Slot = (byte)useobjPacket.Slot,
                     MinilandPoints = miniland.MinilandPoint,
                     LawDurability = minilandObject.DurabilityPoint < 1000,
                     IsFull = full,

--- a/test/NosCore.PacketHandlers.Tests/Miniland/MinilandObjects/UseobjPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MinilandObjects/UseobjPacketHandlerTests.cs
@@ -34,7 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using UseObjPacket = NosCore.Packets.ServerPackets.Miniland.UseObjPacket;
+using UseObjPacket = NosCore.Packets.ClientPackets.Miniland.UseObjPacket;
 
 namespace NosCore.PacketHandlers.Tests.Miniland.MinilandObjects
 {
@@ -163,27 +163,27 @@ namespace NosCore.PacketHandlers.Tests.Miniland.MinilandObjects
 
         private async Task UsingNonExistentObject()
         {
-            var useobjPacket = new UseObjPacket
+            var useobjPacket = new UseObjPacket(_session.Character.Name)
             {
-                ObjectId = 99
+                Slot = 99
             };
             await _useobjPacketHandler.ExecuteAsync(useobjPacket, _session);
         }
 
         private async Task UsingMinigameObject()
         {
-            var useobjPacket = new UseObjPacket
+            var useobjPacket = new UseObjPacket(_session.Character.Name)
             {
-                ObjectId = 0
+                Slot = 0
             };
             await _useobjPacketHandler.ExecuteAsync(useobjPacket, _session);
         }
 
         private async Task UsingWarehouseObject()
         {
-            var useobjPacket = new UseObjPacket
+            var useobjPacket = new UseObjPacket(_session.Character.Name)
             {
-                ObjectId = 0
+                Slot = 0
             };
             await _useobjPacketHandler.ExecuteAsync(useobjPacket, _session);
         }


### PR DESCRIPTION
## Summary
- The `useobj` header is owned by two packet classes (`ClientPackets.Miniland.UseObjPacket` for inbound, `ServerPackets.Miniland.UseObjPacket` for outbound). The deserializer prefers the client class on collisions, so inbound `useobj` materializes as `ClientPackets.UseObjPacket`.
- `UseobjPacketHandler` imported `NosCore.Packets.ServerPackets.Miniland`, making its `PacketHandler<UseObjPacket>` bind to the **server** class. The handler registry keys by `Type`, so the inbound client packet never found a handler — every minigame / warehouse object click logged `Could not found Handler implementation for Packet with Header useobj` and the UI silently stalled.
- Add a `using UseObjPacket = NosCore.Packets.ClientPackets.Miniland.UseObjPacket;` alias so the handler binds to the client class, and switch `ObjectId` → `Slot` to match the client packet's field name.
- Update the test alias / arrange blocks to construct the client class (it has a required `CharacterName` ctor parameter).

## Test plan
- [x] `dotnet test --filter UseobjPacketHandlerTests` (compiles clean, file-lock from running servers blocks DLL replacement locally)
- [ ] CI green
- [ ] Click a placed minigame in-game → `mlo_info` lands; warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved miniland object interaction handling to enhance reliability and accuracy when users interact with objects within their miniland environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->