### PR TITLE
docs: add CLAUDE.md and a manual in-game test plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,5 +126,16 @@ applies pending migrations on startup.
 
 ## Manual verification
 
-`documentation/manual-test-plan.md` lists what has to be checked in a running client,
-because a good deal of this project is only observable there.
+Much of this project is only observable in a running client. Automated tests cover the
+arithmetic; they do not tell you whether a bar moved or a monster walked.
+
+**Read `documentation/manual-test-plan.md` whenever a change touches gameplay** — combat,
+stats, movement, equipment, skills, monsters or the character — and quote the relevant
+checks back when handing the work over, so there is a concrete list to run rather than a
+vague "test it in game".
+
+**Add to that file when you add a gameplay feature.** If a change genuinely cannot be
+observed from the client — it guards an unreachable state, or it is data waiting on
+behaviour that is not wired yet — say so in its "Not verifiable yet" section instead of
+inventing steps. Never claim a gameplay change is verified on the strength of unit tests
+alone; say what was tested and what still needs a client.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,64 @@
 # NosCore
 
 A NosTale server reimplementation. .NET 10, EF Core 10 + Npgsql + NodaTime, Autofac,
-Arch.Core ECS, Wolverine for messaging, source generators, warnings-as-errors.
+Arch.Core ECS, Wolverine for messaging, source generators, `TreatWarningsAsErrors`.
+
+---
+
+## Code conventions
+
+### Comments are the exception, not the default
+
+Write **no comment** unless the *why* cannot be inferred from names and types. When one is
+genuinely needed, a line or two. These all get removed in review:
+
+- restating what the code already says
+- narrative essays about how a bug was found, what it cost, or how many declarations exist
+- provenance — where a number came from, which other project does it differently
+- `ONE ASSUMPTION IS OURS`-style emphasis, block capitals, rhetorical structure
+
+A comment earns its place by answering a question the reader would otherwise have to go
+digging for. `// Array.Empty so "nothing worn" compares equal to None.` is worth a line.
+Three paragraphs on why a table might be wrong are not.
+
+Do not describe *what changed* — that is the commit message's job, and it goes stale the
+moment someone else edits the file.
+
+### English only
+
+Code, comments, commit messages, PR bodies, test names. Non-English text has reached
+review more than once and always comes back.
+
+### No BOM
+
+`.cs` files have no UTF-8 BOM. Editors add them silently on save; check before pushing:
+
+```bash
+for f in $(git diff --name-only origin/master...HEAD | grep '\.cs$'); do
+  [ "$(head -c 3 "$f" | xxd -p)" = "efbbbf" ] && echo "BOM: $f"
+done
+```
+
+`.resx` files in this repo are inconsistent already — leave those alone.
+
+### Keep semantic types
+
+Do not flatten a `bool` or an enum to a number because the wire value happens to be `0`
+or `1`. The serializer handles the conversion; the type is what makes the call site
+readable.
+
+### Ship only what is wired
+
+No placeholder enums, tabs, buttons or handlers for behaviour that does not exist. A
+reference screenshot or a `.dat` column is not a specification — wire-status is. If
+something is deliberately empty, that has to be the point (see
+`NosCore.PacketHandlers/NoAction/`, which is no-op by design).
+
+### Versions are real
+
+A new project starts at `0.0.1`. Do not label unshipped work `v2.1`.
+
+---
 
 ## Where things belong
 
@@ -21,10 +78,6 @@ rather than the right one is the most common reason a PR is sent back.
 | `NosCore.PathFinder` | `c:\dev\NosCore.PathFinder` | Brushfire, flow field, jump point search |
 | `NosCore.Analyzers` | — | Roslyn analyzers |
 
-Editing a sibling checkout does **not** affect this build. It needs a release: branch → PR →
-merge → tag `X.Y.Z` → wait for nuget.org indexing → bump `Directory.Packages.props` here.
-A change spanning packages is a chain, not a PR.
-
 `NosCore.Algorithm` already owns `CloseDefence`, `Damage`, `Dignity`, `DistanceDefence`,
 `DistanceDodge`, `Dodge`, `Experience`, `FairyExperience`, `FamilyExperience`,
 `HeroExperience`, `HitRate`, `Hp`, `JobExperience`, `MagicDefence`, `MateExperience`, `Mp`,
