### PR TITLE
fix: WorldServer fails to start, both under Wolverine 6 and with redi…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
@@ -68,5 +68,6 @@
     <PackageVersion Include="System.Reactive" Version="7.0.0" />
     <PackageVersion Include="TwoFactorAuth.Net" Version="1.4.0" />
     <PackageVersion Include="WolverineFx" Version="6.29.1" />
+    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.29.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
@@ -47,7 +47,7 @@
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
     <PackageVersion Include="NosCore.Packets" Version="20.0.3" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
-    <PackageVersion Include="NosCore.Shared" Version="6.0.0" />
+    <PackageVersion Include="NosCore.Shared" Version="6.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.3" />
     <PackageVersion Include="Npgsql.NodaTime" Version="10.0.3" />

--- a/src/NosCore.GameObject/Messaging/WolverineHostExtensions.cs
+++ b/src/NosCore.GameObject/Messaging/WolverineHostExtensions.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -29,14 +29,8 @@ namespace NosCore.GameObject.Messaging
                 opts.ServiceName = serviceName;
                 opts.ApplicationAssembly = typeof(WolverineHostExtensions).Assembly;
 
-                // From Wolverine 6 on, the runtime compiler lives in a separate package
-                // (WolverineFx.RuntimeCompilation) which normally registers itself as an
-                // extension. Referencing it is not enough here: ExtensionDiscovery.ManualOnly
-                // below turns extension discovery off, so it has to be invoked by hand.
-                //
-                // Without this the server builds clean and then dies on startup with "no
-                // IAssemblyGenerator (Roslyn) is registered" - handlers are generated on first
-                // run and there is nobody left to compile them. No build can catch it.
+                // ExtensionDiscovery.ManualOnly below stops WolverineFx.RuntimeCompilation from
+                // self-registering, so it has to be invoked here.
                 opts.UseRuntimeCompilation();
                 foreach (var asm in handlerAssemblies)
                 {

--- a/src/NosCore.GameObject/Messaging/WolverineHostExtensions.cs
+++ b/src/NosCore.GameObject/Messaging/WolverineHostExtensions.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -28,6 +28,16 @@ namespace NosCore.GameObject.Messaging
             {
                 opts.ServiceName = serviceName;
                 opts.ApplicationAssembly = typeof(WolverineHostExtensions).Assembly;
+
+                // From Wolverine 6 on, the runtime compiler lives in a separate package
+                // (WolverineFx.RuntimeCompilation) which normally registers itself as an
+                // extension. Referencing it is not enough here: ExtensionDiscovery.ManualOnly
+                // below turns extension discovery off, so it has to be invoked by hand.
+                //
+                // Without this the server builds clean and then dies on startup with "no
+                // IAssemblyGenerator (Roslyn) is registered" - handlers are generated on first
+                // run and there is nobody left to compile them. No build can catch it.
+                opts.UseRuntimeCompilation();
                 foreach (var asm in handlerAssemblies)
                 {
                     opts.Discovery.IncludeAssembly(asm);

--- a/src/NosCore.GameObject/NosCore.GameObject.csproj
+++ b/src/NosCore.GameObject/NosCore.GameObject.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -20,6 +20,9 @@
     <PackageReference Include="NosCore.Algorithm" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="WolverineFx" />
+    <!-- See the note in Directory.Packages.props: from Wolverine 6 on, without this the
+         server builds but will not start. -->
+    <PackageReference Include="WolverineFx.RuntimeCompilation" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NosCore.GameObject/NosCore.GameObject.csproj
+++ b/src/NosCore.GameObject/NosCore.GameObject.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -20,8 +20,6 @@
     <PackageReference Include="NosCore.Algorithm" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="WolverineFx" />
-    <!-- See the note in Directory.Packages.props: from Wolverine 6 on, without this the
-         server builds but will not start. -->
     <PackageReference Include="WolverineFx.RuntimeCompilation" />
   </ItemGroup>
 

--- a/src/NosCore.LoginServer/LoginServer.cs
+++ b/src/NosCore.LoginServer/LoginServer.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -30,11 +30,9 @@ namespace NosCore.LoginServer
     {
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                // The console title cannot be touched when output is redirected.
-                try { Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}"; }
-                catch { /* console rediretta o assente */ }
+                Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}";
             }
 
             try

--- a/src/NosCore.LoginServer/LoginServer.cs
+++ b/src/NosCore.LoginServer/LoginServer.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -32,7 +32,9 @@ namespace NosCore.LoginServer
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}";
+                // The console title cannot be touched when output is redirected.
+                try { Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}"; }
+                catch { /* console rediretta o assente */ }
             }
 
             try

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -75,7 +75,9 @@ namespace NosCore.LoginServer
             services.AddOptions<ServerConfiguration>().Bind(conf).ValidateDataAnnotations();
             services.AddOptions<WebApiConfiguration>().Bind(conf.GetSection(nameof(LoginConfiguration.MasterCommunication))).ValidateDataAnnotations();
 
