### PR TITLE
What the attacker does to the defender's resistances

### DIFF
--- a/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
@@ -170,6 +170,7 @@ public sealed class BattleStatsProvider(IBuffService buffService) : IBattleStats
         int critInflicting = 0, critDamage = 0;
         int defenceAll = 0, defenceMelee = 0, defenceRanged = 0, defenceMagical = 0;
         int hitRateFlat = 0, dodgeFlat = 0;
+        int foeAll = 0, foeFire = 0, foeWater = 0, foeLight = 0, foeDark = 0;
         int moraleFlat = 0;
         int elementAll = 0, elementFire = 0, elementWater = 0, elementLight = 0, elementDark = 0;
 
@@ -219,6 +220,21 @@ public sealed class BattleStatsProvider(IBuffService buffService) : IBattleStats
                         else if (sub == (byte)AdditionalTypes.Defence.MagicalIncreased) defenceMagical += first;
                         else if (sub == (byte)AdditionalTypes.Defence.MagicalDecreased) defenceMagical -= first;
                         break;
+                    // Type 14, and the mirror of type 13: that one is the resistance of whoever
+                    // is being hit, this is what the one hitting does to it. Both end up in the
+                    // same subtraction in ComputeElementalDamage.
+                    case BCardType.CardType.EnemyElementResistance:
+                        if (sub == (byte)AdditionalTypes.EnemyElementResistance.AllIncreased) foeAll += first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.AllDecreased) foeAll -= first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.FireIncreased) foeFire += first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.FireDecreased) foeFire -= first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.WaterIncreased) foeWater += first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.WaterDecreased) foeWater -= first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.LightIncreased) foeLight += first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.LightDecreased) foeLight -= first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.DarkIncreased) foeDark += first;
+                        else if (sub == (byte)AdditionalTypes.EnemyElementResistance.DarkDecreased) foeDark -= first;
+                        break;
                     case BCardType.CardType.Target:
                         if (sub == (byte)AdditionalTypes.Target.AllHitRateIncreased) hitRateFlat += first;
                         else if (sub == (byte)AdditionalTypes.Target.AllHitRateDecreased) hitRateFlat -= first;
@@ -265,6 +281,10 @@ public sealed class BattleStatsProvider(IBuffService buffService) : IBattleStats
             MaxHit = (int)((stats.MaxHit + attackAllFlat + attackMeleeFlat) * (1 + (damageAllPct + damageMeleePct) / 100.0)),
             MinDistance = (int)((stats.MinDistance + attackAllFlat + attackRangedFlat) * (1 + (damageAllPct + damageRangedPct) / 100.0)),
             MaxDistance = (int)((stats.MaxDistance + attackAllFlat + attackRangedFlat) * (1 + (damageAllPct + damageRangedPct) / 100.0)),
+            EnemyFireResistance = stats.EnemyFireResistance + foeAll + foeFire,
+            EnemyWaterResistance = stats.EnemyWaterResistance + foeAll + foeWater,
+            EnemyLightResistance = stats.EnemyLightResistance + foeAll + foeLight,
+            EnemyDarkResistance = stats.EnemyDarkResistance + foeAll + foeDark,
             HitRate = stats.HitRate + hitRateFlat,
             DistanceRate = stats.DistanceRate + hitRateFlat,
             CriticalChance = stats.CriticalChance + critInflicting,

--- a/src/NosCore.GameObject/Services/BattleService/DamageCalculator.cs
+++ b/src/NosCore.GameObject/Services/BattleService/DamageCalculator.cs
@@ -242,12 +242,14 @@ public sealed class DamageCalculator(IRandomProvider random) : IDamageCalculator
         var attackElement = attacker.Element;
         var elementalBoost = ElementalBoost[Math.Min(attackElement, (byte)4), Math.Min(defender.Element, (byte)4)];
 
+        // The defender's own resistance, plus what the attacker does to it (type 14). A
+        // "reduces the enemy's fire resistance by 20" arrives as -20, so the two simply add.
         var monsterResistance = attackElement switch
         {
-            1 => defender.FireResistance,
-            2 => defender.WaterResistance,
-            3 => defender.LightResistance,
-            4 => defender.DarkResistance,
+            1 => defender.FireResistance + attacker.EnemyFireResistance,
+            2 => defender.WaterResistance + attacker.EnemyWaterResistance,
+            3 => defender.LightResistance + attacker.EnemyLightResistance,
+            4 => defender.DarkResistance + attacker.EnemyDarkResistance,
             _ => 0,
         };
 

--- a/src/NosCore.GameObject/Services/BattleService/Model/CombatStats.cs
+++ b/src/NosCore.GameObject/Services/BattleService/Model/CombatStats.cs
@@ -49,4 +49,11 @@ public readonly record struct CombatStats(
     int FireResistance,
     int WaterResistance,
     int LightResistance,
-    int DarkResistance);
+    int DarkResistance,
+    // Type 14: what the ATTACKER does to the defender's resistances. Carried by the attacker and
+    // read against the defender's own, so a "reduces the enemy's fire resistance by 20" arrives
+    // here as -20 and the damage step adds the two together.
+    int EnemyFireResistance = 0,
+    int EnemyWaterResistance = 0,
+    int EnemyLightResistance = 0,
+    int EnemyDarkResistance = 0);

