### PR TITLE
A mount changes the sprite and nothing else

### DIFF
--- a/src/NosCore.GameObject/Services/SpeedCalculationService/SpeedCalculationService.cs
+++ b/src/NosCore.GameObject/Services/SpeedCalculationService/SpeedCalculationService.cs
@@ -35,14 +35,16 @@ namespace NosCore.GameObject.Services.SpeedCalculationService
 
         public byte CalculateSpeed(ICharacterEntity characterEntity)
         {
-            var defaultSpeed = speedService.GetSpeed(characterEntity.Class);
-            if (characterEntity.VehicleSpeed != null)
+            // IsVehicled and not "VehicleSpeed is not null": the component declares that field as
+            // a plain byte and the interface widens it to byte?, so the null branch could never
+            // be taken - the service answered VehicleSpeed always, which is 0 on foot. Nothing
+            // reported it because nothing called the service at all.
+            if (characterEntity.IsVehicled)
             {
-                return (byte)characterEntity.VehicleSpeed;
-
+                return characterEntity.VehicleSpeed ?? 0;
             }
 
-            return CalculateSpeed(characterEntity, defaultSpeed);
+            return CalculateSpeed(characterEntity, speedService.GetSpeed(characterEntity.Class));
         }
     }
 }

--- a/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
+++ b/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
@@ -31,7 +31,8 @@ namespace NosCore.GameObject.Services.TransformationService
 {
     public class TransformationService(IClock clock, IExperienceService experienceService,
             IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService, ILogger<TransformationService> logger,
-            ILogLanguageLocalizer<LogLanguageKey> logLanguage, IOptions<WorldConfiguration> worldConfiguration)
+            ILogLanguageLocalizer<LogLanguageKey> logLanguage, IOptions<WorldConfiguration> worldConfiguration,
+            SpeedCalculationService.ISpeedCalculationService speedCalculationService)
         : ITransformationService
     {
         public async Task RemoveSpAsync(ClientSession session)
@@ -159,6 +160,11 @@ namespace NosCore.GameObject.Services.TransformationService
             var character = session.Character;
             character.IsVehicled = true;
             character.VehicleSpeed = item.Speed;
+
+            // cond carries Speed, not VehicleSpeed, and Speed is written once at login from
+            // the class table. Without this line the mount changes the sprite and nothing
+            // else: the player rides at walking pace, and no packet or log says otherwise.
+            character.Speed = speedCalculationService.CalculateSpeed(character);
             character.MorphUpgrade = 0;
             character.MorphDesign = 0;
             character.Morph = item.SecondMorph == 0
@@ -201,6 +207,7 @@ namespace NosCore.GameObject.Services.TransformationService
 
             character.IsVehicled = false;
             character.VehicleSpeed = 0;
+            character.Speed = speedCalculationService.CalculateSpeed(character);
 
             var mapInstance = character.MapInstance;
             var condPacket = session.Character.GenerateCond();

--- a/test/NosCore.GameObject.Tests/Services/SpeedCalculationService/SpeedCalculationServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/SpeedCalculationService/SpeedCalculationServiceTests.cs
@@ -57,10 +57,29 @@ namespace NosCore.GameObject.Tests.Services.SpeedCalculationService
 
             var charMock = new Mock<ICharacterEntity>();
             charMock.SetupGet(x => x.Class).Returns(characterClass);
+            // Both, because a mount sets both. Setting only VehicleSpeed described a state that
+            // cannot happen, and the old null check happened to answer it correctly.
+            charMock.SetupGet(x => x.IsVehicled).Returns(true);
             charMock.SetupGet(x => x.VehicleSpeed).Returns(50);
 
             var speed = SpeedCalculationService.CalculateSpeed(charMock.Object);
             Assert.AreEqual(50, speed);
+        }
+
+        // On foot VehicleSpeed is 0, not null - the component declares it as a plain byte. Reading
+        // it whenever it "is not null" therefore answered 0 for everyone, and it went unnoticed
+        // because nothing called this service.
+        [TestMethod]
+        public void OnFootTheVehicleSpeedIsIgnoredRatherThanReturnedAsZero()
+        {
+            SpeedService.Setup(x => x.GetSpeed(CharacterClassType.Archer)).Returns((byte)12);
+
+            var charMock = new Mock<ICharacterEntity>();
+            charMock.SetupGet(x => x.Class).Returns(CharacterClassType.Archer);
+            charMock.SetupGet(x => x.IsVehicled).Returns(false);
+            charMock.SetupGet(x => x.VehicleSpeed).Returns((byte)0);
+
+            Assert.AreEqual(12, SpeedCalculationService.CalculateSpeed(charMock.Object));
         }
 
         [TestMethod]

