### PR TITLE
fix: pin DtoGenerator to Roslyn 5.6.0 so the generator loads

### DIFF
--- a/tools/NosCore.DtoGenerator/NosCore.DtoGenerator.csproj
+++ b/tools/NosCore.DtoGenerator/NosCore.DtoGenerator.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.6.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
#2274 bumped `Microsoft.CodeAnalysis.CSharp` to `5.9.0` centrally. `NosCore.DtoGenerator` had no `VersionOverride`, so it picked the bump up and its generator assembly started demanding a compiler newer than the one the .NET `10.0.300` SDK ships:

```
error CS9057: Analyzer assembly 'NosCore.DtoGenerator.dll' cannot be used because it
references version '5.9.0.0' of the compiler, which is newer than the currently
running version '5.6.0.0'   [src/NosCore.Data/NosCore.Data.csproj]
```

`master` does not build locally right now. It went green in CI only because the hosted runner resolves a newer `10.0.x` SDK than the one installed here.

A source generator has to target the oldest Roslyn it must run on, not the newest available — `NosCore.EcsGenerator` already pins `5.6.0` for exactly this reason. `DtoGenerator` now matches it.

Verified: `dotnet build NosCore.sln` fails on `master` with CS9057 and succeeds with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)