### PR TITLE
A job-level gate says the job level, not the class

### DIFF
--- a/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
@@ -148,12 +148,16 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
                 }
             }
 
+            // The gate is the job level, and the message said "you do not belong to the required
+            // class" - accusing the one thing that was fine. The class gate is the combined check
+            // above, which sends CanNotWearThat; these two were crossed. The sibling codebase
+            // answers "Your joblevel is too low!" on this same condition.
             if (session.Character.JobLevel < itemInstance.ItemInstance.Item.LevelJobMinimum)
             {
                 await session.SendPacketAsync(new MsgiPacket
                 {
                     Type = MessageType.Default,
-                    Message = Game18NConstString.CanNotBeWornDifferentClass
+                    Message = Game18NConstString.CanNotBeWornLowJobLevel
                 });
                 return;
             }

--- a/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
@@ -148,10 +148,8 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
                 }
             }
 
-            // The gate is the job level, and the message said "you do not belong to the required
-            // class" - accusing the one thing that was fine. The class gate is the combined check
-            // above, which sends CanNotWearThat; these two were crossed. The sibling codebase
-            // answers "Your joblevel is too low!" on this same condition.
+            // The class gate is the combined check above, which sends CanNotWearThat; this one
+            // is the job level and was answering with the class message.
             if (session.Character.JobLevel < itemInstance.ItemInstance.Item.LevelJobMinimum)
             {
                 await session.SendPacketAsync(new MsgiPacket

--- a/test/NosCore.GameObject.Tests/Messaging/Handlers/UseItem/WearHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Messaging/Handlers/UseItem/WearHandlerTests.cs
@@ -134,6 +134,19 @@ namespace NosCore.GameObject.Tests.Messaging.Handlers.UseItem
                 .ExecuteAsync();
         }
 
+        [TestMethod]
+        public async Task LowJobLevelIsRejectedWithTheJobLevelMessage()
+        {
+            await new Spec("An item whose LevelJobMinimum exceeds character.JobLevel is rejected, and the message says so - the class message belongs to the combined gate above")
+                .Given(ItemInInventoryOfType_, ItemType.Specialist)
+                .And(ItemRequiresJobLevel_, (byte)55)
+                .And(CharacterIsJobLevel_, (byte)1)
+                .WhenAsync(UsingTheItem)
+                .Then(LowJobLevelShouldHaveBeenSent)
+                .And(NoDifferentClassPacketSent)
+                .ExecuteAsync();
+        }
+
         private void ItemHasValidTime_(int seconds)
         {
             _item.ItemInstance.Item.ItemValidTime = seconds;
@@ -195,6 +208,32 @@ namespace NosCore.GameObject.Tests.Messaging.Handlers.UseItem
         private void CharacterGenderIs_(GenderType gender)
         {
             _session.Character.Gender = gender;
+        }
+
+        private void ItemRequiresJobLevel_(byte level)
+        {
+            _item.ItemInstance.Item.LevelJobMinimum = level;
+        }
+
+        private void CharacterIsJobLevel_(byte level)
+        {
+            _session.Character.JobLevel = level;
+        }
+
+        private void LowJobLevelShouldHaveBeenSent()
+        {
+            var msg = _session.LastPackets.OfType<MsgiPacket>()
+                .FirstOrDefault(p => p.Message == Game18NConstString.CanNotBeWornLowJobLevel);
+            Assert.IsNotNull(msg);
+        }
+
+        // The failure this guards against sends a real message on the right condition, so it
+        // raises nothing: the player is simply told the wrong reason.
+        private void NoDifferentClassPacketSent()
+        {
+            var msg = _session.LastPackets.OfType<MsgiPacket>()
+                .FirstOrDefault(p => p.Message == Game18NConstString.CanNotBeWornDifferentClass);
+            Assert.IsNull(msg);
         }
 
         private async Task UsingTheItem() => await UsingTheItemWithMode_(1);


### PR DESCRIPTION
The check is `JobLevel < LevelJobMinimum` and the answer was `CanNotBeWornDifferentClass` — "you do not belong to the required class", accusing the one thing that was fine.

The two messages are crossed. The class restriction is part of the combined level/sex/class gate further up, which sends `CanNotWearThat`:

```csharp
if (item.LevelMinimum > ... || (item.Sex != 0 && ...) || (item.Class != 0 && ...))
{
    // -> CanNotWearThat
}
...
if (session.Character.JobLevel < item.LevelJobMinimum)
{
    // -> CanNotBeWornDifferentClass   <- here
}
```

`Game18NConstString.CanNotBeWornLowJobLevel` already exists and was unused. OpenNos answers `LOW_JOB_LVL` ("Your joblevel is too low!") on this same condition.

Where it shows up in play: a Wild Keeper card needs job level 55, and a class change resets the job level to 1 — so the player is told they are the wrong class right after changing class, which is the most misleading moment possible.

The test asserts both halves: the job-level message is sent, and the class message is not. Being wrong here sends a real message on the right condition, so nothing raises — the player is just told the wrong reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the message shown when an item cannot be worn because the character’s job level is too low.
  - Items rejected for insufficient job level no longer display the unrelated class restriction message.

- **Tests**
  - Added coverage to verify the correct message and rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->