### PR TITLE
docs: generalise CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,37 +1,20 @@
 # NosCore
 
-A NosTale server reimplementation. .NET 10, EF Core 10 + Npgsql + NodaTime, Autofac,
+A NosTale server reimplementation. .NET 10, EF Core + Npgsql + NodaTime, Autofac,
 Arch.Core ECS, Wolverine for messaging, source generators, `TreatWarningsAsErrors`.
 
 ---
 
 ## Code conventions
 
-### Comments are the exception, not the default
+**Comments are the exception.** Write one only when the *why* cannot be inferred from names
+and types, and keep it to a line or two. Do not restate what the code says, narrate how a
+bug was found, or record where a value came from. Do not describe what changed — that is
+the commit message's job.
 
-Write **no comment** unless the *why* cannot be inferred from names and types. When one is
-genuinely needed, a line or two. These all get removed in review:
+**English only** — code, comments, commit messages, PR bodies, test names.
 
-- restating what the code already says
-- narrative essays about how a bug was found, what it cost, or how many declarations exist
-- provenance — where a number came from, which other project does it differently
-- `ONE ASSUMPTION IS OURS`-style emphasis, block capitals, rhetorical structure
-
-A comment earns its place by answering a question the reader would otherwise have to go
-digging for. `// Array.Empty so "nothing worn" compares equal to None.` is worth a line.
-Three paragraphs on why a table might be wrong are not.
-
-Do not describe *what changed* — that is the commit message's job, and it goes stale the
-moment someone else edits the file.
-
-### English only
-
-Code, comments, commit messages, PR bodies, test names. Non-English text has reached
-review more than once and always comes back.
-
-### No BOM
-
-`.cs` files have no UTF-8 BOM. Editors add them silently on save; check before pushing:
+**No UTF-8 BOM on `.cs` files.** Some editors add one on save. Check before pushing:
 
 ```bash
 for f in $(git diff --name-only origin/master...HEAD | grep '\.cs$'); do
@@ -39,53 +22,37 @@ for f in $(git diff --name-only origin/master...HEAD | grep '\.cs$'); do
 done
 ```
 
-`.resx` files in this repo are inconsistent already — leave those alone.
+**Keep semantic types.** Do not flatten a `bool` or an enum to a number because the wire
+value happens to be `0` or `1`; the serializer handles the conversion.
 
-### Keep semantic types
-
-Do not flatten a `bool` or an enum to a number because the wire value happens to be `0`
-or `1`. The serializer handles the conversion; the type is what makes the call site
-readable.
-
-### Ship only what is wired
-
-No placeholder enums, tabs, buttons or handlers for behaviour that does not exist. A
-reference screenshot or a `.dat` column is not a specification — wire-status is. If
-something is deliberately empty, that has to be the point (see
-`NosCore.PacketHandlers/NoAction/`, which is no-op by design).
-
-### Versions are real
-
-A new project starts at `0.0.1`. Do not label unshipped work `v2.1`.
+**Ship only what is wired.** No placeholder enums, handlers or UI for behaviour that does
+not exist yet. A data file listing a field is not a reason to expose it.
 
 ---
 
 ## Where things belong
 
 NosCore is a main repo plus independently versioned NuGet packages, each in its own repo
-under `NosCoreIO`. **A fact goes in exactly one place.** Putting it in the convenient place
-rather than the right one is the most common reason a PR is sent back.
+under `NosCoreIO`. **A fact belongs in exactly one place.** Choosing the convenient place
+over the correct one is the most common reason a change is sent back.
 
-### Sibling packages — separate repos, separate release cycle
+### Sibling packages
 
-| Package | Local checkout | Owns |
-|---|---|---|
-| `NosCore.Packets` | `c:\dev\NosCore.Packets` | Every packet class and the serializer. All wire-format knowledge. |
-| `NosCore.Algorithm` | `c:\dev\NosCore.Algorithm` | Every stat and progression formula or table |
-| `NosCore.Shared` | `c:\dev\NosCore.Shared` | I18N, `Logger`, cross-cutting enums, config primitives |
-| `NosCore.Dao` | `c:\dev\NosCore.Dao` | Data-access abstraction (`IDao<,>`) |
-| `NosCore.Networking` | `c:\dev\NosCore.Networking` | Session and socket plumbing |
-| `NosCore.PathFinder` | `c:\dev\NosCore.PathFinder` | Brushfire, flow field, jump point search |
-| `NosCore.Analyzers` | — | Roslyn analyzers |
+| Package | Owns |
+|---|---|
+| `NosCore.Packets` | Every packet class and the serializer — all wire-format knowledge |
+| `NosCore.Algorithm` | Every stat and progression formula or table |
+| `NosCore.Shared` | I18N, logging, cross-cutting enums, config primitives |
+| `NosCore.Dao` | Data-access abstraction (`IDao<,>`) |
+| `NosCore.Networking` | Session and socket plumbing |
+| `NosCore.PathFinder` | Brushfire, flow field, jump point search |
+| `NosCore.Analyzers` | Roslyn analyzers |
 
