### PR TITLE
chore: bump NosCore.Packets to 21.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
     <PackageVersion Include="NosCore.FastMember" Version="1.5.0" />
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
-    <PackageVersion Include="NosCore.Packets" Version="20.0.3" />
+    <PackageVersion Include="NosCore.Packets" Version="21.0.0" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
     <PackageVersion Include="NosCore.Shared" Version="6.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />


### PR DESCRIPTION
Picks up NosCoreIO/NosCore.Packets#494 and #495.

What it brings that matters here:

* **`gidx`'s family id is now a nullable id**, so the packet finally matches what a capture shows — `gidx 1 521919 5083 [NDM](Gardien) 3` with a family, `gidx 1 741328 -1 - 0` without. Both reproduce exactly on 21.0.0. This is what #2283 needs to send the family tag at all.
* `sc_n`'s boots slot is dotted like the other three.

Builds and tests clean — nothing in this repository referenced `GidxFamilySubPacket`, so the breaking part of the major bump costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the centrally managed packet library to version 21.0.0.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->