### PR TITLE
Add the BCard subtypes the files declare and the enums stop before

### DIFF
--- a/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
+++ b/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
@@ -113,12 +113,7 @@ namespace NosCore.Data.Enumerations.Buff
             ChanceMagicalDecreased = 42,
 
             /// <summary>
-            /// "Final damage from incoming critical hits is reduced by %s%% per critical hit
-            /// (max. %s hits)." Not a negation of anything above it: the first four pairs are the
-            /// parry, which is a chance, while this is priced per critical in a RUN.
-            ///
-            /// 52 carries that same sentence word for word, so the suffix marks the X2 slot and
-            /// not an inversion. Nothing in the game data declares it today.
+            /// Per-critical reduction over a run of hits, not a chance like 11-42.
             /// </summary>
             CriticalDamageReducedPerHit = 51,
             CriticalDamageReducedPerHitNegated = 52
@@ -1304,36 +1299,8 @@ namespace NosCore.Data.Enumerations.Buff
         }
 
         /// <summary>
-        /// Type 104. Five of the ten subtypes were missing, and the fourth pair was marked as not
-        /// existing when the files declare it.
+        /// 52 targets allies, not enemies - it is not the negation of 51.
         /// </summary>
-        /// <remarks>
-        /// What BCard.dat says, resolved through the client's language files:
-        ///
-        ///     11  "When you're defending, there is a %s%% chance of %s%% of the damage being
-        ///          reflected at the enemy (up to 50%% of the max. HP of the player with the buff)."
-        ///     12  the same sentence WITHOUT the cap - not a negation of 11
-        ///     21  "All opponents within %s space(s) take %s damage every 1.5 seconds."
-        ///     22  the same sentence, word for word
-        ///     31  "When you're defending, there is a %s%% chance of summoning a(n) %s."
-        ///     32  the same, summoning two
-        ///     41  "Increases the attack power of your NosMate by %s%%."
-        ///     42  the same sentence, word for word
-        ///     51  "All opponents within %s space(s) suffer %s every 1.5 seconds."
-        ///     52  "Allies within %s space(s) suffer [%s] every 1.5 seconds."
-        ///
-        /// 51 and 52 are not a pair either: one names enemies and the other allies, so a handler
-        /// that treats 52 as the negation of 51 would put a hostile aura on its own party.
-        ///
-        /// For 22 and 42 the client repeats the X1 sentence unchanged, so the files give the
-        /// second slot no meaning of its own. The `Negated` suffix here means "the X2 slot",
-        /// which is what it already means for the identical-text pairs upstream names that way
-        /// (see Type107.MagicArmourFlatNegated) - it is not a claim that the effect inverts.
-        /// Nothing in the game data declares 22 or 42 today.
-        ///
-        /// The names of 12 and of the existing 51 are left alone so nothing downstream breaks;
-        /// what they actually mean is written above.
-        /// </remarks>
         public enum Type104 : byte
         {
             ReflectOnDeff = 11,

--- a/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
+++ b/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
@@ -110,7 +110,15 @@ namespace NosCore.Data.Enumerations.Buff
             ChanceRangedIncreased = 31,
             ChanceRangedDecreased = 32,
             ChanceMagicalIncreased = 41,
-            ChanceMagicalDecreased = 42
+            ChanceMagicalDecreased = 42,
+
+            /// <summary>
+            /// "Final damage from incoming critical hits is reduced by %s%% per critical hit
+            /// (max. %s hits)." Not a negation of anything above it: the first four pairs are the
+            /// parry, which is a chance, while this is priced per critical in a RUN.
+            /// </summary>
+            CriticalDamageReducedPerHit = 51,
+            CriticalDamageReducedPerHitNegated = 52
         }
 
         public enum BossMonstersSkill : byte

--- a/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
+++ b/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -116,6 +116,9 @@ namespace NosCore.Data.Enumerations.Buff
             /// "Final damage from incoming critical hits is reduced by %s%% per critical hit
             /// (max. %s hits)." Not a negation of anything above it: the first four pairs are the
             /// parry, which is a chance, while this is priced per critical in a RUN.
