### PR TITLE
fix: use the official aspnet base image so the Docker publish resolves

### DIFF
--- a/deploy/Dockerfile-login
+++ b/deploy/Dockerfile-login
@@ -1,25 +1,10 @@
-# cf https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/10.0/alpine3.21/amd64/Dockerfile
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:10.0-alpine3.24-amd64
 
-ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:10.0.1-alpine3.21-amd64
-
-# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
-# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
-
-# ASP.NET Core version
-ENV ASPNET_VERSION=10.0.1
+# runtime-deps sets DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true and ships no ICU data.
+# See https://aka.ms/dotnet-globalization-alpine-containers
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-
-# Install ASP.NET Core
-RUN wget -O aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='ef84b8bcfb323a11acc57e54068e1ff7daa400bd5c8aeb89c65fb13fb2ad9e302986647495561a0c4fda5eb4c0836a67e5e7e591d58661f20cd6ddff97d6d4c9' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
-
-# Update package list and install libicu (ICU libraries) for Alpine
-RUN apk update \
-    && apk add --no-cache icu-libs
+RUN apk add --no-cache icu-libs
 
 COPY ./build/net10.0 /app/build/net10.0
 COPY ./configuration /app/configuration

--- a/deploy/Dockerfile-master
+++ b/deploy/Dockerfile-master
@@ -1,25 +1,10 @@
-# cf https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/10.0/alpine3.21/amd64/Dockerfile
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:10.0-alpine3.24-amd64
 
-ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:10.0.1-alpine3.21-amd64
-
-# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
-# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
-
-# ASP.NET Core version
-ENV ASPNET_VERSION=10.0.1
+# runtime-deps sets DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true and ships no ICU data.
+# See https://aka.ms/dotnet-globalization-alpine-containers
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-
-# Install ASP.NET Core
-RUN wget -O aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='ef84b8bcfb323a11acc57e54068e1ff7daa400bd5c8aeb89c65fb13fb2ad9e302986647495561a0c4fda5eb4c0836a67e5e7e591d58661f20cd6ddff97d6d4c9' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
-
-# Update package list and install libicu (ICU libraries) for Alpine
-RUN apk update \
-    && apk add --no-cache icu-libs
+RUN apk add --no-cache icu-libs
 
 COPY ./build/net10.0 /app/build/net10.0
 COPY ./configuration /app/configuration

--- a/deploy/Dockerfile-world
+++ b/deploy/Dockerfile-world
@@ -1,25 +1,10 @@
-# cf https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/10.0/alpine3.21/amd64/Dockerfile
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:10.0-alpine3.24-amd64
 
-ARG REPO=mcr.microsoft.com/dotnet/runtime
-FROM $REPO:10.0.1-alpine3.21-amd64
-
-# .NET globalization APIs will use invariant mode by default because DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true is set
-# by the base runtime-deps image. See https://aka.ms/dotnet-globalization-alpine-containers for more information.
-
-# ASP.NET Core version
-ENV ASPNET_VERSION=10.0.1
+# runtime-deps sets DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true and ships no ICU data.
+# See https://aka.ms/dotnet-globalization-alpine-containers
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-
-# Install ASP.NET Core
-RUN wget -O aspnetcore.tar.gz https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$ASPNET_VERSION/aspnetcore-runtime-$ASPNET_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='ef84b8bcfb323a11acc57e54068e1ff7daa400bd5c8aeb89c65fb13fb2ad9e302986647495561a0c4fda5eb4c0836a67e5e7e591d58661f20cd6ddff97d6d4c9' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && tar -oxzf aspnetcore.tar.gz -C /usr/share/dotnet ./shared/Microsoft.AspNetCore.App \
-    && rm aspnetcore.tar.gz
-
-# Update package list and install libicu (ICU libraries) for Alpine
-RUN apk update \
-    && apk add --no-cache icu-libs
+RUN apk add --no-cache icu-libs
 
 COPY ./build/net10.0 /app/build/net10.0
 COPY ./configuration /app/configuration
@@ -27,7 +12,5 @@ COPY ./configuration /app/configuration
 WORKDIR /app/build/net10.0
 
 EXPOSE 1337 5001
-
-# RUN dotnet help
 
 ENTRYPOINT ["dotnet", "NosCore.WorldServer.dll"]


### PR DESCRIPTION
Every `master` build has been failing at the image publish step:

```
ERROR: failed to solve: mcr.microsoft.com/dotnet/runtime:10.0.1-alpine3.21-amd64: not found
```

MCR garbage-collects old patch tags, and `10.0.1-alpine3.21-amd64` is gone. The compile and test steps were fine — only the publish broke.

### What changed

The three Dockerfiles were building ASP.NET Core on top of the **runtime** image by hand: `wget` the tarball, verify a hard-coded SHA512, untar it into the shared framework. That is three pins that have to move together on every patch — the base tag, `ASPNET_VERSION`, and the checksum — and it is why the base tag drifted far enough behind to be deleted.

`mcr.microsoft.com/dotnet/aspnet` ships that framework already, so the download, the checksum and the version pin are all gone.

Two deliberate choices:
- **Floating `10.0` tag instead of a patch**, so MCR retiring a patch cannot break the build the same way again.
- **ICU is still installed explicitly** — `runtime-deps` sets `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true` and ships no ICU data, and NosCore needs real culture data.

### Verification

Built all three images locally against this branch:

```
$ docker run --rm --entrypoint dotnet noscore-login-test --list-runtimes
Microsoft.AspNetCore.App 10.0.11 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.NETCore.App 10.0.11 [/usr/share/dotnet/shared/Microsoft.NETCore.App]

$ docker run --rm --entrypoint sh noscore-login-test -c 'ls /usr/lib/libicu*; echo $DOTNET_SYSTEM_GLOBALIZATION_INVARIANT'
/usr/lib/libicudata.so.78
...
false
```

`docker run noscore-login-test` prints the banner and runs through to its Postgres connection, failing only on `Connection refused` with no database present. That also exercises the headless `PrintHeader` fix from #2278 in a real no-console environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)