### PR TITLE
chore: bump NosCore.Packets to 21.0.0 and NosCore.Algorithm to 2.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,12 +40,12 @@
     <PackageVersion Include="NodaTime" Version="3.3.3" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
     <PackageVersion Include="NodaTime.Testing" Version="3.3.3" />
-    <PackageVersion Include="NosCore.Algorithm" Version="2.0.0" />
+    <PackageVersion Include="NosCore.Algorithm" Version="2.1.0" />
     <PackageVersion Include="NosCore.Analyzers" Version="2.0.0" />
     <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
     <PackageVersion Include="NosCore.FastMember" Version="1.5.0" />
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
-    <PackageVersion Include="NosCore.Packets" Version="20.0.3" />
+    <PackageVersion Include="NosCore.Packets" Version="21.0.0" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
     <PackageVersion Include="NosCore.Shared" Version="6.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />


### PR DESCRIPTION
Consumer bump for the two releases just published.

**NosCore.Packets 21.0.0** (NosCoreIO/NosCore.Packets#494, #495)
- `gidx`'s family id flattened from a two-field sub-packet to a nullable id, matching the client-side `GidxPacket` next to it and the captured wire
- `ScnPacket` index 9 given the `SpecialSeparator` its three siblings carry
- the sub-packet serializer patch from #493 reverted — it was solving a mis-modelled packet at the wrong level

Major bump because `GidxFamilySubPacket` was removed; nothing in NosCore referenced it, so the practical impact here is nil.

**NosCore.Algorithm 2.1.0** (NosCoreIO/NosCore.Algorithm#130)
- family experience table corrected in every row and extended from 19 to 30 levels. The old table would have asked a level 1 family for 100 000 instead of 80 000, and a family reaching 19 could not have levelled at all.

Build succeeds, 927/927 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated centrally managed package versions to newer releases.
  * Improved compatibility with the latest algorithm and packet handling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->