--- a/test/NosCore.GameObject.Tests/Services/BattleService/EnemyElementResistanceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/EnemyElementResistanceTests.cs
@@ -1,0 +1,185 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.Data.Enumerations.Buff;
+using NodaTime;
+using System.Collections.Generic;
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NosCore.Data.Enumerations.Battle;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Services.BattleService;
+using NosCore.GameObject.Services.BattleService.Model;
+using NosCore.Shared.Enumerations;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // BCard type 14, "Changes enemy's resistances": 210 declarations, and the mirror of type 13.
+    // That one is the resistance of whoever is being hit; this is what the one hitting does to
+    // it, so it is carried by the attacker and read against the defender's own number.
+    //
+    // Getting the sign backwards would make resistance-piercing effects protect the target
+    // instead, and nothing would report it - the fight goes on, the numbers are just wrong.
+    [TestClass]
+    public class EnemyElementResistanceTests
+    {
+        private static DamageCalculator Calculator()
+        {
+            var random = new Mock<IRandomProvider>();
+            // High roll: the ordinary dodge chance has a floor of 1%, so a low one would make
+            // every attack miss and there would be no damage to compare.
+            random.Setup(r => r.NextDouble()).Returns(0.99);
+            random.Setup(r => r.Next(It.IsAny<int>(), It.IsAny<int>())).Returns(0);
+            return new DamageCalculator(random.Object);
+        }
+
+        // Element 1 is fire on both sides, so the elemental step actually runs.
+        private static CombatStats Attacker(int enemyFireResistance = 0) => new()
+        {
+            Level = 50,
+            Class = CharacterClassType.Swordsman,
+            MinHit = 200,
+            MaxHit = 200,
+            HitRate = 5000,
+            Morale = 50,
+            Element = 1,
+            ElementRate = 100,
+            EnemyFireResistance = enemyFireResistance
+        };
+
+        private static CombatStats Defender(int fireResistance) => new()
+        {
+            Level = 1,
+            Element = 2,
+            FireResistance = fireResistance
+        };
+
+        // The skill has to declare the element too, and the same one as the attacker:
+        // ComputeElementalDamage returns zero otherwise, and every number below would be
+        // identical for a reason that has nothing to do with resistances.
+        private static SkillInfo Melee => new(
+            SkillVnum: 1, CastId: 1, Cooldown: 0, AttackAnimation: 0, CastEffect: 0, Effect: 0,
+            Type: 0, HitType: TargetHitType.SingleTargetHit, Range: 0, TargetRange: 0,
+            TargetType: 0, Element: 1, Duration: 0, MpCost: 0, BCards: Array.Empty<BCardDto>());
+
+        [TestMethod]
+        public void PiercingTheResistanceDoesMoreDamageThanNotPiercingIt()
+        {
+            var calculator = Calculator();
+
+            var plain = calculator.Calculate(Attacker(), Defender(50), Melee).Damage;
+            var piercing = calculator.Calculate(Attacker(enemyFireResistance: -30), Defender(50), Melee).Damage;
+
+            Assert.IsTrue(piercing > plain,
+                $"piercing 30 of the 50 should hurt more: {piercing} against {plain}");
+        }
+
+        // The sign is the whole point. A positive value raises the enemy's resistance, which is
+        // what subtypes 11 to 51 say, and it must not be read as piercing.
+        [TestMethod]
+        public void RaisingTheEnemysResistanceDoesLessDamage()
+        {
+            var calculator = Calculator();
+
+            var plain = calculator.Calculate(Attacker(), Defender(20), Melee).Damage;
+            var hardened = calculator.Calculate(Attacker(enemyFireResistance: 30), Defender(20), Melee).Damage;
+
+            Assert.IsTrue(hardened < plain,
+                $"raising it by 30 should hurt less: {hardened} against {plain}");
+        }
+
+        // It adds to the defender's own rather than replacing it: a defender with no resistance
+        // and an attacker that pierces nothing must land exactly the same blow either way.
+        [TestMethod]
+        public void WithNeitherSideDeclaringAnythingNothingChanges()
+        {
+            var calculator = Calculator();
+
+            var withoutTheField = calculator.Calculate(Attacker(), Defender(0), Melee).Damage;
+            var withZero = calculator.Calculate(Attacker(enemyFireResistance: 0), Defender(0), Melee).Damage;
+
+            Assert.AreEqual(withoutTheField, withZero);
+        }
+
+        // Only the attacker's own element is looked up, so a water-piercing effect leaves a fire
+        // attack alone.
+        // --- the fold, not only what reads it -------------------------------------------------
+        //
+        // The four tests above set the field by hand, so they say nothing about the step that
+        // fills it: folding the water value into the fire field would leave them all green.
+
+        private static CombatStats FoldOf(AdditionalTypes.EnemyElementResistance subType, short value)
+        {
+            var monster = new NpcMonsterDto();
+            var entity = new Mock<INonPlayableEntity>();
+            entity.SetupGet(e => e.NpcMonster).Returns(monster);
+            entity.SetupGet(e => e.Level).Returns((byte)1);
+            entity.SetupGet(e => e.HeroLevel).Returns((byte)0);
+
+            var buffs = new Mock<IBuffService>();
+            buffs.Setup(b => b.GetActiveBuffs(It.IsAny<IAliveEntity>())).Returns(new List<BuffInstance>
+            {
+                new(CardId: 1, BuffType: BuffType.Bad, Caster: null,
+                    StartedAt: Instant.MinValue, ExpiresAt: Instant.MaxValue,
+                    BCards: new[]
+                    {
+                        new BCardDto
+                        {
+                            Type = (byte)BCardType.CardType.EnemyElementResistance,
+                            SubType = (byte)subType,
+                            FirstData = value
+                        }
+                    })
+            });
+
+            return new BattleStatsProvider(buffs.Object).GetStats(entity.Object);
+        }
+
+        [TestMethod]
+        public void EachElementLandsInItsOwnField()
+        {
+            var fire = FoldOf(AdditionalTypes.EnemyElementResistance.FireDecreased, 20);
+
+            Assert.AreEqual(-20, fire.EnemyFireResistance);
+            Assert.AreEqual(0, fire.EnemyWaterResistance, "only fire was named");
+            Assert.AreEqual(0, fire.EnemyLightResistance);
+            Assert.AreEqual(0, fire.EnemyDarkResistance);
+        }
+
+        [TestMethod]
+        public void TheAllSubtypeReachesEveryElement()
+        {
+            var all = FoldOf(AdditionalTypes.EnemyElementResistance.AllDecreased, 15);
+
+            Assert.AreEqual(-15, all.EnemyFireResistance);
+            Assert.AreEqual(-15, all.EnemyWaterResistance);
+            Assert.AreEqual(-15, all.EnemyLightResistance);
+            Assert.AreEqual(-15, all.EnemyDarkResistance);
+        }
+
+        [TestMethod]
+        public void TheIncreasingSubtypeKeepsItsSign()
+        {
+            var hardened = FoldOf(AdditionalTypes.EnemyElementResistance.WaterIncreased, 12);
+
+            Assert.AreEqual(12, hardened.EnemyWaterResistance);
+        }
+
+        [TestMethod]
+        public void OnlyTheElementBeingAttackedWithIsRead()
+        {
+            var calculator = Calculator();
+
+            var plain = calculator.Calculate(Attacker(), Defender(50), Melee).Damage;
+            var wrongElement = calculator.Calculate(
+                Attacker() with { EnemyWaterResistance = -50 }, Defender(50), Melee).Damage;
+
+            Assert.AreEqual(plain, wrongElement);
+        }
+    }
+}