@@ -32,7 +85,7 @@ A change spanning packages is a chain, not a PR.
 **If a number is a curve or a stat formula it belongs there**, as `I<Thing>Service` +
 `<Thing>Service`, with the level ceiling in `Constants.cs` and an approval table in
 `test/NosCore.Algorithm.Tests/DocumentationTest.cs`. Do not hand-roll a lookup table in
-`NosCore.GameObject`.
+`NosCore.GameObject` — that has been reviewed out twice.
 
 ### Projects in this repo
 
@@ -45,17 +98,28 @@ A change spanning packages is a chain, not a PR.
 | `NosCore.Parser` | `.dat` ingestion and documentation generation | — |
 | `NosCore.Core` | Shared infrastructure | — |
 
+`NosCore.Data` being data-only and `NosCore.GameObject` holding the logic is deliberate,
+not an accident to be tidied up.
+
 ### Deciding, in order
 
 1. A **wire shape** — field order, separator, sentinel? → `NosCore.Packets`, and a packet
    trace is the only acceptable evidence.
 2. A **number that scales with level or a stat**? → `NosCore.Algorithm`.
 3. The **meaning of a `.dat` column or a BCard subtype**? → an enum in `NosCore.Data`,
-   wired by `NosCore.Parser`. `.dat` data belongs in the database, not in a generated C#
-   table.
+   wired by `NosCore.Parser`. `.dat` data belongs in the database, **not** in a generated
+   C# table checked into the repo — a table cannot be regenerated when the client updates.
 4. **Behaviour** — what happens when an effect fires? → a service in `NosCore.GameObject`.
 5. A **player-facing string**? → a `LanguageKey` plus every `.resx` under
    `NosCore.Data/Resource/`, never a literal.
+
+### Schema changes
+
+Additive where possible. When a value's source changes, rewire the parser rather than
+dropping or renaming existing columns. Expand a `.dat` bitmask into one boolean column per
+flag — never store the raw mask as a single aggregate column.
+
+---
 
 ## Research sources, and the rule about them
 
@@ -65,7 +129,8 @@ descending order of trust:
 1. **The client `.dat` files** (`C:\Users\erwan\Desktop\parser`) — authoritative. The
    matching `_code_<lang>_<File>.txt` language files carry the human-readable description
    of each row; pair them to learn what a subtype actually does.
-2. **Packet traces** — authoritative for the wire.
+2. **Packet traces** — authoritative for the wire. A trace outranks any other
+   implementation's packet class.
 3. **nosapki.com** — a live game database, reliable for anything player-facing, and the
    right way to check a table before trusting it. Watch whether "Level N" means *at* N or
    *to leave* N, and whether its table runs further than yours.
@@ -78,7 +143,7 @@ descending order of trust:
 **Never name these sources in code, comments, commit messages or PR bodies.** Describe
 NosCore's behaviour in its own terms. Euphemisms count — "the sibling codebase", "the older
 emulators", "the reference implementation" are the same violation and have all been sent
-back in review. Referencing the `.dat` files or a trace is fine; they are project input.
+back. Referencing the `.dat` files or a trace is fine; they are project input.
 
 If a number is doubtful, record the doubt without its provenance:
 
