### PR TITLE
Damage as a percentage of HP, which the case did not read

### DIFF
--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -4,9 +4,6 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
-using NosCore.Data.Enumerations.Buff;
-using NosCore.Data.StaticEntities;
-using System.Collections.Generic;
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;

--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -200,19 +200,14 @@ public sealed class HitQueue(
     /// skills are this subtype, and the case was not read at all.
     /// </summary>
     /// <remarks>
-    /// ONE ASSUMPTION IS OURS, and it is the same one the sibling codebase carries so the two do
-    /// not drift: the percentage is taken from MAXIMUM HP. The file says only "HP by %s%%" and
-    /// does not distinguish, and on current HP the loss would halve and halve again without ever
-    /// finishing anything - which is not what a skill declaring 90% is for.
+    /// The percentage is taken from maximum HP. The file says only "HP by %s%%"; off current HP
+    /// the loss would halve and halve again without ever finishing anything, which is not what a
+    /// skill declaring 90% is for.
     ///
-    /// Subtype 32 hits the caster instead, and no skill in the file declares it; it is left out
-    /// rather than written blind against no data.
+    /// Subtype 32 hits the caster instead and no skill declares it, so it is left out.
     ///
-    /// It can kill, and that is a deliberate difference from the sibling codebase, which floors
-    /// the victim at 1 HP. That floor is a workaround for where the effect runs there - outside
-    /// the blow, so a kill would bypass the death sequence. Here the loss is part of the same
-    /// subtraction as the blow itself, so the ordinary path handles the death, and nothing in the
-    /// file says the effect must leave its victim standing.
+    /// The loss can kill: it is part of the same subtraction as the blow, so the ordinary death
+    /// path handles it and nothing says the effect must leave its victim standing.
     /// </remarks>
     private static int PercentageHpLoss(IAliveEntity target, IReadOnlyList<BCardDto> bCards)
     {

--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -4,6 +4,9 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Data.StaticEntities;
+using System.Collections.Generic;
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
@@ -132,7 +135,8 @@ public sealed class HitQueue(
                 return;
             }
 
-            var newHp = target.Hp - damage.Damage;
+            // Damage proportional to HP rather than to the stats, on top of the blow.
+            var newHp = target.Hp - damage.Damage - PercentageHpLoss(target, request.Skill.BCards);
             var overkill = 0;
             var killed = false;
             if (newHp <= 0)
@@ -189,6 +193,44 @@ public sealed class HitQueue(
             logger.LogError(ex, "Failed to apply hit to entity {Handle}", request.Target.Handle);
             request.Completion.TrySetException(ex);
         }
+    }
+
+    /// <summary>
+    /// Type 37 subtype 31: "Decreases the opponent's HP by %s%%." 112 of the 122 declarations on
+    /// skills are this subtype, and the case was not read at all.
+    /// </summary>
+    /// <remarks>
+    /// ONE ASSUMPTION IS OURS, and it is the same one the sibling codebase carries so the two do
+    /// not drift: the percentage is taken from MAXIMUM HP. The file says only "HP by %s%%" and
+    /// does not distinguish, and on current HP the loss would halve and halve again without ever
+    /// finishing anything - which is not what a skill declaring 90% is for.
+    ///
+    /// Subtype 32 hits the caster instead, and no skill in the file declares it; it is left out
+    /// rather than written blind against no data.
+    ///
+    /// It can kill, and that is a deliberate difference from the sibling codebase, which floors
+    /// the victim at 1 HP. That floor is a workaround for where the effect runs there - outside
+    /// the blow, so a kill would bypass the death sequence. Here the loss is part of the same
+    /// subtraction as the blow itself, so the ordinary path handles the death, and nothing in the
+    /// file says the effect must leave its victim standing.
+    /// </remarks>
+    private static int PercentageHpLoss(IAliveEntity target, IReadOnlyList<BCardDto> bCards)
+    {
+        var loss = 0;
+        for (var i = 0; i < bCards.Count; i++)
+        {
+            var bCard = bCards[i];
+            if ((BCardType.CardType)bCard.Type != BCardType.CardType.RecoveryAndDamagePercent
+                || bCard.SubType != (byte)AdditionalTypes.RecoveryAndDamagePercent.DecreaseEnemyHp
+                || bCard.FirstData <= 0)
+            {
+                continue;
+            }
+
+            loss += target.MaxHp * bCard.FirstData / 100;
+        }
+
+        return loss;
     }
 
     private static void FlipIsAlive(IAliveEntity entity, bool alive)

--- a/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
@@ -214,8 +214,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             Assert.AreEqual(499, target.Hp);
         }
 
