### PR TITLE
ci: harden GitHub Actions against secret exfiltration

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,7 +34,11 @@ jobs:
         dotnet test test/NosCore.PacketHandlers.Tests/NosCore.PacketHandlers.Tests.csproj --no-build --filter TestCategory!=OPTIONAL-TEST /p:CollectCoverage=true /p:CoverletOutput="../TestResults/" /p:MergeWith="../TestResults/coverlet.json" /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute='GeneratedCodeAttribute' /p:ExcludeByAttribute='Obsolete' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:CoverletOutput='./tools/coverage.opencover.xml'
         dotnet test test/NosCore.Tests.Shared/NosCore.Tests.Shared.csproj --no-build --filter TestCategory!=OPTIONAL-TEST /p:CollectCoverage=true /p:CoverletOutput="../TestResults/" /p:MergeWith="../TestResults/coverlet.json" /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute='GeneratedCodeAttribute' /p:ExcludeByAttribute='Obsolete' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:CoverletOutput='./tools/coverage.opencover.xml'
         dotnet test test/NosCore.WebApi.Tests/NosCore.WebApi.Tests.csproj --no-build --filter TestCategory!=OPTIONAL-TEST /p:CollectCoverage=true /p:CoverletOutput="../TestResults/" /p:MergeWith="../TestResults/coverlet.json" /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute='GeneratedCodeAttribute' /p:ExcludeByAttribute='Obsolete' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:CoverletOutput='./tools/coverage.opencover.xml'
-        curl -s https://codecov.io/bash | bash -s -- -t $(CODECOV_TOKEN)
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Login to DockerHub
       if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Hardening pass on the CI workflow after reviewing the org for the fork-PR secret-exfiltration pattern (pwn request / `pull_request_target` abuse) seen in recent supply-chain attacks.

## Audit result
- No workflow in the org uses `pull_request_target`, `workflow_run`, or `issue_comment` triggers, so fork PRs already run without access to repo secrets and with a forced read-only `GITHUB_TOKEN`.
- Docker Hub login and image pushes are gated on `github.ref == refs/heads/master`, so they never run for PRs.

## Changes in this PR
- **Explicit `permissions: contents: read`** on the workflow. The repo default was `write`; the workflow never uses `GITHUB_TOKEN`, so least privilege costs nothing. (Repo Actions settings were also switched to read-only default + PR approval disabled.)
- **Removed `curl -s https://codecov.io/bash | bash`.** The bash uploader is deprecated and was the vector of the 2021 Codecov supply-chain attack; running an unpinned remote script early in the same job that later holds Docker Hub credentials is exactly the exfiltration path to avoid. The `$(CODECOV_TOKEN)` syntax was also broken bash, so the token was never actually sent. Replaced with `codecov/codecov-action@v5` using the existing `CODECOV_TOKEN` secret (empty on fork PRs, where the action falls back to tokenless upload for public repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build workflows to use read-only repository access.
  * Improved test coverage reporting with a supported coverage upload integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->