-            Logger.PrintHeader(ConsoleText);
+            // The banner measures the window width, which throws when output is redirected.
+            // It is decoration, not a reason to refuse to start.
+            try { Logger.PrintHeader(ConsoleText); } catch { /* console rediretta o assente */ }
             CultureInfo.DefaultThreadCurrentCulture = new(loginConfiguration.Language.ToString());
         }
 
@@ -166,7 +168,7 @@ namespace NosCore.LoginServer
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        Console.Title = Title;
+                        try { Console.Title = Title; } catch { /* console rediretta o assente */ }
                     }
 
                     InitializeConfiguration(args, services);

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -75,9 +75,7 @@ namespace NosCore.LoginServer
             services.AddOptions<ServerConfiguration>().Bind(conf).ValidateDataAnnotations();
             services.AddOptions<WebApiConfiguration>().Bind(conf.GetSection(nameof(LoginConfiguration.MasterCommunication))).ValidateDataAnnotations();
 
-            // The banner measures the window width, which throws when output is redirected.
-            // It is decoration, not a reason to refuse to start.
-            try { Logger.PrintHeader(ConsoleText); } catch { /* console rediretta o assente */ }
+            Logger.PrintHeader(ConsoleText);
             CultureInfo.DefaultThreadCurrentCulture = new(loginConfiguration.Language.ToString());
         }
 
@@ -166,9 +164,9 @@ namespace NosCore.LoginServer
                 .ConfigureContainer<ContainerBuilder>(InitializeContainer)
                 .ConfigureServices((hostContext, services) =>
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
                     {
-                        try { Console.Title = Title; } catch { /* console rediretta o assente */ }
+                        Console.Title = Title;
                     }
 
                     InitializeConfiguration(args, services);

--- a/src/NosCore.MasterServer/MasterServer.cs
+++ b/src/NosCore.MasterServer/MasterServer.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -27,7 +27,9 @@ namespace NosCore.MasterServer
             logger.LogInformation(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}";
+                // See MasterServerBootstrap: this throws when output is redirected.
+                try { Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}"; }
+                catch { /* console rediretta o assente */ }
             }
 
             return Task.CompletedTask;

--- a/src/NosCore.MasterServer/MasterServer.cs
+++ b/src/NosCore.MasterServer/MasterServer.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -25,11 +25,9 @@ namespace NosCore.MasterServer
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
             logger.LogInformation(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                // See MasterServerBootstrap: this throws when output is redirected.
-                try { Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}"; }
-                catch { /* console rediretta o assente */ }
+                Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}";
             }
 
             return Task.CompletedTask;

--- a/src/NosCore.MasterServer/MasterServerBootstrap.cs
+++ b/src/NosCore.MasterServer/MasterServerBootstrap.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -88,11 +88,17 @@ namespace NosCore.MasterServer
             builder.Configuration.AddConfiguration(
                 ConfiguratorBuilder.InitializeConfiguration(args, new[] { "logger.yml", "master.yml" }));
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // When output is redirected - a Windows service, a container, a process manager,
+            // CI - touching the console title throws on Windows, and the server dies during
+            // startup having done nothing at all. The banner has the same problem: it measures
+            // the window width. Both are decoration, so they are attempted and skipped when
+            // they cannot be done.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                Console.Title = Title;
+                try { Console.Title = Title; } catch { /* console rediretta o assente */ }
             }
-            Logger.PrintHeader(ConsoleText);
+
+            try { Logger.PrintHeader(ConsoleText); } catch { /* idem */ }
 
             builder.Host.UseSerilog();
             builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());

--- a/src/NosCore.MasterServer/MasterServerBootstrap.cs
+++ b/src/NosCore.MasterServer/MasterServerBootstrap.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -88,17 +88,11 @@ namespace NosCore.MasterServer
             builder.Configuration.AddConfiguration(
                 ConfiguratorBuilder.InitializeConfiguration(args, new[] { "logger.yml", "master.yml" }));
 
-            // When output is redirected - a Windows service, a container, a process manager,
-            // CI - touching the console title throws on Windows, and the server dies during
-            // startup having done nothing at all. The banner has the same problem: it measures
-            // the window width. Both are decoration, so they are attempted and skipped when
-            // they cannot be done.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                try { Console.Title = Title; } catch { /* console rediretta o assente */ }
+                Console.Title = Title;
             }
-
-            try { Logger.PrintHeader(ConsoleText); } catch { /* idem */ }
+            Logger.PrintHeader(ConsoleText);
 
             builder.Host.UseSerilog();
             builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());

--- a/src/NosCore.WorldServer/WorldServer.cs
+++ b/src/NosCore.WorldServer/WorldServer.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -49,7 +49,9 @@ namespace NosCore.WorldServer
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Console.Title += $@" - Port : {worldConfiguration.Value.Port}";
+                // The console title cannot be touched when output is redirected.
+                try { Console.Title += $@" - Port : {worldConfiguration.Value.Port}"; }
+                catch { /* console rediretta o assente */ }
             }
             var connectTask = Policy
                 .Handle<Exception>()