### PR DESCRIPTION
BCard type 14, *"Changes enemy's resistances"* — **210 declarations**, and the mirror of type 13 in #2307. That one is the resistance of whoever is being hit; this is what the one hitting does to it, so it rides on the attacker and is read against the defender's own number.

```
11: Increases the enemy's elemental resistances by %s.
12: Reduces the enemy's elemental resistances by %s.
21..52: the same, one element at a time.
```

A *"reduces by 20"* folds to `-20`, so the damage step simply adds the two. The sign is the whole point: read backwards, resistance-piercing effects would protect the target instead, and nothing would report it — the fight goes on and the numbers are just wrong.

Written on the fold rather than beside the equipment, so the 194 declarations on items arrive with no further work once the worn pieces' BCards reach the same place.

### The tests needed a second layer

Four of the seven go through the damage step with the field set by hand. A mutation that folded the *water* value into the *fire* field left all four green — so three more go through `BattleStatsProvider` itself. Testing the new code and not the step that fills it is a hole I had pointed out to me on #2304 earlier today.

Flipping the sign fails two; folding the wrong element fails one.

### One known conflict, and it is trivial

This conflicts with **#2305** on `CombatStats.cs`, and only there. Both PRs add optional parameters to the same positional record, and C# requires those to come last — so both insertions land at the same point and git cannot merge them. The resolution is *keep both blocks*; nothing has to be decided.

I checked every other pair among my open PRs with `git merge-tree` (36 combinations) and this is the only one left.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Elemental resistance increases and reductions from active buffs now affect combat damage calculations.
  * Added support for fire, water, light, dark, and all-element resistance modifiers.
  * Resistance modifiers are applied only to matching attack elements.

* **Bug Fixes**
  * Improved handling of resistance-piercing and resistance-increasing effects, including zero-value and sign behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->