### PR TITLE
FCOMBO triplets are read one field too early

### DIFF
--- a/src/NosCore.Parser/Parsers/SkillParser.cs
+++ b/src/NosCore.Parser/Parsers/SkillParser.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -144,22 +144,9 @@ namespace NosCore.Parser.Parsers
             return list;
         }
 
-        // The steps of a combo chain, from Skill.dat's FCOMBO section.
-        //
-        // THE FIRST FIELD IS NOT A STEP, IT IS A SWITCH: 1 when the skill has a chain and 0 when
-        // it has not - true of all 1958 skills in the file. Five triplets of (hit, animation,
-        // effect) follow it. Counting the triplets from the switch instead of after it shifted
-        // every step by one field:
-        //
-        //     220 "Basic Slash"   FCOMBO 1 | 3 40 513 | 4 25 525 | 5 13 524 | 0 0 0 | 0 0 0
-        //     read as             (hit 1, anim 3, eff 40), (hit 513, ...), (hit 525, ...)
-        //
-        // Hit 513 never arrives - the consecutive-hit counter stays in single figures - so the
-        // chain could not fire, and nothing said so: no exception, just the third blow's special
-        // animation that never plays. Twenty-one skills carry an FCOMBO.
-        //
-        // The raw row starts at index 2 (field 0 is empty, field 1 is the section name), so the
-        // switch is at 2 and triplet j starts at 3 + j*3.
+        // FCOMBO's first field is a switch (has a chain / has not), not a step. The row starts
+        // at index 2, so triplet j starts at 3 + j*3; counting from the switch shifted every
+        // step by one field and the chain never fired.
         private List<ComboDto> AddCombos(Dictionary<string, string[][]> chunks)
         {
             var list = new List<ComboDto>();

--- a/src/NosCore.Parser/Parsers/SkillParser.cs
+++ b/src/NosCore.Parser/Parsers/SkillParser.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -144,6 +144,22 @@ namespace NosCore.Parser.Parsers
             return list;
         }
 
+        // The steps of a combo chain, from Skill.dat's FCOMBO section.
+        //
+        // THE FIRST FIELD IS NOT A STEP, IT IS A SWITCH: 1 when the skill has a chain and 0 when
+        // it has not - true of all 1958 skills in the file. Five triplets of (hit, animation,
+        // effect) follow it. Counting the triplets from the switch instead of after it shifted
+        // every step by one field:
+        //
+        //     220 "Basic Slash"   FCOMBO 1 | 3 40 513 | 4 25 525 | 5 13 524 | 0 0 0 | 0 0 0
+        //     read as             (hit 1, anim 3, eff 40), (hit 513, ...), (hit 525, ...)
+        //
+        // Hit 513 never arrives - the consecutive-hit counter stays in single figures - so the
+        // chain could not fire, and nothing said so: no exception, just the third blow's special
+        // animation that never plays. Twenty-one skills carry an FCOMBO.
+        //
+        // The raw row starts at index 2 (field 0 is empty, field 1 is the section name), so the
+        // switch is at 2 and triplet j starts at 3 + j*3.
         private List<ComboDto> AddCombos(Dictionary<string, string[][]> chunks)
         {
             var list = new List<ComboDto>();
@@ -152,9 +168,9 @@ namespace NosCore.Parser.Parsers
                 var comb = new ComboDto
                 {
                     SkillVNum = Convert.ToInt16(chunks["VNUM"][0][2]),
-                    Hit = short.Parse(chunks["FCOMBO"][0][j * 3 + 2]),
-                    Animation = short.Parse(chunks["FCOMBO"][0][j * 3 + 3]),
-                    Effect = short.Parse(chunks["FCOMBO"][0][j * 3 + 4])
+                    Hit = short.Parse(chunks["FCOMBO"][0][(j * 3) + 3]),
+                    Animation = short.Parse(chunks["FCOMBO"][0][(j * 3) + 4]),
+                    Effect = short.Parse(chunks["FCOMBO"][0][(j * 3) + 5])
                 };
                 if ((comb.Hit == 0) && (comb.Animation == 0) && (comb.Effect == 0))
                 {

--- a/test/NosCore.Parser.Tests/SkillParserTests.cs
+++ b/test/NosCore.Parser.Tests/SkillParserTests.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -100,7 +100,8 @@ namespace NosCore.Parser.Tests
             short cooldown = 0,
             short mpCost = 0,
             short itemVNum = 0,
-            byte levelMinimum = 0)
+            byte levelMinimum = 0,
+            string fcombo = "0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0")
         {
             return $"\tVNUM\t{skillVNum}\r\n" +
                    $"\tNAME\t{name}\r\n" +
@@ -115,10 +116,62 @@ namespace NosCore.Parser.Tests
                    "\tBASIC\t2\t0\t0\t0\t0\t0\r\n" +
                    "\tBASIC\t3\t0\t0\t0\t0\t0\r\n" +
                    "\tBASIC\t4\t0\t0\t0\t0\t0\r\n" +
-                   "\tFCOMBO\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\r\n" +
+                   $"\tFCOMBO\t{fcombo}\r\n" +
                    "\tCELL\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\r\n" +
                    "\tZ_DESC\t0\r\n" +
                    "#=========================================================";
+        }
+
+        [TestMethod]
+        public async Task SkillParser_ReadsComboTripletsAfterTheSwitch()
+        {
+            // The real FCOMBO row of skill 220, "Basic Slash". The leading 1 is the switch that
+            // says the skill has a chain at all; the triplets follow it.
+            //
+            //     FCOMBO 1 | 3 40 513 | 4 25 525 | 5 13 524 | 0 0 0 | 0 0 0
+            //
+            // Counting from the switch instead of after it produced (hit 1, anim 3, eff 40) and
+            // then hits 513 and 525 - numbers the consecutive-hit counter never reaches, so the
+            // chain could not fire and nothing reported it.
+            var content = CreateSkillData(skillVNum: 220, name: "Basic Slash",
+                fcombo: "1\t3\t40\t513\t4\t25\t525\t5\t13\t524\t0\t0\t0\t0\t0\t0");
+            CreateTestFile(content);
+
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object,
+                _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
+            await parser.InsertSkillsAsync(_tempFolder);
+
+            var combos = _savedCombos.Where(c => c.SkillVNum == 220).OrderBy(c => c.Hit).ToList();
+            Assert.AreEqual(3, combos.Count);
+
+            Assert.AreEqual(3, combos[0].Hit);
+            Assert.AreEqual(40, combos[0].Animation);
+            Assert.AreEqual(513, combos[0].Effect);
+
+            Assert.AreEqual(4, combos[1].Hit);
+            Assert.AreEqual(25, combos[1].Animation);
+            Assert.AreEqual(525, combos[1].Effect);
+
+            Assert.AreEqual(5, combos[2].Hit);
+            Assert.AreEqual(13, combos[2].Animation);
+            Assert.AreEqual(524, combos[2].Effect);
+
+            Assert.IsTrue(combos.All(c => c.Hit < 10),
+                "a hit number in the hundreds is a triplet read one field early");
+        }
+
+        [TestMethod]
+        public async Task SkillParser_ASkillWithNoChainSavesNoSteps()
+        {
+            // The switch is 0 and every triplet is zero: nothing to save. Guards against the
+            // switch itself being mistaken for a step.
+            CreateTestFile(CreateSkillData(skillVNum: 1, name: "Fireball"));
+
+            var parser = new SkillParser(_bCardDaoMock.Object, _comboDaoMock.Object,
+                _skillDaoMock.Object, NullLoggerFactory.Instance, _logLanguageMock.Object);
+            await parser.InsertSkillsAsync(_tempFolder);
+
+            Assert.AreEqual(0, _savedCombos.Count);
         }
 
         [TestMethod]