+            ///
+            /// 52 carries that same sentence word for word, so the suffix marks the X2 slot and
+            /// not an inversion. Nothing in the game data declares it today.
             /// </summary>
             CriticalDamageReducedPerHit = 51,
             CriticalDamageReducedPerHitNegated = 52
@@ -1301,7 +1304,7 @@ namespace NosCore.Data.Enumerations.Buff
         }
 
         /// <summary>
-        /// Type 104. Four of the ten subtypes were missing, and the fourth pair was marked as not
+        /// Type 104. Five of the ten subtypes were missing, and the fourth pair was marked as not
         /// existing when the files declare it.
         /// </summary>
         /// <remarks>
@@ -1311,14 +1314,22 @@ namespace NosCore.Data.Enumerations.Buff
         ///          reflected at the enemy (up to 50%% of the max. HP of the player with the buff)."
         ///     12  the same sentence WITHOUT the cap - not a negation of 11
         ///     21  "All opponents within %s space(s) take %s damage every 1.5 seconds."
+        ///     22  the same sentence, word for word
         ///     31  "When you're defending, there is a %s%% chance of summoning a(n) %s."
         ///     32  the same, summoning two
         ///     41  "Increases the attack power of your NosMate by %s%%."
+        ///     42  the same sentence, word for word
         ///     51  "All opponents within %s space(s) suffer %s every 1.5 seconds."
         ///     52  "Allies within %s space(s) suffer [%s] every 1.5 seconds."
         ///
         /// 51 and 52 are not a pair either: one names enemies and the other allies, so a handler
         /// that treats 52 as the negation of 51 would put a hostile aura on its own party.
+        ///
+        /// For 22 and 42 the client repeats the X1 sentence unchanged, so the files give the
+        /// second slot no meaning of its own. The `Negated` suffix here means "the X2 slot",
+        /// which is what it already means for the identical-text pairs upstream names that way
+        /// (see Type107.MagicArmourFlatNegated) - it is not a claim that the effect inverts.
+        /// Nothing in the game data declares 22 or 42 today.
         ///
         /// The names of 12 and of the existing 51 are left alone so nothing downstream breaks;
         /// what they actually mean is written above.
@@ -1332,7 +1343,7 @@ namespace NosCore.Data.Enumerations.Buff
             SummonMonsterOnDef = 31,
             SummonTwoMonstersOnDef = 32,
             MateAttackIncreased = 41,
-            MateAttackDecreased = 42,
+            MateAttackIncreasedNegated = 42,
             AreaBuffEachSecond = 51,
             AreaBuffOnAlliesEachSecond = 52
         }

--- a/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
+++ b/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
@@ -637,16 +637,36 @@ namespace NosCore.Data.Enumerations.Buff
             IgnoreEnemyMoraleNegated = 52
         }
 
+        /// <summary>
+        /// 21-22 are a percentage and 41-42 are flat, which the names do not say. 11-12 and 51-52
+        /// carry the same text as each other in the files, so the X2 slot has no meaning of its own.
+        /// </summary>
         public enum Move : byte
         {
             MovementImpossible = 11,
             MovementImpossibleNegated = 12,
+
+            /// <summary>Movement speed is increased by %s%%.</summary>
             MoveSpeedIncreased = 21,
+
+            /// <summary>Movement speed is decreased by %s%%.</summary>
             MoveSpeedDecreased = 22,
-            SetMovement = 31,
-            SetMovementNegated = 32,
+
+            /// <summary>
+            /// Your movement speed is increased by %s <b>while you are hidden</b>. Not a "set
+            /// movement" of any kind: it is a flat bonus that only applies while invisible.
+            /// </summary>
+            SpeedWhileHiddenIncreased = 31,
+
+            /// <summary>Your movement speed is decreased by %s while you are hidden.</summary>
+            SpeedWhileHiddenDecreased = 32,
+
+            /// <summary>Movement speed is increased by %s. This is the unconditional flat one.</summary>
             MovementSpeedIncreased = 41,
+
+            /// <summary>Movement speed is decreased by %s.</summary>
             MovementSpeedDecreased = 42,
+
             TempMaximized = 51,
             TempMaximizedNegated = 52
         }

