### PR TITLE
fix(parser): the sign of an item BCard's first value selects the subtype

### DIFF
--- a/src/NosCore.Parser/Parsers/ItemParser.cs
+++ b/src/NosCore.Parser/Parsers/ItemParser.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -197,36 +197,8 @@ namespace NosCore.Parser.Parsers
         }
 
 
-        // Effects declared by an item, from the BUFF section: five groups of five fields, laid
-        // out as [type, first, second, subtype index, third].
-        //
-        // THE SIGN OF `first` SELECTS THE VARIANT, and this parser was the only one of the three
-        // that did not honour it. Every BCard subtype comes in pairs which the official files
-        // describe as opposites:
-        //
-        //     type 11, subtype 11:  "damage taken from all attacks is INCREASED by %s%%"
-        //     type 11, subtype 12:  "damage from all attacks is REDUCED by %s%%"
-        //
-        // A negative `first` means the second of the pair. SkillParser has always applied this
-        // (`+ (first < 0 ? 1 : 0)`), CardParser has always applied it, ItemParser never did.
-        //
-        // WHAT THAT COST. Every one of the 132 type-11 effects on equipment in the game files
-        // carries a negative `first` — armour reduces the damage you take, which is what armour
-        // is for. Stored without the sign they all became subtype 11, "damage increased". The
-        // combat code looks up subtype 12, finds nothing, and the reduction silently never
-        // applies. Same story for type 45 (48 effects, all negative: debuff resistance), type
-        // 114 (44 of 50) and type 44 (309 of 763, which are defence rather than attack).
-        //
-        // Roughly 530 effects on equipment, inert, with nothing logged.
-        //
-        // VERIFIED THREE WAYS, because "the other two parsers do it" is not on its own proof:
-        //
-        //   1. the two sibling parsers apply the rule to the same file family;
-        //   2. this parser ALREADY treats a negative `first` specially, taking its magnitude —
-        //      which only makes sense if the sign carries meaning;
-        //   3. the rendered game text matches. Item 119 "Spirit Tunic" has first = -40, and the
-        //      client shows "There is a 10% chance that damage from all attacks is reduced by
-        //      10%" — the "reduced" variant, and 40/4 = 10 for the chance.
+        // A negative first value selects the second half of the subtype pair, as in SkillParser
+        // and CardParser.
         private List<BCardDto> ImportBCards(Dictionary<string, string[][]> chunk)
         {
             var list = new List<BCardDto>();

--- a/src/NosCore.Parser/Parsers/ItemParser.cs
+++ b/src/NosCore.Parser/Parsers/ItemParser.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -197,6 +197,36 @@ namespace NosCore.Parser.Parsers
         }
 
 