@@ -88,41 +153,71 @@ If a number is doubtful, record the doubt without its provenance:
 ```
 
 One contradicted row means re-check the whole table — it is rarely a single bad
-transcription.
+transcription. Check the table's *length* too; inherited tables are often truncated at an
+old level cap.
 
-## Conventions
+The `nostale-reference-mining` skill covers the full method.
 
-- **Comments are the exception.** Default to none. Write one only when the *why* cannot be
-  inferred from names and types, and keep it to a line or two. Long narrative blocks,
-  provenance essays and restating what the code says are all removed in review.
-- **English only**, in code, comments and commit messages.
-- **No UTF-8 BOM** on `.cs` files. Editors add them silently; strip before pushing.
+---
+
+## Git workflow
+
 - **Never commit to `master`.** Branch, PR, CI green, then merge — including one-line
   chores.
-- **Rebase, never merge.** Linear history. `git rebase origin/master`, force-with-lease on
-  push.
-- Keep semantic types. Do not flatten a `bool` or an enum to a number because the wire
-  value happens to be `0`/`1`; the serializer handles the conversion.
-- Schema changes are additive where possible. Expand a `.dat` bitmask into one boolean
-  column per flag rather than storing the raw mask.
+- **Rebase, never merge.** Linear history. `git rebase origin/master`, `--force-with-lease`
+  on push. Never `git merge origin/master` into a branch, and never `git pull` on a feature
+  branch without `--rebase`.
+- Base new work on `origin/master`. Keep iterating on the same feature branch rather than
+  opening a new one per follow-up.
+- Opening a PR is fine unprompted. **Wait for the go-ahead before merging**, unless the
+  request already covers it.
+- After merging anything that changes a shared signature, **re-check the other open PRs**.
+  Git merges text, not meaning: adding a required constructor parameter compiles fine on
+  its own branch and breaks every branch that constructs the type.
 
-## Build and test
+---
+
+## Build, test, troubleshoot
 
 ```bash
 dotnet build NosCore.sln
 dotnet test NosCore.sln
 ```
 
-Source generators live in `tools/NosCore.DtoGenerator` (DTOs from entities) and
-`tools/NosCore.EcsGenerator` (ECS bundles). Both pin Roslyn via `VersionOverride` because a
-generator must target the oldest compiler it runs on — do not let them float to the central
-`Microsoft.CodeAnalysis` version.
+- **Source generators** live in `tools/NosCore.DtoGenerator` (DTOs from entities) and
+  `tools/NosCore.EcsGenerator` (ECS bundles). Both pin Roslyn with `VersionOverride`,
+  because a generator must target the *oldest* compiler it runs on. Do not let them float
+  to the central `Microsoft.CodeAnalysis` version — that produces `CS9057` and breaks every
+  build using the generator.
+- **Migrations**: `dotnet ef migrations add <Name> --project src/NosCore.Database`. Never
+  hand-write the Designer files.
+- **The parser** is interactive by default; `--folder <path>` for a non-interactive run. It
+  applies pending migrations on startup.
+- **`MSB3026` / `MSB3027`** during a build means a running server or an open Visual Studio
+  is holding the DLL. The compile almost certainly succeeded — stop the process rather than
+  chasing a code error.
+- **Do not fake local infrastructure to force a green build.** No invented environment
+  variables, no stubbed-out NuGet sources. Ship the change and hand back the setup steps.
+  NuGet sources that depend on an environment variable go in `Directory.Build.props` behind
+  a `Condition`, never as `%VAR%` in `NuGet.config` (that gives `NU1301` when unset).
+- **C# only.** "In C#" is literal — no native sidecar, however small. Ask before
+  introducing any non-C# component.
+- For image work the house library is **NetVips**, not ImageSharp: ImageSharp 4+ fails a
+  Release build without a purchased Six Labors licence.
 
-Migrations: `dotnet ef migrations add <Name> --project src/NosCore.Database`. Never
-hand-write the Designer files.
+### Releasing a sibling package
 
-The parser is interactive by default; `--folder <path>` for a non-interactive run. It
-applies pending migrations on startup.
+Editing a sibling checkout does **not** affect this build. A change spanning packages is a
+chain, not a PR:
+
+branch → PR → CI → merge → tag `X.Y.Z` (bare, no `v`) → wait for nuget.org indexing →
+`dotnet nuget locals all --clear` → bump `Directory.Packages.props` here → PR.
+
+`dotnet nuget push` succeeding is not the same as the package being restorable; poll
+`https://api.nuget.org/v3-flatcontainer/<id>/index.json` before bumping the consumer. The
+`noscore-packets-release` skill documents the cycle.
+
+---
 
 ## Manual verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# NosCore