--- a/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
+++ b/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -1292,14 +1292,41 @@ namespace NosCore.Data.Enumerations.Buff
             DecreaseConcentration = 52
         }
 
+        /// <summary>
+        /// Type 104. Four of the ten subtypes were missing, and the fourth pair was marked as not
+        /// existing when the files declare it.
+        /// </summary>
+        /// <remarks>
+        /// What BCard.dat says, resolved through the client's language files:
+        ///
+        ///     11  "When you're defending, there is a %s%% chance of %s%% of the damage being
+        ///          reflected at the enemy (up to 50%% of the max. HP of the player with the buff)."
+        ///     12  the same sentence WITHOUT the cap - not a negation of 11
+        ///     21  "All opponents within %s space(s) take %s damage every 1.5 seconds."
+        ///     31  "When you're defending, there is a %s%% chance of summoning a(n) %s."
+        ///     32  the same, summoning two
+        ///     41  "Increases the attack power of your NosMate by %s%%."
+        ///     51  "All opponents within %s space(s) suffer %s every 1.5 seconds."
+        ///     52  "Allies within %s space(s) suffer [%s] every 1.5 seconds."
+        ///
+        /// 51 and 52 are not a pair either: one names enemies and the other allies, so a handler
+        /// that treats 52 as the negation of 51 would put a hostile aura on its own party.
+        ///
+        /// The names of 12 and of the existing 51 are left alone so nothing downstream breaks;
+        /// what they actually mean is written above.
+        /// </remarks>
         public enum Type104 : byte
         {
             ReflectOnDeff = 11,
             ReflectOnDeffNegated = 12,
             AreaDamageEachSecond = 21,
+            AreaDamageEachSecondNegated = 22,
             SummonMonsterOnDef = 31,
-            //SubType 4 didn't exist.
-            AreaBuffEachSecond = 51
+            SummonTwoMonstersOnDef = 32,
+            MateAttackIncreased = 41,
+            MateAttackDecreased = 42,
+            AreaBuffEachSecond = 51,
+            AreaBuffOnAlliesEachSecond = 52
         }
 
         public enum Type107 : byte

--- a/src/NosCore.GameObject/Services/SpeedCalculationService/SpeedCalculationService.cs
+++ b/src/NosCore.GameObject/Services/SpeedCalculationService/SpeedCalculationService.cs
@@ -18,7 +18,12 @@ namespace NosCore.GameObject.Services.SpeedCalculationService
             //        return 0;
             //    }
 
-            var bonusSpeed = 0; /*(byte)GetBuff(CardType.Move, (byte)AdditionalTypes.Move.SetMovementNegated)[0];*/
+            // The movement BCards are still not read. The placeholder that used to sit
+            // here reached for subtype 32, which the files say is "movement speed is
+            // DECREASED by %s while you are hidden": wrong slot and wrong condition for a
+            // general speed bonus. The unconditional flat pair is 41-42, and 21-22 is the
+            // percentage.
+            var bonusSpeed = 0;
             if (defaultSpeed + bonusSpeed > 59)
             {
                 return 59;


### PR DESCRIPTION
BCard.dat declares ten subtypes for type 104; `AdditionalTypes.Type104` had six, and the pair it marked `//SubType 4 didn't exist.` is declared like every other one — the same shape as the note that used to sit on type 94's subtype 41.

    41  "Increases the attack power of your NosMate by %s%%."

Two of the additions are **not** negations, so they are named for what they say rather than with a `Negated` suffix:

| subtype | what the file says |
|---|---|
| `11` | reflect a share of the damage, capped at 50% of the carrier's max HP |
| `12` | the same sentence **without** the cap — not a negation of 11 |
| `51` | "All opponents within %s space(s) suffer %s every 1.5 seconds." |
| `52` | "**Allies** within %s space(s) suffer [%s] every 1.5 seconds." |

A handler treating 52 as 51 negated would hang a hostile aura on its own party.

I left the names of `12` and `51` alone so nothing downstream breaks; what they actually mean is now written on the enum.

Enum only — no behaviour change. Zero warnings, all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the classification of X2 slot effects.
  * Expanded descriptions for additional combat-effect subtypes.
  * Corrected the label for the negated companion-attack increase effect to improve clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->