--- a/test/NosCore.GameObject.Tests/Services/TransformationService/TransformationServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/TransformationService/TransformationServiceTests.cs
@@ -4,6 +4,8 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.GameObject.Ecs.Extensions;
+using NosCore.Algorithm.SpeedService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NosCore.Algorithm.ExperienceService;
@@ -39,7 +41,8 @@ namespace NosCore.GameObject.Tests.Services.TransformationService
                 new Mock<IHeroExperienceService>().Object,
                 Logger,
                 TestHelpers.Instance.LogLanguageLocalizer,
-                TestHelpers.Instance.WorldConfiguration);
+                TestHelpers.Instance.WorldConfiguration,
+                new GameObject.Services.SpeedCalculationService.SpeedCalculationService(new SpeedService()));
         }
 
         [TestMethod]
@@ -60,6 +63,7 @@ namespace NosCore.GameObject.Tests.Services.TransformationService
                 .WhenAsync(ChangingToVehicle)
                 .Then(CharacterShouldBeVehicled)
                 .And(VehicleSpeedShouldBeSet)
+                .And(TheSpeedTheClientSeesIsTheVehicles)
                 .ExecuteAsync();
         }
 
@@ -71,7 +75,23 @@ namespace NosCore.GameObject.Tests.Services.TransformationService
                 .WhenAsync(RemovingVehicle)
                 .Then(CharacterShouldNotBeVehicled)
                 .And(VehicleSpeedShouldBeZero)
+                .And(TheSpeedTheClientSeesIsBackOnFoot)
                 .ExecuteAsync();
+        }
+
+        // VehicleSpeed alone changes nothing the player can feel: `cond` carries Speed, and Speed
+        // was written once at login from the class table. Asserting only VehicleSpeed is what let
+        // a mount that adds no speed look correct.
+        private void TheSpeedTheClientSeesIsTheVehicles()
+        {
+            Assert.AreEqual(20, Session.Character.Speed);
+            Assert.AreEqual(20, Session.Character.GenerateCond().Speed);
+        }
+
+        private void TheSpeedTheClientSeesIsBackOnFoot()
+        {
+            Assert.AreEqual(new SpeedService().GetSpeed(Session.Character.Class),
+                Session.Character.Speed);
         }
 
         private void CharacterHasSpEquipped()

--- a/test/NosCore.PacketHandlers.Tests/Inventory/SpTransformPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Inventory/SpTransformPacketHandlerTests.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Algorithm.SpeedService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NosCore.Algorithm.ExperienceService;
@@ -47,7 +48,8 @@ namespace NosCore.PacketHandlers.Tests.Inventory
             SpTransformPacketHandler = new SpTransformPacketHandler(TestHelpers.Instance.Clock,
                 new TransformationService(TestHelpers.Instance.Clock, new Mock<IExperienceService>().Object,
                     new Mock<IJobExperienceService>().Object, new Mock<IHeroExperienceService>().Object,
-                    new Mock<ILogger<TransformationService>>().Object, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration),
+                    new Mock<ILogger<TransformationService>>().Object, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration,
+                    new NosCore.GameObject.Services.SpeedCalculationService.SpeedCalculationService(new SpeedService())),
                 TestHelpers.Instance.GameLanguageLocalizer);
         }
 


### PR DESCRIPTION
`cond` carries `Speed`, and `Speed` is written once in `CreatePlayer` from the class table and never again. Mounting sets `VehicleSpeed`, which no packet reads — so the player rides at walking pace, and nothing in a log or a packet says so.

### The service for this already exists and nobody calls it

`SpeedCalculationService.CalculateSpeed(ICharacterEntity)` is written to answer exactly this question. `grep` finds no caller anywhere in `src/`.

It is also wrong where it matters:

```csharp
if (characterEntity.VehicleSpeed != null)   // can never be false
{
    return (byte)characterEntity.VehicleSpeed;
}
```

`PlayerStateComponent` declares `VehicleSpeed` as a plain `byte`; `ICharacterEntity` widens it to `byte?`. The null branch is unreachable, so wired as written the service would have returned `0` for everyone on foot. Nothing reported it because nothing called it.

It now keys off `IsVehicled`, and the mount and dismount paths call it.

### The existing test was green for the wrong reason

`VehicleSpeedOverridesDefaultSpeed` set `VehicleSpeed` and left `IsVehicled` at its mock default of `false` — a state a mount never produces. The impossible null check happened to answer it correctly. It now sets both, and a second case covers being on foot with `VehicleSpeed` at 0.

The transformation tests assert the number the client actually receives (`GenerateCond().Speed`), not just `VehicleSpeed`: asserting only the latter is what let a mount that adds no speed look correct.

### Not in this PR

`CalculateSpeed`'s bonus is a commented-out `bonusSpeed = 0` left from upstream, so the movement BCards still do nothing. That is a separate change.