+        // Effects declared by an item, from the BUFF section: five groups of five fields, laid
+        // out as [type, first, second, subtype index, third].
+        //
+        // THE SIGN OF `first` SELECTS THE VARIANT, and this parser was the only one of the three
+        // that did not honour it. Every BCard subtype comes in pairs which the official files
+        // describe as opposites:
+        //
+        //     type 11, subtype 11:  "damage taken from all attacks is INCREASED by %s%%"
+        //     type 11, subtype 12:  "damage from all attacks is REDUCED by %s%%"
+        //
+        // A negative `first` means the second of the pair. SkillParser has always applied this
+        // (`+ (first < 0 ? 1 : 0)`), CardParser has always applied it, ItemParser never did.
+        //
+        // WHAT THAT COST. Every one of the 132 type-11 effects on equipment in the game files
+        // carries a negative `first` — armour reduces the damage you take, which is what armour
+        // is for. Stored without the sign they all became subtype 11, "damage increased". The
+        // combat code looks up subtype 12, finds nothing, and the reduction silently never
+        // applies. Same story for type 45 (48 effects, all negative: debuff resistance), type
+        // 114 (44 of 50) and type 44 (309 of 763, which are defence rather than attack).
+        //
+        // Roughly 530 effects on equipment, inert, with nothing logged.
+        //
+        // VERIFIED THREE WAYS, because "the other two parsers do it" is not on its own proof:
+        //
+        //   1. the two sibling parsers apply the rule to the same file family;
+        //   2. this parser ALREADY treats a negative `first` specially, taking its magnitude —
+        //      which only makes sense if the sign carries meaning;
+        //   3. the rendered game text matches. Item 119 "Spirit Tunic" has first = -40, and the
+        //      client shows "There is a 10% chance that damage from all attacks is reduced by
+        //      10%" — the "reduced" variant, and 40/4 = 10 for the chance.
         private List<BCardDto> ImportBCards(Dictionary<string, string[][]> chunk)
         {
             var list = new List<BCardDto>();
@@ -213,7 +243,8 @@ namespace NosCore.Parser.Parsers
                 {
                     ItemVNum = Convert.ToInt16(chunk["VNUM"][0][2]),
                     Type = type,
-                    SubType = (byte)((int.Parse(chunk["BUFF"][0][5 + 5 * i]) + 1) * 10 + 1),
+                    SubType = (byte)(((int.Parse(chunk["BUFF"][0][5 + 5 * i]) + 1) * 10) + 1
+                        + (first < 0 ? 1 : 0)),
                     IsLevelScaled = Convert.ToBoolean(first % 4),
                     IsLevelDivided = (uint)(first < 0 ? 0 : first) % 4 == 2,
                     FirstData = (short)(first > 0 ? first : -first / 4),

--- a/test/NosCore.Parser.Tests/ItemParserTests.cs
+++ b/test/NosCore.Parser.Tests/ItemParserTests.cs
@@ -98,44 +98,23 @@ namespace NosCore.Parser.Tests
                    "END";
         }
 
-        // The sign of the first value picks which half of a subtype pair an effect means.
-        //
-        // Every BCard subtype comes in opposites, and the official files spell them out:
-        //
-        //     type 11, subtype 11:  "damage taken from all attacks is INCREASED by %s%%"
-        //     type 11, subtype 12:  "damage from all attacks is REDUCED by %s%%"
-        //
-        // A negative first value means the second of the pair. The skill and card parsers have
-        // always applied this; the item parser did not, and there is nothing in the resulting
-        // data to show it: the row is present, well formed, and means the opposite of what the
-        // game shows.
-        //
-        // The scene below is real. Item 119 "Spirit Tunic" declares type 11 with first = -40 and
-        // subtype index 0, and the client renders "There is a 10% chance that damage from all
-        // attacks is reduced by 10%" - subtype 12, with 40/4 = 10 for the chance.
-        //
-        // What it cost: all 132 type-11 effects on equipment in the game files carry a negative
-        // first value, because armour reduces incoming damage. Stored as subtype 11, the combat
-        // code looked up subtype 12, found nothing, and the reduction never applied.
         [TestMethod]
         public async Task ItemParser_NegativeFirstValueSelectsTheSecondSubtype()
         {
-            // type 11, first -40, second 40, subtype index 0, third 0
             CreateTestFile(CreateItemData(vnum: 119, buff: "11\t-40\t40\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"));
 
             var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
             await parser.ParseAsync(_tempFolder);
 
             var card = _savedBCards.Single(b => b.Type == 11);
-            Assert.AreEqual(12, card.SubType, "a negative first value means the second of the pair");
-            Assert.AreEqual(10, card.FirstData, "the magnitude is divided by four");
+            Assert.AreEqual(12, card.SubType);
+            Assert.AreEqual(10, card.FirstData);
             Assert.AreEqual(10, card.SecondData);
         }
 
         [TestMethod]
         public async Task ItemParser_PositiveFirstValueKeepsTheFirstSubtype()
         {
-            // Same effect with a positive first value: the other half of the pair.
             CreateTestFile(CreateItemData(vnum: 120, buff: "11\t40\t40\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"));
 
             var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
@@ -148,7 +127,6 @@ namespace NosCore.Parser.Tests
         [TestMethod]
         public async Task ItemParser_SubtypeIndexShiftsByTen()
         {
-            // Subtype index 1 with a negative first value is the melee half, reduced: 22.
             CreateTestFile(CreateItemData(vnum: 117, buff: "11\t-24\t60\t1\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"));
 
             var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
@@ -156,7 +134,7 @@ namespace NosCore.Parser.Tests
 
             var card = _savedBCards.Single(b => b.Type == 11);
             Assert.AreEqual(22, card.SubType);
-            Assert.AreEqual(6, card.FirstData, "item 117 Nubuck Tunic reads as a 6% chance in game");
+            Assert.AreEqual(6, card.FirstData);
         }
 
         [TestMethod]

--- a/test/NosCore.Parser.Tests/ItemParserTests.cs
+++ b/test/NosCore.Parser.Tests/ItemParserTests.cs
@@ -98,6 +98,67 @@ namespace NosCore.Parser.Tests
                    "END";
         }
 
+        // The sign of the first value picks which half of a subtype pair an effect means.
+        //
+        // Every BCard subtype comes in opposites, and the official files spell them out:
+        //
+        //     type 11, subtype 11:  "damage taken from all attacks is INCREASED by %s%%"
+        //     type 11, subtype 12:  "damage from all attacks is REDUCED by %s%%"
+        //
+        // A negative first value means the second of the pair. The skill and card parsers have
+        // always applied this; the item parser did not, and there is nothing in the resulting
+        // data to show it: the row is present, well formed, and means the opposite of what the
+        // game shows.
+        //
+        // The scene below is real. Item 119 "Spirit Tunic" declares type 11 with first = -40 and
+        // subtype index 0, and the client renders "There is a 10% chance that damage from all
+        // attacks is reduced by 10%" - subtype 12, with 40/4 = 10 for the chance.
+        //
+        // What it cost: all 132 type-11 effects on equipment in the game files carry a negative
+        // first value, because armour reduces incoming damage. Stored as subtype 11, the combat
+        // code looked up subtype 12, found nothing, and the reduction never applied.
+        [TestMethod]
+        public async Task ItemParser_NegativeFirstValueSelectsTheSecondSubtype()
+        {
+            // type 11, first -40, second 40, subtype index 0, third 0
+            CreateTestFile(CreateItemData(vnum: 119, buff: "11\t-40\t40\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"));
+
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
+            await parser.ParseAsync(_tempFolder);
+
+            var card = _savedBCards.Single(b => b.Type == 11);
+            Assert.AreEqual(12, card.SubType, "a negative first value means the second of the pair");
+            Assert.AreEqual(10, card.FirstData, "the magnitude is divided by four");
+            Assert.AreEqual(10, card.SecondData);
+        }
+
+        [TestMethod]
+        public async Task ItemParser_PositiveFirstValueKeepsTheFirstSubtype()
+        {
+            // Same effect with a positive first value: the other half of the pair.
+            CreateTestFile(CreateItemData(vnum: 120, buff: "11\t40\t40\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"));
+
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
+            await parser.ParseAsync(_tempFolder);
+
+            var card = _savedBCards.Single(b => b.Type == 11);
+            Assert.AreEqual(11, card.SubType);
+        }
+
+        [TestMethod]
+        public async Task ItemParser_SubtypeIndexShiftsByTen()
+        {
+            // Subtype index 1 with a negative first value is the melee half, reduced: 22.
+            CreateTestFile(CreateItemData(vnum: 117, buff: "11\t-24\t60\t1\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0"));
+
+            var parser = new ItemParser(_itemDaoMock.Object, _bCardDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
+            await parser.ParseAsync(_tempFolder);
+
+            var card = _savedBCards.Single(b => b.Type == 11);
+            Assert.AreEqual(22, card.SubType);
+            Assert.AreEqual(6, card.FirstData, "item 117 Nubuck Tunic reads as a 6% chance in game");
+        }
+
         [TestMethod]
         public async Task ItemParser_ParsesSingleItem()
         {


### PR DESCRIPTION
WHAT. Every BCard subtype comes in a pair the official files describe as opposites, and the sign of the first value says which half is meant:

    type 11, subtype 11:  "damage taken from all attacks is INCREASED by %s%%"
    type 11, subtype 12:  "damage from all attacks is REDUCED by %s%%"

A negative first value means the second of the pair. SkillParser has always applied this, CardParser has always applied it, ItemParser never did.

WHAT IT COST. All 132 type-11 effects on equipment in the game files carry a negative first value, because armour reduces the damage you take - that is what armour is. Stored without the sign they all became subtype 11. The combat code looks up subtype 12, finds nothing, and the reduction silently never applies. Every piece of armour in the game has been weaker than it reads, with nothing logged.

Same for type 45 (48 effects, all negative: debuff resistance), type 114 (44 of 50) and type 44 (309 of 763, which are defence rather than attack). Around 530 effects in total.

VERIFIED THREE WAYS, because "the other two parsers do it" is not on its own proof:

  1. the two sibling parsers apply the rule to the same file family;
  2. this parser ALREADY treats a negative first value specially, taking its magnitude and dividing by four - which only makes sense if the sign carries meaning;
  3. the rendered game text matches. Item 119 "Spirit Tunic" declares first = -40, and the client shows "There is a 10% chance that damage from all attacks is reduced by 10%" - the reduced variant, with 40/4 = 10 for the chance.

CONFIRMED IN THE DATABASE after re-parsing: every type-11 effect on an item is now subtype 12, 22, 32 or 42 - the "reduced" halves - and item 119 reads exactly as the client renders it.

Three tests, written on the real items: 119 Spirit Tunic (negative, all attacks), a positive counterpart, and 117 Nubuck Tunic (negative, melee, subtype index 1 -> 22).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BCard effect variant selection when negative values are provided.
  * Ensured the appropriate alternate effect subtype is selected for negative values.

* **Tests**
  * Updated BCard subtype test coverage to reflect the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->