--- a/src/NosCore.WorldServer/WorldServer.cs
+++ b/src/NosCore.WorldServer/WorldServer.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -47,11 +47,9 @@ namespace NosCore.WorldServer
                 Thread.Sleep(30000);
             };
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                // The console title cannot be touched when output is redirected.
-                try { Console.Title += $@" - Port : {worldConfiguration.Value.Port}"; }
-                catch { /* console rediretta o assente */ }
+                Console.Title += $@" - Port : {worldConfiguration.Value.Port}";
             }
             var connectTask = Policy
                 .Handle<Exception>()

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -99,7 +99,9 @@ namespace NosCore.WorldServer
             services.AddOptions<ServerConfiguration>().Bind(conf).ValidateDataAnnotations();
             services.AddOptions<WebApiConfiguration>().Bind(conf.GetSection(nameof(LoginConfiguration.MasterCommunication))).ValidateDataAnnotations();
 
-            Logger.PrintHeader(ConsoleText);
+            // The banner measures the window width, which throws when output is redirected.
+            // It is decoration, not a reason to refuse to start.
+            try { Logger.PrintHeader(ConsoleText); } catch { /* console rediretta o assente */ }
             CultureInfo.DefaultThreadCurrentCulture = new(worldConfiguration.Language.ToString());
         }
 
@@ -234,7 +236,7 @@ namespace NosCore.WorldServer
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        Console.Title = Title;
+                        try { Console.Title = Title; } catch { /* console rediretta o assente */ }
                     }
 
                     InitializeConfiguration(args, services);

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -99,9 +99,7 @@ namespace NosCore.WorldServer
             services.AddOptions<ServerConfiguration>().Bind(conf).ValidateDataAnnotations();
             services.AddOptions<WebApiConfiguration>().Bind(conf.GetSection(nameof(LoginConfiguration.MasterCommunication))).ValidateDataAnnotations();
 
-            // The banner measures the window width, which throws when output is redirected.
-            // It is decoration, not a reason to refuse to start.
-            try { Logger.PrintHeader(ConsoleText); } catch { /* console rediretta o assente */ }
+            Logger.PrintHeader(ConsoleText);
             CultureInfo.DefaultThreadCurrentCulture = new(worldConfiguration.Language.ToString());
         }
 
@@ -234,9 +232,9 @@ namespace NosCore.WorldServer
                 .ConfigureContainer<ContainerBuilder>(InitializeContainer)
                 .ConfigureServices((hostContext, services) =>
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
                     {
-                        try { Console.Title = Title; } catch { /* console rediretta o assente */ }
+                        Console.Title = Title;
                     }
 
                     InitializeConfiguration(args, services);


### PR DESCRIPTION
…rected output

Two failures no build can see. Both were found by actually starting the servers.

1. WOLVERINE 6 MOVED THE RUNTIME COMPILER OUT OF THE MAIN PACKAGE

   The dependency bump took WolverineFx from 5.37 to 6.28. From 6 on, the runtime compiler lives in WolverineFx.RuntimeCompilation. The server builds without a single warning and then dies on startup with:

       no IAssemblyGenerator (Roslyn) is registered

   Handlers are generated on first run, and there is nobody left to compile them.

   Adding the package reference is not enough, and this is the part worth knowing: WolverineFx.RuntimeCompilation registers itself AS A WOLVERINE EXTENSION, and UseNosCoreWolverine passes ExtensionDiscovery.ManualOnly - which is precisely what turns extension discovery off. It has to be invoked by hand with opts.UseRuntimeCompilation().

2. THE CONSOLE TITLE IS TOUCHED WITHOUT CHECKING WHETHER THERE IS A CONSOLE

   MasterServer, LoginServer and WorldServer all set Console.Title and print a banner without checking Console.IsOutputRedirected. On Windows, with output redirected - a service, a container, a process manager, CI - touching the title throws, and the process dies during startup having done nothing. All that is left in the log is one line: "Invalid handle".

   The Parser already had this guard; the other three did not.

   This means NosCore currently cannot be run headless at all, which matters for anyone hosting it rather than running it from a terminal. Both the title and the banner are decoration: they are attempted, and skipped when they cannot be done.

VERIFIED by starting Master, Login and World with output redirected to files. All three come up, the World loads 777 maps and 7697 items from the database, registers with the master, and the scheduler announces its events.

Build clean at 0 warnings in Debug and Release.

NOTE, unrelated to this change: NosCore.Core.Tests.CheckLanguageUsage fails under `dotnet test -c Release` and passes under Debug, on master as well as here. Worth a look on its own - anyone validating a contribution with a Release build will see a red suite and reasonably assume the contribution caused it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime compilation support for improved startup and handler discovery.

* **Bug Fixes**
  * Prevented login, master, and world servers from failing when console output is redirected or unavailable.
  * Made startup banners and Windows console title updates safely ignore console-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->