-`NosCore.Algorithm` already owns `CloseDefence`, `Damage`, `Dignity`, `DistanceDefence`,
-`DistanceDodge`, `Dodge`, `Experience`, `FairyExperience`, `FamilyExperience`,
-`HeroExperience`, `HitRate`, `Hp`, `JobExperience`, `MagicDefence`, `MateExperience`, `Mp`,
-`Reputation`, `SecondaryDamage`, `SecondaryHitRate`, `SpExperience`, `Speed` and `Sum`.
-**If a number is a curve or a stat formula it belongs there**, as `I<Thing>Service` +
-`<Thing>Service`, with the level ceiling in `Constants.cs` and an approval table in
-`test/NosCore.Algorithm.Tests/DocumentationTest.cs`. Do not hand-roll a lookup table in
-`NosCore.GameObject` — that has been reviewed out twice.
+`NosCore.Algorithm` holds one service per curve — experience, HP/MP, damage, defence,
+dodge, hit rate, reputation and so on. **Any number that scales with a level or a stat
+belongs there**, as `I<Thing>Service` + `<Thing>Service`, with the ceiling in `Constants.cs`
+and an approval table in its `DocumentationTest`. Do not hand-roll a lookup table inside
+`NosCore.GameObject`.
 
 ### Projects in this repo
 
@@ -98,17 +65,16 @@ rather than the right one is the most common reason a PR is sent back.
 | `NosCore.Parser` | `.dat` ingestion and documentation generation | — |
 | `NosCore.Core` | Shared infrastructure | — |
 
-`NosCore.Data` being data-only and `NosCore.GameObject` holding the logic is deliberate,
-not an accident to be tidied up.
+`NosCore.Data` being data-only and `NosCore.GameObject` holding the logic is deliberate.
 
 ### Deciding, in order
 
-1. A **wire shape** — field order, separator, sentinel? → `NosCore.Packets`, and a packet
-   trace is the only acceptable evidence.
-2. A **number that scales with level or a stat**? → `NosCore.Algorithm`.
+1. A **wire shape** — field order, separator, sentinel? → `NosCore.Packets`, evidenced by a
+   packet trace.
+2. A **number that scales with a level or stat**? → `NosCore.Algorithm`.
 3. The **meaning of a `.dat` column or a BCard subtype**? → an enum in `NosCore.Data`,
-   wired by `NosCore.Parser`. `.dat` data belongs in the database, **not** in a generated
-   C# table checked into the repo — a table cannot be regenerated when the client updates.
+   wired by `NosCore.Parser`. Game data belongs in the database, not in a generated C#
+   table — a table cannot be regenerated when the client updates.
 4. **Behaviour** — what happens when an effect fires? → a service in `NosCore.GameObject`.
 5. A **player-facing string**? → a `LanguageKey` plus every `.resx` under
    `NosCore.Data/Resource/`, never a literal.
@@ -116,47 +82,41 @@ not an accident to be tidied up.
 ### Schema changes
 
 Additive where possible. When a value's source changes, rewire the parser rather than
-dropping or renaming existing columns. Expand a `.dat` bitmask into one boolean column per
-flag — never store the raw mask as a single aggregate column.
+dropping or renaming columns. Expand a bitmask field into one boolean column per flag;
+never store the raw mask as a single aggregate column.
 
 ---
 
-## Research sources, and the rule about them
+## Research sources
 
-The game is closed-source, so unknown formulas and enum meanings get looked up. In
+The game is closed-source, so formulas and enum meanings have to be looked up. In
 descending order of trust:
 
-1. **The client `.dat` files** (`C:\Users\erwan\Desktop\parser`) — authoritative. The
-   matching `_code_<lang>_<File>.txt` language files carry the human-readable description
-   of each row; pair them to learn what a subtype actually does.
-2. **Packet traces** — authoritative for the wire. A trace outranks any other
+1. **The client data files** and their matching language files — authoritative. The data
+   file has the numbers, the language file has the sentence describing what a row does.
+   Pair them.
+2. **Packet traces** — authoritative for the wire, and they outrank any other
    implementation's packet class.