--- a/test/NosCore.Parser.Tests/SkillParserTests.cs
+++ b/test/NosCore.Parser.Tests/SkillParserTests.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -125,14 +125,7 @@ namespace NosCore.Parser.Tests
         [TestMethod]
         public async Task SkillParser_ReadsComboTripletsAfterTheSwitch()
         {
-            // The real FCOMBO row of skill 220, "Basic Slash". The leading 1 is the switch that
-            // says the skill has a chain at all; the triplets follow it.
-            //
-            //     FCOMBO 1 | 3 40 513 | 4 25 525 | 5 13 524 | 0 0 0 | 0 0 0
-            //
-            // Counting from the switch instead of after it produced (hit 1, anim 3, eff 40) and
-            // then hits 513 and 525 - numbers the consecutive-hit counter never reaches, so the
-            // chain could not fire and nothing reported it.
+            // Skill 220's real row: the leading 1 is the switch, the triplets follow it.
             var content = CreateSkillData(skillVNum: 220, name: "Basic Slash",
                 fcombo: "1\t3\t40\t513\t4\t25\t525\t5\t13\t524\t0\t0\t0\t0\t0\t0");
             CreateTestFile(content);


### PR DESCRIPTION
The first field of an `FCOMBO` row is **not a step, it is a switch**: 1 when the skill has a combo chain and 0 when it has not — true of all 1958 skills in the file. Five triplets of (hit, animation, effect) follow it, and `AddCombos` counted them from the switch instead of from after it.

```
220 Basic Slash   FCOMBO 1 | 3 40 513 | 4 25 525 | 5 13 524 | 0 0 0 | 0 0 0
read as           (hit 1, anim 3, eff 40), (hit 513, ...), (hit 525, ...)
```

Hit 513 never arrives — the consecutive-hit counter stays in single figures — so the chain could not fire on any of the twenty-one skills that carry one. Nothing reported it: no exception, just the third blow’s special animation that never plays.

The raw row starts at index 2 (field 0 is empty, field 1 is the section name), so the switch sits at 2 and triplet *j* starts at `3 + j*3`.

### Tests

Two. The first parses the real row above and asserts all three steps, ending with a check that no hit number reaches double figures — that is the shape this bug had, and the shape any future off-by-one would have. The second holds a skill with no chain to zero saved steps, so the switch cannot be mistaken for a step again.

Zero warnings, all tests pass.