### PR TITLE
Pushes, pulls and charges, which nothing read

### DIFF
--- a/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
+++ b/src/NosCore.Data/Enumerations/Buff/AdditionalTypes.cs
@@ -791,12 +791,18 @@ namespace NosCore.Data.Enumerations.Buff
             PetTrainerExperienceNegated = 52
         }
 
+        /// <summary>
+        /// 21-22 is a pull and not a taunt, whatever "focus" suggested. The file says "Draws
+        /// enemies to %s fields away from you", the value is a distance of 0 to 4, and the
+        /// skills carrying it are called Drawing Shot, Rotating Hammer and Spider King's Draw.
+        /// A taunt would have no distance to declare.
+        /// </summary>
         public enum SpecialActions : byte
         {
             PushBack = 11,
             PushBackNegated = 12,
-            FocusEnemies = 21,
-            FocusEnemiesNegated = 22,
+            DrawEnemies = 21,
+            DrawEnemiesNegated = 22,
             Charge = 31,
             ChargeNegated = 32,
             RunAway = 41,

--- a/src/NosCore.GameObject/Services/BattleService/ForcedMovement.cs
+++ b/src/NosCore.GameObject/Services/BattleService/ForcedMovement.cs
@@ -1,0 +1,59 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+
+namespace NosCore.GameObject.Services.BattleService;
+
+/// <summary>
+/// The geometry behind BCard type 40: a push, a pull, a charge. All three walk an entity along
+/// a line, and all three have to stop before the first wall.
+/// </summary>
+public static class ForcedMovement
+{
+    /// <summary>
+    /// Where the walk ends: the geometry on its own, with no entity and no map behind it.
+    /// </summary>
+    /// <remarks>
+    /// Separated out because this is the part that can be wrong in a way nobody notices - a step
+    /// too many puts somebody inside a wall, a step too few makes a charge stop short - and
+    /// because the part around it can only move a real ECS bundle, so a test double would never
+    /// budge and would prove nothing.
+    /// </remarks>
+    public static (short X, short Y) Destination(short fromX, short fromY, short towardsX,
+        short towardsY, int steps, int stepX, int stepY, int stopAt,
+        Func<short, short, bool> isWalkable)
+    {
+        var x = fromX;
+        var y = fromY;
+        var closingIn = stepX == Math.Sign(towardsX - fromX) && stepY == Math.Sign(towardsY - fromY);
+
+        for (var i = 0; i < steps; i++)
+        {
+            if (closingIn && Chebyshev(x, y, towardsX, towardsY) <= stopAt)
+            {
+                break;
+            }
+
+            var nextX = (short)(x + stepX);
+            var nextY = (short)(y + stepY);
+
+            // Zero is walkable and anything else is wall - the grid reads the opposite way round
+            // from the obvious one.
+            if (!isWalkable(nextX, nextY))
+            {
+                break;
+            }
+
+            x = nextX;
+            y = nextY;
+        }
+
+        return (x, y);
+    }
+    private static int Chebyshev(short ax, short ay, short bx, short by) =>
+        Math.Max(Math.Abs(ax - bx), Math.Abs(ay - by));
+}

--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -5,15 +5,20 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Arch.Core;
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Data.StaticEntities;
 using NosCore.GameObject.Ecs;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Services.BattleService.Model;
 using NosCore.GameObject.Infastructure;
+using NosCore.Networking;
 using NosCore.Packets.Enumerations;
+using NosCore.Packets.ServerPackets.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.BattleService;
@@ -98,21 +103,23 @@ public sealed class HitQueue(
         }
     }
 