-3. **nosapki.com** — a live game database, reliable for anything player-facing, and the
-   right way to check a table before trusting it. Watch whether "Level N" means *at* N or
-   *to leave* N, and whether its table runs further than yours.
-4. **OpenNos** (`C:\dev\OpenNos`) — a pre-i18n fork of an old client. Every constant is a
-   hypothesis, never an answer. Errors already found and fixed downstream: BCard types
-   56/57 swapped, `NoPenatly` sharing a value with `DistanceDamageIncreasing`, subtypes
-   marked "didn't exist" that do, enum members numbered `00`/`01` which are not valid
-   subtypes, and the entire family experience table.
+3. **Community game databases** — reliable for player-facing values, and the right way to
+   check a table before trusting it. Confirm whether a row means *at* level N or *to leave*
+   level N, and whether the table runs further than the one you have.
+4. **Other server implementations** — a hypothesis, never an answer. They are forks of
+   older clients and carry known-wrong constants.
 
-**Never name these sources in code, comments, commit messages or PR bodies.** Describe
-NosCore's behaviour in its own terms. Euphemisms count — "the sibling codebase", "the older
-emulators", "the reference implementation" are the same violation and have all been sent
-back. Referencing the `.dat` files or a trace is fine; they are project input.
+**Never name a source in code, comments, commit messages or PR bodies.** Describe NosCore's
+behaviour in its own terms. Euphemisms count — "the sibling codebase", "the older
+emulators", "the reference implementation" are the same violation. Referencing the game's
+own data files or a packet trace is fine; those are project input.
 
-If a number is doubtful, record the doubt without its provenance:
+If a value is doubtful, record the doubt without its provenance:
 
 ```csharp
 // A ginfo line puts a level 7 family's bar at 640 000 against the 1 900 000 here, so at
 // least that row is suspect.
 ```
 
-One contradicted row means re-check the whole table — it is rarely a single bad
-transcription. Check the table's *length* too; inherited tables are often truncated at an
-old level cap.
-
-The `nostale-reference-mining` skill covers the full method.
+One contradicted row means re-checking the whole table rather than patching that row — and
+check the table's length too, since inherited tables are often truncated at an old cap.
 
 ---
 
@@ -164,58 +124,49 @@ The `nostale-reference-mining` skill covers the full method.
 
 - **Never commit to `master`.** Branch, PR, CI green, then merge — including one-line
   chores.
-- **Rebase, never merge.** Linear history. `git rebase origin/master`, `--force-with-lease`
-  on push. Never `git merge origin/master` into a branch, and never `git pull` on a feature
-  branch without `--rebase`.
-- Base new work on `origin/master`. Keep iterating on the same feature branch rather than
+- **Rebase, never merge.** Linear history: `git rebase origin/master`, `--force-with-lease`
+  on push. Never merge `master` into a branch.
+- Base new work on `origin/master`, and keep iterating on the same branch rather than
   opening a new one per follow-up.
-- Opening a PR is fine unprompted. **Wait for the go-ahead before merging**, unless the
-  request already covers it.
+- Opening a PR unprompted is fine; **wait for approval before merging** unless the request
+  already covers it.
 - After merging anything that changes a shared signature, **re-check the other open PRs**.
-  Git merges text, not meaning: adding a required constructor parameter compiles fine on
-  its own branch and breaks every branch that constructs the type.
+  Git merges text, not meaning: a new required constructor parameter compiles on its own
+  branch and breaks every branch that constructs the type.
 
 ---
 
-## Build, test, troubleshoot
+## Build and test
 
 ```bash
 dotnet build NosCore.sln
 dotnet test NosCore.sln
 ```
 
-- **Source generators** live in `tools/NosCore.DtoGenerator` (DTOs from entities) and
-  `tools/NosCore.EcsGenerator` (ECS bundles). Both pin Roslyn with `VersionOverride`,
-  because a generator must target the *oldest* compiler it runs on. Do not let them float
-  to the central `Microsoft.CodeAnalysis` version — that produces `CS9057` and breaks every
-  build using the generator.
+- **Source generators** live under `tools/`. They pin their Roslyn version deliberately: a
+  generator must target the *oldest* compiler it will run on. Letting them float to the
+  central `Microsoft.CodeAnalysis` version produces `CS9057` and breaks every build that
+  uses them.
 - **Migrations**: `dotnet ef migrations add <Name> --project src/NosCore.Database`. Never
   hand-write the Designer files.
