### PR TITLE
The guaranteed hit and the guaranteed dodge

### DIFF
--- a/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
@@ -214,6 +214,7 @@ public sealed class BattleStatsProvider(
         int moraleFlat = 0;
         int resistAll = 0, resistFire = 0, resistWater = 0, resistLight = 0, resistDark = 0;
         int elementAll = 0, elementFire = 0, elementWater = 0, elementLight = 0, elementDark = 0;
+        int guaranteedHit = 0, guaranteedDodge = 0;
 
         foreach (var source in CardSources(buffs, equipment))
         {
@@ -288,6 +289,22 @@ public sealed class BattleStatsProvider(
                         if (sub == (byte)AdditionalTypes.Morale.MoraleIncreased) moraleFlat += first;
                         else if (sub == (byte)AdditionalTypes.Morale.MoraleDecreased) moraleFlat -= first;
                         break;
+                    // Type 16. The file gives X1 and X2 the same sentence, so the second slot
+                    // carries no meaning of its own and both add - and in the data no skill
+                    // declares one with a negative value anyway.
+                    case BCardType.CardType.GuarantedDodgeRangedAttack:
+                        if (sub is (byte)AdditionalTypes.GuarantedDodgeRangedAttack.AttackHitChance
+                            or (byte)AdditionalTypes.GuarantedDodgeRangedAttack.AttackHitChanceNegated)
+                        {
+                            guaranteedHit += first;
+                        }
+                        else if (sub is (byte)AdditionalTypes.GuarantedDodgeRangedAttack.AlwaysDodgePropability
+                            or (byte)AdditionalTypes.GuarantedDodgeRangedAttack.AlwaysDodgePropabilityNegated)
+                        {
+                            guaranteedDodge += first;
+                        }
+
+                        break;
                     case BCardType.CardType.Element:
                         if (sub == (byte)AdditionalTypes.Element.AllIncreased) elementAll += first;
                         else if (sub == (byte)AdditionalTypes.Element.AllDecreased) elementAll -= first;
@@ -361,6 +378,8 @@ public sealed class BattleStatsProvider(
             LightResistance = stats.LightResistance + resistAll + resistLight,
             DarkResistance = stats.DarkResistance + resistAll + resistDark,
             ElementRate = stats.ElementRate + elementFlatBonus,
+            GuaranteedHitChance = stats.GuaranteedHitChance + guaranteedHit,
+            GuaranteedDodgeChance = stats.GuaranteedDodgeChance + guaranteedDodge,
         };
     }
 

--- a/src/NosCore.GameObject/Services/BattleService/DamageCalculator.cs
+++ b/src/NosCore.GameObject/Services/BattleService/DamageCalculator.cs
@@ -43,19 +43,40 @@ public sealed class DamageCalculator(IRandomProvider random) : IDamageCalculator
         // Dodge phase: only melee/ranged skills can miss. Magicians never dodge.
         if ((skill.Type == 0 || skill.Type == 1) && attacker.Class != CharacterClassType.Mage)
         {
-            var dodgeMultiplier = Math.Min(5.0, context.MonsterDodge / (double)(context.MainHitRate + 1));
-            // Cubic-fit dodge chance from OpenNos: approximates a sharp rise after the
-            // attacker's hit rate falls behind the defender's dodge by ~2x.
-            var chance = Math.Max(1.0,
-                -0.25 * Math.Pow(dodgeMultiplier, 3)
-                - 0.57 * Math.Pow(dodgeMultiplier, 2)
-                + 25.3 * dodgeMultiplier
-                - 1.41);
+            // Type 16 overrides this roll from both sides: subtype 11 on the attacker is "there
+            // is a %s%% chance that every attack hits", subtype 21 on the defender is "always
+            // dodge the target with a probability of %s%%".
+            //
+            // THE ORDER IS OURS, NOT THE FILE'S. When both are present and both roll, one has to
+            // win, and nothing in BCard.dat says which: the attacker's guarantee goes first
+            // because its sentence is the unconditional one. A rare intersection - subtype 21
+            // appears on no skill at all, only on cards - but it had to be decided rather than
+            // left to the order of two ifs.
+            var alwaysHits = attacker.GuaranteedHitChance > 0
+                && random.NextDouble() * 100 <= attacker.GuaranteedHitChance;
 
-            // RNG returns [0,100). A dodge lands if roll <= chance (chance is percent).
-            if (random.NextDouble() * 100 <= chance)
+            if (!alwaysHits)
             {
-                return new DamageResult(0, SuPacketHitMode.Miss);
+                if (defender.GuaranteedDodgeChance > 0
+                    && random.NextDouble() * 100 <= defender.GuaranteedDodgeChance)
+                {
+                    return new DamageResult(0, SuPacketHitMode.Miss);
+                }
+
+                var dodgeMultiplier = Math.Min(5.0, context.MonsterDodge / (double)(context.MainHitRate + 1));
+                // Cubic-fit dodge chance from OpenNos: approximates a sharp rise after the
+                // attacker's hit rate falls behind the defender's dodge by ~2x.
+                var chance = Math.Max(1.0,
+                    -0.25 * Math.Pow(dodgeMultiplier, 3)
+                    - 0.57 * Math.Pow(dodgeMultiplier, 2)
+                    + 25.3 * dodgeMultiplier
+                    - 1.41);
+
+                // RNG returns [0,100). A dodge lands if roll <= chance (chance is percent).
+                if (random.NextDouble() * 100 <= chance)
+                {
+                    return new DamageResult(0, SuPacketHitMode.Miss);
+                }
             }
         }
 

--- a/src/NosCore.GameObject/Services/BattleService/DamageCalculator.cs
+++ b/src/NosCore.GameObject/Services/BattleService/DamageCalculator.cs
@@ -64,8 +64,8 @@ public sealed class DamageCalculator(IRandomProvider random) : IDamageCalculator
                 }
 
                 var dodgeMultiplier = Math.Min(5.0, context.MonsterDodge / (double)(context.MainHitRate + 1));
-                // Cubic-fit dodge chance from OpenNos: approximates a sharp rise after the
-                // attacker's hit rate falls behind the defender's dodge by ~2x.
+                // Cubic fit: the chance rises sharply once the attacker's hit rate falls behind
+                // the defender's dodge by about twice.
                 var chance = Math.Max(1.0,
                     -0.25 * Math.Pow(dodgeMultiplier, 3)
                     - 0.57 * Math.Pow(dodgeMultiplier, 2)

--- a/src/NosCore.GameObject/Services/BattleService/Model/CombatStats.cs
+++ b/src/NosCore.GameObject/Services/BattleService/Model/CombatStats.cs
@@ -56,4 +56,7 @@ public readonly record struct CombatStats(
     int EnemyFireResistance = 0,
     int EnemyWaterResistance = 0,
     int EnemyLightResistance = 0,
-    int EnemyDarkResistance = 0);
+    int EnemyDarkResistance = 0,
+    // Type 16: overrides of the ordinary dodge roll, both as a percentage.
+    int GuaranteedHitChance = 0,
+    int GuaranteedDodgeChance = 0);

--- a/test/NosCore.GameObject.Tests/Services/BattleService/GuaranteedHitAndDodgeTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/GuaranteedHitAndDodgeTests.cs
@@ -1,0 +1,141 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.Data.Enumerations.Battle;
+using NosCore.Data.StaticEntities;
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NosCore.GameObject.Services.BattleService;
+using NosCore.GameObject.Services.BattleService.Model;
+using NosCore.Packets.Enumerations;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // Type 16 of BCard.dat, the two subtypes that override the ordinary dodge roll:
+    //
+    //   11: "There is a %s%% chance that every attack hits."     232 of 253 skill declarations
+    //   21: "Always dodge the target with a probability of %s%%."  none on skills, 44 on cards
+    //
+    // Getting either one backwards raises nothing: combat carries on and the numbers drift.
+    [TestClass]
+    public class GuaranteedHitAndDodgeTests
+    {
+        private Mock<IRandomProvider> _random = null!;
+        private DamageCalculator _calculator = null!;
+
+        // A defender built to dodge nearly always, so an attack that lands can only have landed
+        // because the guarantee overrode the roll.
+        private static CombatStats Defender(int guaranteedDodge = 0) => new()
+        {
+            Level = 1,
+            DefenceDodge = 5000,
+            DistanceDefenceDodge = 5000,
+            GuaranteedDodgeChance = guaranteedDodge
+        };
+
+        private static CombatStats Attacker(int guaranteedHit = 0) => new()
+        {
+            Level = 50,
+            Class = CharacterClassType.Swordsman,
+            MinHit = 100,
+            MaxHit = 100,
+            HitRate = 1,
+            Morale = 50,
+            GuaranteedHitChance = guaranteedHit
+        };
+
+        private static SkillInfo Skill(byte type) => new(
+            SkillVnum: 1, CastId: 1, Cooldown: 0, AttackAnimation: 0, CastEffect: 0, Effect: 0,
+            Type: type, HitType: TargetHitType.SingleTargetHit, Range: 0, TargetRange: 0,
+            TargetType: 0, Element: 0, Duration: 0, MpCost: 0, BCards: Array.Empty<BCardDto>());
+
+        private static SkillInfo Melee => Skill(0);
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _random = new Mock<IRandomProvider>();
+            // Every roll comes back 0, which is under any threshold - the ordinary dodge
+            // chance has a floor of 1% - so the ordinary dodge always fires unless something
+            // skips it. That is what makes a landed hit here proof of an override.
+            _random.Setup(r => r.NextDouble()).Returns(0);
+            _random.Setup(r => r.Next(It.IsAny<int>(), It.IsAny<int>())).Returns(0);
+            _calculator = new DamageCalculator(_random.Object);
+        }
+
+        [TestMethod]
+        public void WithoutTheGuaranteeThisDefenderDodges()
+        {
+            var result = _calculator.Calculate(Attacker(), Defender(), Melee);
+
+            Assert.AreEqual(SuPacketHitMode.Miss, result.HitMode);
+        }
+
+        [TestMethod]
+        public void AGuaranteedHitBeatsADefenderThatWouldAlwaysDodge()
+        {
+            var result = _calculator.Calculate(Attacker(guaranteedHit: 100), Defender(), Melee);
+
+            Assert.AreNotEqual(SuPacketHitMode.Miss, result.HitMode);
+            Assert.IsTrue(result.Damage > 0);
+        }
+
+        // Zero must not read as "always". The percentage is summed from the active effects, so
+        // the common case is nobody carrying one at all.
+        [TestMethod]
+        public void AZeroChanceGuaranteeDoesNothing()
+        {
+            var result = _calculator.Calculate(Attacker(guaranteedHit: 0), Defender(), Melee);
+
+            Assert.AreEqual(SuPacketHitMode.Miss, result.HitMode);
+        }
+
+        // This one needs a high roll, not the class default: the ordinary dodge chance has a
+        // floor of 1%, so with a roll of 0 even a defender with no dodge at all still dodges,
+        // and there would be no "would otherwise be hit" to compare against.
+        [TestMethod]
+        public void AGuaranteedDodgeMissesADefenderThatWouldOtherwiseBeHit()
+        {
+            var random = new Mock<IRandomProvider>();
+            random.Setup(r => r.NextDouble()).Returns(0.99);
+            var calculator = new DamageCalculator(random.Object);
+            var wideOpen = new CombatStats { Level = 1, DefenceDodge = 0, DistanceDefenceDodge = 0 };
+
+            var landed = calculator.Calculate(Attacker(), wideOpen, Melee);
+            Assert.AreNotEqual(SuPacketHitMode.Miss, landed.HitMode, "setup: this one should land");
+
+            var dodged = calculator.Calculate(Attacker(),
+                wideOpen with { GuaranteedDodgeChance = 100 }, Melee);
+
+            Assert.AreEqual(SuPacketHitMode.Miss, dodged.HitMode);
+        }
+
+        // The order is ours and not the file's, so it gets a test rather than a comment alone:
+        // with both at 100 the attacker's guarantee wins.
+        [TestMethod]
+        public void WhenBothFireTheAttackersGuaranteeWins()
+        {
+            var result = _calculator.Calculate(
+                Attacker(guaranteedHit: 100), Defender(guaranteedDodge: 100), Melee);
+
+            Assert.AreNotEqual(SuPacketHitMode.Miss, result.HitMode);
+        }
+
+        // A mage's attacks never enter the dodge phase, so neither guarantee applies there.
+        [TestMethod]
+        public void AMagicSkillIsUntouchedByEither()
+        {
+            var mage = Attacker() with { Class = CharacterClassType.Mage };
+
+            var result = _calculator.Calculate(mage, Defender(guaranteedDodge: 100),
+                Skill(2));
+
+            Assert.AreNotEqual(SuPacketHitMode.Miss, result.HitMode);
+        }
+    }
+}