-        // It goes through the ordinary death rather than being floored short of it, which is
-        // where this deliberately differs from the sibling codebase.
+        // It goes through the ordinary death rather than being floored short of it.
         [TestMethod]
         public async Task ThePercentageDamageCanKillAndTheDeathIsTheOrdinaryOne()
         {

--- a/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Data.Enumerations.Buff;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -142,6 +143,116 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             Assert.AreEqual(HitStatus.Missed, outcome.Status);
             Assert.AreEqual(100, target.Hp);
             Assert.AreEqual(0, target.HitList.Count);
+        }
+
+        // --- Type 37 subtype 31, "Decreases the opponent's HP by %s%%" ----------------------
+        //
+        // 112 of the 122 declarations on skills are this subtype, and the case was not read at
+        // all. The percentage comes off MAXIMUM HP - our assumption, stated in the code, because
+        // the file says only "HP by %s%%". These pin it: read off current HP every number below
+        // changes, and nothing would raise.
+
+        private static BCardDto PercentOfHp(short percent) => new()
+        {
+            Type = (byte)BCardType.CardType.RecoveryAndDamagePercent,
+            SubType = (byte)AdditionalTypes.RecoveryAndDamagePercent.DecreaseEnemyHp,
+            FirstData = percent
+        };
+
+        private static HitQueue QueueDealing(int ordinaryDamage)
+        {
+            var calc = new Mock<IDamageCalculator>();
+            calc.Setup(c => c.Calculate(It.IsAny<CombatStats>(), It.IsAny<CombatStats>(), It.IsAny<SkillInfo>()))
+                .Returns(new DamageResult(ordinaryDamage, SuPacketHitMode.SuccessAttack));
+            var stats = new Mock<IBattleStatsProvider>();
+            stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
+            return new HitQueue(calc.Object, stats.Object, new Mock<IBuffService>().Object,
+                new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
+        }
+
+        [TestMethod]
+        public async Task ThePercentageComesOffTheMaximumAndNotTheCurrentHp()
+        {
+            // Half of the maximum is 500. Off the current 600 it would be 300, and the target
+            // would end at 290 instead of 90.
+            var target = new FakeBattleEntity { Hp = 600, MaxHp = 1000 };
+            var attacker = new FakeBattleEntity();
+
+            await QueueDealing(10).EnqueueAsync(Request(attacker, target) with
+            {
+                Skill = MakeSkill() with { BCards = new[] { PercentOfHp(50) } }
+            });
+
+            Assert.AreEqual(90, target.Hp);
+        }
+
+        [TestMethod]
+        public async Task WithoutTheEffectOnlyTheOrdinaryDamageLands()
+        {
+            var target = new FakeBattleEntity { Hp = 600, MaxHp = 1000 };
+            var attacker = new FakeBattleEntity();
+
+            await QueueDealing(10).EnqueueAsync(Request(attacker, target) with { Skill = MakeSkill() });
+
+            Assert.AreEqual(590, target.Hp);
+        }
+
+        // Two slots on one skill add up: the loop must not stop at the first.
+        [TestMethod]
+        public async Task TwoDeclarationsOnOneSkillBothCount()
+        {
+            var target = new FakeBattleEntity { Hp = 1000, MaxHp = 1000 };
+            var attacker = new FakeBattleEntity();
+
+            // One point of ordinary damage, not zero: a blow that rolls zero is already a miss
+            // by the guard above, and the percentage rides along with a blow that landed.
+            await QueueDealing(1).EnqueueAsync(Request(attacker, target) with
+            {
+                Skill = MakeSkill() with { BCards = new[] { PercentOfHp(20), PercentOfHp(30) } }
+            });
+
+            Assert.AreEqual(499, target.Hp);
+        }
+
+        // It goes through the ordinary death rather than being floored short of it, which is
+        // where this deliberately differs from the sibling codebase.
+        [TestMethod]
+        public async Task ThePercentageDamageCanKillAndTheDeathIsTheOrdinaryOne()
+        {
+            var target = new FakeBattleEntity { Hp = 200, MaxHp = 1000 };
+            var attacker = new FakeBattleEntity();
+
+            var outcome = await QueueDealing(1).EnqueueAsync(Request(attacker, target) with
+            {
+                Skill = MakeSkill() with { BCards = new[] { PercentOfHp(90) } }
+            });
+
+            Assert.AreEqual(0, target.Hp);
+            Assert.IsTrue(outcome.Killed);
+            Assert.IsFalse(target.IsAlive);
+        }
+
+        // Subtype 32 hits the caster, and no skill in the file declares it. Reading it here would
+        // take the HP off the wrong entity.
+        [TestMethod]
+        public async Task TheSelfInflictedSubtypeIsNotReadAsIfItHitTheTarget()
+        {
+            var target = new FakeBattleEntity { Hp = 1000, MaxHp = 1000 };
+            var attacker = new FakeBattleEntity();
+            var selfInflicted = new BCardDto
+            {
+                Type = (byte)BCardType.CardType.RecoveryAndDamagePercent,
+                SubType = (byte)AdditionalTypes.RecoveryAndDamagePercent.DecreaseSelfHp,
+                FirstData = 50
+            };
+
+            await QueueDealing(1).EnqueueAsync(Request(attacker, target) with
+            {
+                Skill = MakeSkill() with { BCards = new[] { selfInflicted } }
+            });
+
+            // Only the ordinary point of damage: the self-inflicted subtype took nothing here.
+            Assert.AreEqual(999, target.Hp);
         }
 
         private static HitRequest Request(IAliveEntity attacker, IAliveEntity target) => new(


### PR DESCRIPTION
BCard type 37 subtype 31 — *"Decreases the opponent's HP by %s%%."*

**112 of the 122 declarations on skills are this one subtype**, and nothing read it: the skills carrying it did none of what they declare. The percentages in the file run from 5% to 100%, with 90% appearing twelve times — these are boss skills meant to take most of a health bar in one blow.

### One assumption is ours

The percentage comes off **maximum** HP. The file says only "HP by %s%%" and does not distinguish, so this is the one point that does not come from it. Off current HP the loss would halve and halve again without ever finishing anything, which is not what a skill declaring 90% is for.

It is the same assumption the sibling codebase already carries, so the two do not drift.

### One difference from the sibling, on purpose

It can kill. The loss is part of the same subtraction as the blow, so the ordinary death path handles it.

The sibling floors the victim at 1 HP, but that is a workaround for *where* it applies the effect — outside the blow, where a kill would bypass the death sequence. Here that does not arise, and nothing in the file says the effect must leave its victim standing.

### Left out

Subtype 32 hits the caster instead, and no skill in the file declares it. Written blind against no data it would be a guess, so it is not here.

### Checked by breaking it

Reading the percentage off current HP instead of maximum fails two of the five tests. One test also documents an existing guard I ran into: a blow whose ordinary damage rolls to zero is already treated as a miss, so the percentage rides along with a blow that landed rather than standing on its own.