-- **The parser** is interactive by default; `--folder <path>` for a non-interactive run. It
-  applies pending migrations on startup.
-- **`MSB3026` / `MSB3027`** during a build means a running server or an open Visual Studio
-  is holding the DLL. The compile almost certainly succeeded — stop the process rather than
-  chasing a code error.
+- **The parser** is interactive by default; pass `--folder <path>` for a non-interactive
+  run. It applies pending migrations on startup.
+- **`MSB3026` / `MSB3027`** means a running server or an open IDE is holding the DLL. The
+  compile almost certainly succeeded — stop the process rather than hunting for a code
+  error.
 - **Do not fake local infrastructure to force a green build.** No invented environment
-  variables, no stubbed-out NuGet sources. Ship the change and hand back the setup steps.
-  NuGet sources that depend on an environment variable go in `Directory.Build.props` behind
-  a `Condition`, never as `%VAR%` in `NuGet.config` (that gives `NU1301` when unset).
-- **C# only.** "In C#" is literal — no native sidecar, however small. Ask before
-  introducing any non-C# component.
-- For image work the house library is **NetVips**, not ImageSharp: ImageSharp 4+ fails a
-  Release build without a purchased Six Labors licence.
+  variables, no stubbed-out package sources. Make the change and hand back the setup steps.
+- **C# only.** Ask before introducing any non-C# component.
 
-### Releasing a sibling package
+### Changing a sibling package
 
-Editing a sibling checkout does **not** affect this build. A change spanning packages is a
-chain, not a PR:
+Editing a sibling repo does not affect this build. It is a chain, not a single PR:
 
-branch → PR → CI → merge → tag `X.Y.Z` (bare, no `v`) → wait for nuget.org indexing →
-`dotnet nuget locals all --clear` → bump `Directory.Packages.props` here → PR.
+branch → PR → CI → merge → tag `X.Y.Z` (bare, no `v` prefix) → wait for nuget.org indexing
+→ clear the local NuGet cache → bump `Directory.Packages.props` here → PR.
 
-`dotnet nuget push` succeeding is not the same as the package being restorable; poll
-`https://api.nuget.org/v3-flatcontainer/<id>/index.json` before bumping the consumer. The
-`noscore-packets-release` skill documents the cycle.
+A successful `dotnet nuget push` is not the same as the package being restorable; poll the
+flat-container index before bumping the consumer.
 
 ---
 
@@ -226,11 +177,9 @@ arithmetic; they do not tell you whether a bar moved or a monster walked.
 
 **Read `documentation/manual-test-plan.md` whenever a change touches gameplay** — combat,
 stats, movement, equipment, skills, monsters or the character — and quote the relevant
-checks back when handing the work over, so there is a concrete list to run rather than a
-vague "test it in game".
+checks when handing the work over, so there is a concrete list to run.
 
-**Add to that file when you add a gameplay feature.** If a change genuinely cannot be
-observed from the client — it guards an unreachable state, or it is data waiting on
-behaviour that is not wired yet — say so in its "Not verifiable yet" section instead of
-inventing steps. Never claim a gameplay change is verified on the strength of unit tests
-alone; say what was tested and what still needs a client.
+**Add to that file when you add a gameplay feature.** If something genuinely cannot be
+observed from the client, say so in its "Not verifiable yet" section instead of inventing
+steps. Never call a gameplay change verified on unit tests alone; state what was tested and
+what still needs a client.


### PR DESCRIPTION
The first version was written from one week of review history on one machine, so a lot of it would not have transferred to anyone else picking the file up.

Three things were wrong with it:

- **Absolute local paths** for the data files and reference checkouts. Those exist on exactly one machine; for any other agent or contributor they are dead references.
- **Named external projects**, which sat awkwardly against the rule three sections down saying they must never be named.
- **Rules justified by incident** — "this has been sent back twice", specific past bugs, counts of declarations. That is changelog, not guidance, and it dates immediately.

It now states the rules themselves and describes sources by kind rather than by name and path. Same coverage — placement, conventions, git workflow, build traps, the release chain, manual verification — in 185 lines instead of 236, and nothing in it depends on whose machine it is read from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance and conventions.
  * Clarified workflows for decisions, schemas, research sources, Git, builds, testing, releases, and manual verification.
  * Simplified and generalized troubleshooting and project setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->