### PR DESCRIPTION
BCard type 16, the two subtypes that override the ordinary dodge roll:

```
11: There is a %s%% chance that every attack hits.
21: Always dodge the target with a probability of %s%%.
```

**232 of the 253 declarations on skills are subtype 11**, and not one of them carries a negative value, so the X2 slots never appear there — and the file gives X1 and X2 the same sentence anyway, so both add rather than cancelling. Subtype 21 is on no skill at all; its 44 declarations live on cards.

Two fields on `CombatStats`, folded from the active effects the same way as everything else, and read in the dodge phase of `DamageCalculator`.

### One decision is ours, not the file's

When both are present and both roll, one has to win, and nothing in `BCard.dat` says which. The attacker's guarantee goes first, because its sentence is the unconditional one. Rather than leave that to the order of two `if`s and a comment, it has a test.

### Left out, with the reason

- **31**, "no penalty for ranged attacks at close range": the penalty it would lift never fires. `Chebyshev()` in `DamageCalculator` returns `int.MaxValue` because `CombatStats` carries no position, so the close-range branch is unreachable. Removing a penalty that does not apply is not worth the code, and the dead penalty is its own question.
- **41** (damage rising with distance) and **51** (fairy damage per debuff) need distance and fairy state that are not in `CombatStats` either.

### Checked by breaking it

Disabling the guaranteed hit fails two tests; disabling the guaranteed dodge fails one. One of the tests needed a high roll rather than the class default, because the ordinary dodge chance has a floor of 1% — with a roll of 0 even a defender with no dodge at all still dodges, and there would have been no "would otherwise be hit" to compare against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guaranteed-hit and guaranteed-dodge combat effects from applicable buff cards.
  * Attacks with guaranteed hit now bypass dodge checks.
  * Guaranteed dodge effects can force attacks to miss before standard dodge calculations.
  * When both effects apply, guaranteed hit takes precedence.
  * Magic skills remain unaffected by these effects.

* **Tests**
  * Added coverage for guaranteed effects, standard dodging, precedence rules, zero-value modifiers, and magic skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->