+
+A NosTale server reimplementation. .NET 10, EF Core 10 + Npgsql + NodaTime, Autofac,
+Arch.Core ECS, Wolverine for messaging, source generators, warnings-as-errors.
+
+## Where things belong
+
+NosCore is a main repo plus independently versioned NuGet packages, each in its own repo
+under `NosCoreIO`. **A fact goes in exactly one place.** Putting it in the convenient place
+rather than the right one is the most common reason a PR is sent back.
+
+### Sibling packages — separate repos, separate release cycle
+
+| Package | Local checkout | Owns |
+|---|---|---|
+| `NosCore.Packets` | `c:\dev\NosCore.Packets` | Every packet class and the serializer. All wire-format knowledge. |
+| `NosCore.Algorithm` | `c:\dev\NosCore.Algorithm` | Every stat and progression formula or table |
+| `NosCore.Shared` | `c:\dev\NosCore.Shared` | I18N, `Logger`, cross-cutting enums, config primitives |
+| `NosCore.Dao` | `c:\dev\NosCore.Dao` | Data-access abstraction (`IDao<,>`) |
+| `NosCore.Networking` | `c:\dev\NosCore.Networking` | Session and socket plumbing |
+| `NosCore.PathFinder` | `c:\dev\NosCore.PathFinder` | Brushfire, flow field, jump point search |
+| `NosCore.Analyzers` | — | Roslyn analyzers |
+
+Editing a sibling checkout does **not** affect this build. It needs a release: branch → PR →
+merge → tag `X.Y.Z` → wait for nuget.org indexing → bump `Directory.Packages.props` here.
+A change spanning packages is a chain, not a PR.
+
+`NosCore.Algorithm` already owns `CloseDefence`, `Damage`, `Dignity`, `DistanceDefence`,
+`DistanceDodge`, `Dodge`, `Experience`, `FairyExperience`, `FamilyExperience`,
+`HeroExperience`, `HitRate`, `Hp`, `JobExperience`, `MagicDefence`, `MateExperience`, `Mp`,
+`Reputation`, `SecondaryDamage`, `SecondaryHitRate`, `SpExperience`, `Speed` and `Sum`.
+**If a number is a curve or a stat formula it belongs there**, as `I<Thing>Service` +
+`<Thing>Service`, with the level ceiling in `Constants.cs` and an approval table in
+`test/NosCore.Algorithm.Tests/DocumentationTest.cs`. Do not hand-roll a lookup table in
+`NosCore.GameObject`.
+
+### Projects in this repo
+
+| Project | Owns | Must not contain |
+|---|---|---|
+| `NosCore.Data` | DTOs, enumerations, `.resx` language resources | game logic |
+| `NosCore.Database` | EF entities and migrations | game logic |
+| `NosCore.GameObject` | ECS bundles/components, game services, event handlers | wire formats, stat curves |
+| `NosCore.PacketHandlers` | One handler per client packet | rules that belong in a service |
+| `NosCore.Parser` | `.dat` ingestion and documentation generation | — |
+| `NosCore.Core` | Shared infrastructure | — |
+
+### Deciding, in order
+
+1. A **wire shape** — field order, separator, sentinel? → `NosCore.Packets`, and a packet
+   trace is the only acceptable evidence.
+2. A **number that scales with level or a stat**? → `NosCore.Algorithm`.
+3. The **meaning of a `.dat` column or a BCard subtype**? → an enum in `NosCore.Data`,
+   wired by `NosCore.Parser`. `.dat` data belongs in the database, not in a generated C#
+   table.
+4. **Behaviour** — what happens when an effect fires? → a service in `NosCore.GameObject`.
+5. A **player-facing string**? → a `LanguageKey` plus every `.resx` under
+   `NosCore.Data/Resource/`, never a literal.
+
+## Research sources, and the rule about them
+
+The game is closed-source, so unknown formulas and enum meanings get looked up. In
+descending order of trust:
+
+1. **The client `.dat` files** (`C:\Users\erwan\Desktop\parser`) — authoritative. The
+   matching `_code_<lang>_<File>.txt` language files carry the human-readable description
+   of each row; pair them to learn what a subtype actually does.
+2. **Packet traces** — authoritative for the wire.
+3. **nosapki.com** — a live game database, reliable for anything player-facing, and the
+   right way to check a table before trusting it. Watch whether "Level N" means *at* N or
+   *to leave* N, and whether its table runs further than yours.
+4. **OpenNos** (`C:\dev\OpenNos`) — a pre-i18n fork of an old client. Every constant is a
+   hypothesis, never an answer. Errors already found and fixed downstream: BCard types
+   56/57 swapped, `NoPenatly` sharing a value with `DistanceDamageIncreasing`, subtypes
+   marked "didn't exist" that do, enum members numbered `00`/`01` which are not valid
+   subtypes, and the entire family experience table.
+
+**Never name these sources in code, comments, commit messages or PR bodies.** Describe
+NosCore's behaviour in its own terms. Euphemisms count — "the sibling codebase", "the older
+emulators", "the reference implementation" are the same violation and have all been sent
+back in review. Referencing the `.dat` files or a trace is fine; they are project input.
+
+If a number is doubtful, record the doubt without its provenance:
+
+```csharp
+// A ginfo line puts a level 7 family's bar at 640 000 against the 1 900 000 here, so at
+// least that row is suspect.
+```
+
+One contradicted row means re-check the whole table — it is rarely a single bad
+transcription.
+
+## Conventions
+
+- **Comments are the exception.** Default to none. Write one only when the *why* cannot be
+  inferred from names and types, and keep it to a line or two. Long narrative blocks,
+  provenance essays and restating what the code says are all removed in review.
+- **English only**, in code, comments and commit messages.
+- **No UTF-8 BOM** on `.cs` files. Editors add them silently; strip before pushing.
+- **Never commit to `master`.** Branch, PR, CI green, then merge — including one-line
+  chores.
+- **Rebase, never merge.** Linear history. `git rebase origin/master`, force-with-lease on
+  push.
+- Keep semantic types. Do not flatten a `bool` or an enum to a number because the wire
+  value happens to be `0`/`1`; the serializer handles the conversion.
+- Schema changes are additive where possible. Expand a `.dat` bitmask into one boolean
+  column per flag rather than storing the raw mask.
+
+## Build and test
+
+```bash
+dotnet build NosCore.sln
+dotnet test NosCore.sln
+```
+
+Source generators live in `tools/NosCore.DtoGenerator` (DTOs from entities) and
+`tools/NosCore.EcsGenerator` (ECS bundles). Both pin Roslyn via `VersionOverride` because a
+generator must target the oldest compiler it runs on — do not let them float to the central
+`Microsoft.CodeAnalysis` version.
+
+Migrations: `dotnet ef migrations add <Name> --project src/NosCore.Database`. Never
+hand-write the Designer files.
+
+The parser is interactive by default; `--folder <path>` for a non-interactive run. It
+applies pending migrations on startup.
+
+## Manual verification
+
+`documentation/manual-test-plan.md` lists what has to be checked in a running client,
+because a good deal of this project is only observable there.

