### PR TITLE
The last percentage division without a guard

### DIFF
--- a/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/PlayerBundleExtensions.cs
@@ -770,8 +770,12 @@ public static class PlayerBundleExtensions
             VisualId = player.VisualId,
             Level = player.Level,
             HeroLvl = player.HeroLevel,
-            HpPercentage = (int)(player.Hp / (float)player.MaxHp * 100),
-            MpPercentage = (int)(player.Mp / (float)player.MaxMp * 100),
+            // Guarded the way the rest of the file guards it. A maximum of zero is not a
+            // state the game reaches today, but the division is on floats: it does not
+            // throw, it yields NaN, and the cast then puts a meaningless number in the two
+            // fields the client draws as the health and mana bars.
+            HpPercentage = player.MaxHp > 0 ? (int)(player.Hp / (float)player.MaxHp * 100) : 100,
+            MpPercentage = player.MaxMp > 0 ? (int)(player.Mp / (float)player.MaxMp * 100) : 100,
             CurrentHp = player.Hp,
             CurrentMp = player.Mp,
             MaxHp = player.MaxHp,

--- a/test/NosCore.GameObject.Tests/Ecs/Extensions/StatInfoPercentageTests.cs
+++ b/test/NosCore.GameObject.Tests/Ecs/Extensions/StatInfoPercentageTests.cs
@@ -1,0 +1,76 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.GameObject.Ecs.Extensions;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.Tests.Shared;
+
+namespace NosCore.GameObject.Tests.Ecs.Extensions
+{
+    // The two percentages in `st` are the health and mana bars the client draws.
+    //
+    // Every other place that computes them guards the maximum first; GenerateStatInfo was the one
+    // that did not. It never threw and never would: the division is on floats, so a maximum of
+    // zero yields NaN and the cast puts a meaningless number in the packet. Nothing in a log, and
+    // a bar that reads as whatever that number happened to be.
+    [TestClass]
+    public class StatInfoPercentageTests
+    {
+        private ClientSession _session = null!;
+
+        [TestInitialize]
+        public async Task SetupAsync()
+        {
+            await TestHelpers.ResetAsync();
+            _session = await TestHelpers.Instance.GenerateSessionAsync();
+        }
+
+        [TestMethod]
+        public void WithARealMaximumThePercentagesAreTheOrdinaryOnes()
+        {
+            _session.Character.MaxHp = 1000;
+            _session.Character.Hp = 250;
+            _session.Character.MaxMp = 400;
+            _session.Character.Mp = 400;
+
+            var packet = _session.Character.GenerateStatInfo();
+
+            Assert.AreEqual(25, packet.HpPercentage);
+            Assert.AreEqual(100, packet.MpPercentage);
+        }
+
+        [TestMethod]
+        public void AZeroMaximumDoesNotPutNonsenseInTheBar()
+        {
+            _session.Character.MaxHp = 0;
+            _session.Character.Hp = 0;
+            _session.Character.MaxMp = 0;
+            _session.Character.Mp = 0;
+
+            var packet = _session.Character.GenerateStatInfo();
+
+            // The value matters less than the fact that it is a value: unguarded, the cast of a
+            // NaN gives whatever the platform gives, and the assertion below would be a coin toss.
+            Assert.AreEqual(100, packet.HpPercentage);
+            Assert.AreEqual(100, packet.MpPercentage);
+        }
+
+        // The same packet built by the same call for the same character has to agree with the
+        // guarded computation the rest of the file uses.
+        [TestMethod]
+        public void ItAgreesWithTheGuardedComputationElsewhere()
+        {
+            _session.Character.MaxHp = 777;
+            _session.Character.Hp = 111;
+
+            var packet = _session.Character.GenerateStatInfo();
+
+            Assert.AreEqual((int)(111 / 777f * 100), packet.HpPercentage);
+        }
+    }
+}


### PR DESCRIPTION
`GenerateStatInfo` divides by `MaxHp` and `MaxMp` with nothing checking them, while every other place that computes the same two percentages checks first — including one five hundred lines up **in the same file**:

```csharp
// PlayerBundleExtensions.cs:238
Hp = player.MaxHp > 0 ? (int)(player.Hp / (float)player.MaxHp * 100) : 100,

// PlayerBundleExtensions.cs:773
HpPercentage = (int)(player.Hp / (float)player.MaxHp * 100),
```

It never threw and never would. The division is on floats, so a maximum of zero gives `NaN` rather than an exception, and the cast then puts a meaningless number in the two fields the client draws as the health and mana bars. No log, no symptom to search for.

### I swept the rest rather than fixing only what I tripped over

Every other float division of this shape in `src/` is guarded:

| | |
|---|---|
| `AliveEntityExtension` 102-106 | `MaxHp > 0 ? … : 100` |
| `MonsterBundleExtensions` 33 | `MaxHp > 0 ? … : 100` |
| `NpcBundleExtensions` 33 | `MaxHp > 0 ? … : 100` |
| `VisualEntityExtension` 36 | `?? 1` |
| `PlayerBundleExtensions` 238-239 | `MaxHp > 0 ? … : 100` |
| `DamageCalculator.RollBaseDamage` | returns early on `max <= min` |
| `RewardService` 98 | caller returns on `totalDamage <= 0` |

`GenerateStatInfo` was the only one left.

The fallback of 100 is the one the guarded computation in the same file already uses, rather than inventing a second convention for the same question.

Removing the guard fails one of the three tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented health and mana displays from showing invalid values when their maximum is zero.
  - Zero-maximum stats now display as 100% instead of causing an invalid calculation.
  - Preserved the existing percentage calculations for stats with valid maximum values.

- **Tests**
  - Added coverage for normal percentages, zero-maximum handling, and consistency with guarded calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->