-    private Task TryApplyHit(HitRequest request)
+    // async because the effects a blow carries are awaited below: they have to follow the
+    // blow, not race it.
+    private async Task TryApplyHit(HitRequest request)
     {
         try
         {
             if (request.Cancellation.IsCancellationRequested)
             {
                 request.Completion.TrySetResult(new HitOutcome(HitStatus.Cancelled, 0, SuPacketHitMode.SuccessAttack, false));
-                return Task.CompletedTask;
+                return;
             }
 
             var target = request.Target;
             if (!target.IsAlive)
             {
                 request.Completion.TrySetResult(new HitOutcome(HitStatus.Cancelled, 0, SuPacketHitMode.SuccessAttack, false));
-                return Task.CompletedTask;
+                return;
             }
 
             var attackerStats = statsProvider.GetStats(request.Origin);
@@ -122,7 +129,7 @@ public sealed class HitQueue(
             if (damage.HitMode == SuPacketHitMode.Miss || damage.Damage <= 0)
             {
                 request.Completion.TrySetResult(new HitOutcome(HitStatus.Missed, 0, damage.HitMode, false));
-                return Task.CompletedTask;
+                return;
             }
 
             var newHp = target.Hp - damage.Damage;
@@ -141,6 +148,15 @@ public sealed class HitQueue(
                 // setters only sync what's assigned), so we flip it explicitly here to keep
                 // IAliveEntity.IsAlive honest for subsequent attackers and packet fields.
                 FlipIsAlive(target, false);
+            }
+
+            // A push, a pull or a charge, if the skill declares one. Before the hit list
+            // below rather than after it: the credit for the blow does not depend on where
+            // anybody ended up, but a later reader will expect the position to be settled.
+            if (!killed)
+            {
+                await ApplySpecialActionsAsync(request.Skill.BCards, request.Origin, target)
+                    .ConfigureAwait(false);
             }
 
             // Track contribution per attacker so reward distribution can weight by
@@ -173,7 +189,6 @@ public sealed class HitQueue(
             logger.LogError(ex, "Failed to apply hit to entity {Handle}", request.Target.Handle);
             request.Completion.TrySetException(ex);
         }
-        return Task.CompletedTask;
     }
 
     private static void FlipIsAlive(IAliveEntity entity, bool alive)
@@ -191,6 +206,126 @@ public sealed class HitQueue(
         while (channel.Reader.TryRead(out var pending))
         {
             pending.Completion.TrySetResult(new HitOutcome(HitStatus.Cancelled, 0, SuPacketHitMode.SuccessAttack, false));
+        }
+    }
+
+    /// <summary>
+    /// Type 40, "Special Actions". Three of its subtypes are used by the game's skills, and all
+    /// three move somebody:
+    ///
+    ///     11: Push your opponent back %s fields.          49 declarations
+    ///     21: Draws enemies to %s fields away from you.    64
+    ///     31: Charge at enemies within %s fields.          21
+    /// </summary>
+    /// <remarks>
+    /// SUBTYPE 21 IS A PULL, not a taunt. The value is a distance - 0 to 4 across the file, and
+    /// 0 means "up against you" - and the skills carrying it are called Drawing Shot, Rotating
+    /// Hammer and Spider King's Draw. A taunt would have nothing to do with a number of fields.
+    ///
+    /// THE RULE FOR ALL THREE IS THE SAME: walk cell by cell and stop in front of the first
+    /// obstacle. Jumping straight to the destination would put somebody inside a wall or past the
+    /// edge of the map, and from there they cannot get out - the client and the server would
+    /// disagree about where they are.
+    ///
+    /// Subtypes 41 "Run Away!" and 51 "Hide" are declared by no skill in the file and are not
+    /// written here: there is nothing to check them against.
+    /// </remarks>
+    private async Task ApplySpecialActionsAsync(IReadOnlyList<BCardDto> bCards, IAliveEntity origin,
+        IAliveEntity target)
+    {
+        for (var i = 0; i < bCards.Count; i++)
+        {
+            var bCard = bCards[i];
+            if ((BCardType.CardType)bCard.Type != BCardType.CardType.SpecialActions)
+            {
+                continue;
+            }
+
+            var fields = Math.Max(0, (int)bCard.FirstData);
+            switch ((AdditionalTypes.SpecialActions)bCard.SubType)
+            {
+                // The target slides backwards along the line joining it to whoever struck.
+                case AdditionalTypes.SpecialActions.PushBack:
+                    await SlideAsync(target, origin.MapX, origin.MapY, Math.Max(1, fields),
+                        away: true, stopAt: 0).ConfigureAwait(false);
+                    break;
+
+                // The target is drawn in until it is `fields` away from the caster.
+                case AdditionalTypes.SpecialActions.DrawEnemies:
+                    await SlideAsync(target, origin.MapX, origin.MapY, int.MaxValue,
+                        away: false, stopAt: fields).ConfigureAwait(false);
+                    break;
+
+                // The caster closes on the target and stops beside it.
+                case AdditionalTypes.SpecialActions.Charge:
+                    await SlideAsync(origin, target.MapX, target.MapY, Math.Max(1, fields),
+                        away: false, stopAt: 1).ConfigureAwait(false);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks <paramref name="entity" /> one cell at a time along the line to (towardsX, towardsY),
+    /// for at most <paramref name="steps" /> cells, stopping before the first wall and never
+    /// closing nearer than <paramref name="stopAt" /> cells.
+    /// </summary>
+    private static async Task SlideAsync(IAliveEntity entity, short towardsX, short towardsY,
+        int steps, bool away, int stopAt)
+    {
+        var map = entity.MapInstance?.Map;
+        if (map == null)
+        {
+            return;
+        }
+
+        // The step is the sign of the difference, so it runs diagonally when both coordinates
+        // differ - the same way everything else in the game moves.
+        var stepX = Math.Sign(entity.MapX - towardsX);
+        var stepY = Math.Sign(entity.MapY - towardsY);
+        if (!away)
+        {
+            stepX = -stepX;
+            stepY = -stepY;
+        }
+
+        if (stepX == 0 && stepY == 0)
+        {
+            return;
+        }
+
+        var (x, y) = ForcedMovement.Destination(entity.MapX, entity.MapY, towardsX, towardsY, steps, stepX, stepY,
+            stopAt, map.IsWalkable);
+
+        if ((x == entity.MapX && y == entity.MapY) || !TryPlace(entity, x, y))
+        {
+            return;
+        }
+
+        // The client has to be told, or it goes on drawing the entity where it was and the two
+        // sides stop agreeing about who is within reach of what.
+        if (entity.MapInstance != null)
+        {
+            await entity.MapInstance.SendPacketAsync(new TpPacket
+            {
+                VisualType = entity.VisualType,
+                VisualId = entity.VisualId,
+                X = x,
+                Y = y,
+            }).ConfigureAwait(false);
+        }
+    }
+
+    // The position lives on a component, and only the concrete bundles can write it - the
+    // interface exposes it read-only. Same shape as FlipIsAlive below.
+    private static bool TryPlace(IAliveEntity entity, short x, short y)
+    {
+        switch (entity)
+        {
+            case PlayerComponentBundle p: p.PositionX = x; p.PositionY = y; return true;
+            case MonsterComponentBundle m: m.PositionX = x; m.PositionY = y; return true;
+            case NpcComponentBundle n: n.PositionX = x; n.PositionY = y; return true;
+            default: return false;
         }
     }
 }

--- a/test/NosCore.GameObject.Tests/Services/BattleService/ForcedMovementTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/ForcedMovementTests.cs
@@ -1,0 +1,114 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.GameObject.Services.BattleService;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // BCard type 40. Three of its subtypes are used by the game's skills, and all three move
+    // somebody:
+    //
+    //   11: Push your opponent back %s fields.        49 declarations
+    //   21: Draws enemies to %s fields away from you.  64
+    //   31: Charge at enemies within %s fields.        21
+    //
+    // The risk is not that they fail to work. It is that they work too well - that somebody ends
+    // up inside a wall or off the edge of the map, where they cannot get out and where the client
+    // and the server stop agreeing about where they are.
+    //
+    // These drive the geometry on its own. The part around it can only move a real ECS bundle, so
+    // a test double would never budge and would prove nothing.
+    [TestClass]
+    public class ForcedMovementTests
+    {
+        // Eight wide, six high, clear except a vertical wall at x = 5. Off the grid is wall too,
+        // the way the real map reads it.
+        private static bool Walkable(short x, short y) =>
+            x >= 0 && x < 8 && y >= 0 && y < 6 && x != 5;
+
+        private static (short X, short Y) Push(short fromX, short fromY, short awayFromX,
+            short awayFromY, int fields) =>
+            ForcedMovement.Destination(fromX, fromY, awayFromX, awayFromY, fields,
+                Math.Sign(fromX - awayFromX), Math.Sign(fromY - awayFromY), 0, Walkable);
+
+        private static (short X, short Y) Draw(short fromX, short fromY, short towardsX,
+            short towardsY, int stopAt) =>
+            ForcedMovement.Destination(fromX, fromY, towardsX, towardsY, int.MaxValue,
+                Math.Sign(towardsX - fromX), Math.Sign(towardsY - fromY), stopAt, Walkable);
+
+        [TestMethod]
+        public void APushSlidesTheTargetTheOtherWayFromWhoStruck()
+        {
+            // Attacker at (1,2), target at (2,2), pushed one field: away is +x.
+            Assert.AreEqual((3, 2), Push(2, 2, 1, 2, 1));
+        }
+
+        [TestMethod]
+        public void APushGoesTheWholeDistanceWhenNothingIsInTheWay()
+        {
+            Assert.AreEqual((4, 2), Push(1, 2, 0, 2, 3));
+        }
+
+        // The one that matters. A push of ten fields into a wall at x=5 must stop at 4, not walk
+        // through it and not stop short of it.
+        [TestMethod]
+        public void APushStopsInFrontOfTheWallInsteadOfCrossingIt()
+        {
+            Assert.AreEqual((4, 2), Push(1, 2, 0, 2, 10));
+        }
+
+        [TestMethod]
+        public void APushStopsAtTheEdgeOfTheMap()
+        {
+            // Pushed towards -x from (2,3): the edge is at 0, and -1 is not walkable.
+            Assert.AreEqual((0, 3), Push(2, 3, 3, 3, 10));
+        }
+
+        [TestMethod]
+        public void APushRunsDiagonallyWhenBothCoordinatesDiffer()
+        {
+            Assert.AreEqual((3, 4), Push(2, 3, 1, 2, 1));
+        }
+
+        // "Draws enemies to %s fields away from you": the target closes in until it is that far,
+        // and no nearer. Twenty-five of the sixty-four declarations say zero.
+        [TestMethod]
+        public void ADrawBringsTheTargetToTheDistanceTheFileNames()
+        {
+            Assert.AreEqual((2, 2), Draw(4, 2, 0, 2, 2));
+        }
+
+        [TestMethod]
+        public void ADrawOfZeroBringsTheTargetRightUp()
+        {
+            Assert.AreEqual((1, 2), Draw(4, 2, 1, 2, 0));
+        }
+
+        // A pull is stopped by a wall like everything else. The target at (6,2) cannot be drawn
+        // past the wall at x=5, so it does not move at all.
+        [TestMethod]
+        public void ADrawCannotPullSomebodyThroughAWall()
+        {
+            Assert.AreEqual((6, 2), Draw(6, 2, 1, 2, 1));
+        }
+
+        [TestMethod]
+        public void ADrawWithNothingBetweenGoesAllTheWay()
+        {
+            Assert.AreEqual((2, 2), Draw(4, 2, 1, 2, 1));
+        }
+
+        // Standing on top of the other one already: no step, and no packet either.
+        [TestMethod]
+        public void NobodyMovesWhenThereIsNowhereToGo()
+        {
+            Assert.AreEqual((4, 2), Draw(4, 2, 4, 2, 0));
+        }
+
+    }
+}


### PR DESCRIPTION
BCard type 40. Three of its subtypes are used by the game's skills — **134 declarations** between them — and all three move somebody:

```
11: Push your opponent back %s fields.         49
21: Draws enemies to %s fields away from you.  64
31: Charge at enemies within %s fields.        21
```

### Subtype 21 is a pull, not a taunt

The enum called it `FocusEnemies`. The file says *"Draws enemies to %s fields away from you"*, the value is a **distance** — 0 to 4 across the whole file, and 25 of the 64 say zero, which is "up against you" — and the skills carrying it are named **Drawing Shot**, **Rotating Hammer** and **Spider King's Draw**.

A taunt has nothing to do with a number of fields. Renamed to `DrawEnemies`.

### The rule is the same for all three

Walk cell by cell and stop in front of the first obstacle. Jumping to the destination would put somebody inside a wall or past the edge of the map, and from there they cannot get out — the client and the server would stop agreeing about where they are.

The geometry is its own class rather than a private method, for two reasons: it is the part that can be wrong quietly (a step too many puts you in a wall, a step too few makes a charge stop short), and the part around it can only move a real ECS bundle — the position lives on a component and the interface exposes it read-only, so a test double would never budge and would prove nothing.

### Left out, with the reason

Subtypes 41 *"Run Away!"* and 51 *"Hide"* are declared by no skill in the file. There would be nothing to check an implementation against.

### Checked by breaking it

Ignoring the wall fails three tests; stopping one cell short of the named distance fails three.

`TryApplyHit` becomes `async`, the same change #2304 makes for the same reason — I gave both the identical comment so the two merge cleanly rather than colliding on a difference that means nothing.