--- a/documentation/manual-test-plan.md
+++ b/documentation/manual-test-plan.md
@@ -1,0 +1,143 @@
+# Manual test plan
+
+Most of what changes in this project is only observable in a running client. Automated
+tests cover the arithmetic; this covers the part where a bar moves, a monster walks, or a
+skill does what its description says.
+
+Work through the sections that touch what you changed. Tick as you go.
+
+## Setup
+
+- [ ] LoginServer, MasterServer and WorldServer all start and stay up
+- [ ] The banner prints and the character list loads
+- [ ] Log in on a GM account (`$Help` lists the commands; if it does nothing, the account
+      is not GM and none of the rest will work)
+
+Useful commands: `$CreateItem <vnum> [amount] [upgrade]`, `$SetLevel`, `$SetJobLevel`,
+`$Teleport`, `$Position`, `$Kill`, `$ChangeClass`, `$Invisible`, `$ClearInventory`.
+
+Avoid `$Speed` while testing movement — it overrides the value the mount and buff paths
+compute and will mask a regression.
+
+---
+
+## Combat
+
+### Worn equipment contributes to stats
+
+- [ ] Naked, open the stat window and note min/max attack and the three defences
+- [ ] `$CreateItem` a weapon and an armour, equip both
+- [ ] The stat window changes, and the numbers include the piece's own values
+- [ ] Hit a monster before and after equipping — the damage is visibly different
+- [ ] An upgraded piece (`$CreateItem <vnum> 1 <upgrade>`) contributes more than a +0 of
+      the same vnum
+
+Both the item model and the instance count. A +0 and a +10 of the same vnum giving the
+same damage means only one of the two is being read.
+
+### Combo chains
+
+- [ ] With a class whose basic attack chains (skill 220 is the Swordsman's), attack the
+      same target repeatedly
+- [ ] The chain advances through its steps instead of replaying the first
+- [ ] The animation and effect change between steps
+
+### Skills that move somebody — BCard type 40
+
+- [ ] **Push (subtype 11)** — the target is pushed back the declared number of cells
+- [ ] **Pull (subtype 21)** — the target is drawn *towards* you, not taunted in place.
+      Drawing Shot, Rotating Hammer and Spider King's Draw carry this
+- [ ] **Charge (subtype 31)** — you move to the target
+- [ ] In all three, a wall stops the movement in front of it — nobody ends up inside
+      geometry or on the far side
+- [ ] A value of 0 on a pull means "up against you", not "no movement"
+
+### Damage as a percentage of HP — BCard type 37 subtype 31
+
+- [ ] A skill declaring this takes the percentage off the target's **maximum** HP, not its
+      current HP
+- [ ] It stacks on top of the ordinary blow rather than replacing it
+- [ ] It can kill, and the death is the ordinary one: corpse, rewards, respawn all behave
+      as any other kill
+
+Boss skills declaring 90% should take most of a bar in one hit.
+
+### Guaranteed hit and guaranteed dodge — BCard type 16
+
+- [ ] A skill with subtype 11 lands even against a target that normally dodges often
+- [ ] A card granting subtype 21 causes misses against it
+- [ ] With both in play nothing locks up or throws — the attacker's guarantee is resolved
+      first by design
+
+### Elemental resistance — BCard types 13 and 14
+
+- [ ] A buff that raises your resistance to an element reduces the elemental damage you
+      take from it
+- [ ] A buff that lowers the enemy's resistance raises the elemental damage you deal
+- [ ] An "all elements" effect applies to each of fire, water, light and dark rather than
+      being ignored
+
+---
+
+## Monsters
+
+### Respawn timing
+
+- [ ] `$Kill` a monster and time the respawn against its `.dat` value: the field is in
+      **tenths of a second**, so 400 means forty seconds
+- [ ] Monsters do not flicker back within a second of dying
+- [ ] A monster whose file value is 0 still respawns, after the one-second minimum
+
+This one is easy to eyeball — before the fix everything came back a hundred times too fast.
+
+---
+
+## Character
+
+### Mounts
+
+- [ ] Mount a vehicle: the sprite changes **and** you move faster
+- [ ] Dismount: the speed returns to the class value
+- [ ] Speed survives a map change while mounted
+
+### Class change
+
+- [ ] `$ChangeClass` to another class
+- [ ] The skill bar holds the new class's skills, not the old ones
+- [ ] No leftover icons the client refuses to cast
+- [ ] **Relog** and confirm the old skills have not come back — the rows behind the list
+      have to be gone, not just the in-memory list
+
+### Equipment gates
+
+- [ ] Try to wear an item above your job level: the message says the **job level** is too
+      low, not that you are the wrong class
+- [ ] Try to wear an item for another class: that one still says wrong class
+- [ ] `$SetJobLevel` above the requirement, then equip — it succeeds
+
+---
+
+## Regression sweep
+
+Quick pass after any combat or stat change:
+
+- [ ] Log in, walk, attack a monster, take damage, die, respawn
+- [ ] HP and MP bars track the real values through all of it
+- [ ] Pick up an item, equip it, unequip it
+- [ ] Change map, then change back
+- [ ] Log out and back in — nothing that was learned, worn or spent has reverted
+
+---
+
+## Not verifiable yet
+
+Recorded so nobody spends time hunting for them:
+
+- **BCard subtype names and additions** — data-only. Observable only once a skill or card
+  using a given subtype is wired to behaviour.
+- **The `st` percentage guard** — guards a zero maximum, which is not a state the game
+  reaches. It cannot be triggered from the client by design.
+- **Family experience and the `gidx` family id** — the family feature itself is not merged
+  yet, so neither the corrected curve nor the flattened packet field has a path to the
+  client.
+- **Mates and instances** — same, still open.


### PR DESCRIPTION
Two documents, both written from things that came up repeatedly in this week's reviews.

### `CLAUDE.md`

Repo-root context, so it loads automatically in any session here. It records what kept
having to be said:

- **Which package owns what** — the sibling repos and their release cycle, the projects in
  this repo with an explicit *must not contain* column, and a five-step decision order for
  placing a new fact. Two PRs this week hand-rolled experience tables in `NosCore.GameObject`
  when `NosCore.Algorithm` already owned every other curve; one checked in a generated C#
  table of `Skill.dat` data instead of parsing it.
- **The research sources and their ranking** — `.dat` files and traces first, nosapki next,
  OpenNos last and hypothesis-only, with its confirmed errors listed.
- **The rule that none of them may be named in code.** Four PRs this week named another
  codebase in comments, most of them through euphemisms rather than outright, so the
  euphemisms are spelled out.
- Conventions that were corrected by hand more than once: comments are the exception,
  English only, no BOM on `.cs`, never commit to master, rebase never merge.

### `documentation/manual-test-plan.md`

A checklist for what only a running client can confirm, organised by area and written
against the actual GM commands. It covers this week's merges — equipment finally
contributing to stats, respawn timing, mounts, class change, combo chains, and the four
BCard families that went in.

It also has a **"Not verifiable yet"** section rather than inventing steps for things that
have no path to the client: the data-only subtype work, the `st` guard against a state the
game cannot reach, and family/mate/instance work that is still open. Better to say so than
have someone hunt for a bar that was never going to move.

Both files are BOM-free and reference no external codebase by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project guidance covering development conventions, ownership, research practices, schema usage, Git workflows, builds, troubleshooting, and release procedures.
  * Added a manual client testing guide for combat, monsters, mounts, classes, equipment, persistence, regression checks, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->