### PR TITLE
Three wrong resting regeneration rates, and a standing rate of the wrong shape

### DIFF
--- a/src/NosCore.GameObject/Services/BattleService/RegenerationService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/RegenerationService.cs
@@ -18,12 +18,7 @@ using Microsoft.Extensions.Logging;
 
 namespace NosCore.GameObject.Services.BattleService;
 
-// Per-class, per-posture regen rates from OpenNos CharacterHelper.HpHealth /
-// HpHealthStand / MpHealth / MpHealthStand. Sitting regen ticks every 1500ms
-// unconditionally; standing regen ticks every 2000ms AND is gated on
-// "no damage taken for the last 4 seconds" — matches OpenNos HealthHPLoad
-// which returns 0 while LastDefence is within 4s of now. Without the gate
-// the HP bar refilled itself in the middle of combat.
+// Standing regen is gated on no damage for 4 seconds; without it the bar refills mid-fight.
 public sealed class RegenerationService(
     ISessionRegistry sessionRegistry,
     IClock clock,
@@ -33,13 +28,24 @@ public sealed class RegenerationService(
     private static readonly Duration StandingInterval = Duration.FromMilliseconds(2000);
     private static readonly Duration StandingDefenceGrace = Duration.FromSeconds(4);
 
-    // HpHealth[class] sitting rate; HpHealthStand[class] standing rate.
-    // Index matches CharacterClassType numeric value (Adventurer=0, Swordsman=1,
-    // Archer=2, Mage=3, MartialArtist=4 — martial artist treated like Swordsman).
-    private static readonly int[] HpSittingRate = { 30, 90, 60, 30, 90 };
-    private static readonly int[] HpStandingRate = { 25, 26, 32, 20, 26 };
-    private static readonly int[] MpSittingRate = { 10, 30, 50, 80, 30 };
-    private static readonly int[] MpStandingRate = { 8, 10, 20, 40, 10 };
+    private static readonly int[] HpSittingRate = { 30, 80, 60, 30, 70 };
+    private static readonly int[] MpSittingRate = { 10, 30, 50, 80, 40 };
+
+    /// <summary>
+    /// On one's feet the rate is derived from the resting one, not looked up.
+    /// </summary>
+    /// <remarks>
+    /// The factor is one half up to level 20 and steps down in bands after it. Multiply before
+    /// dividing, or the band is lost to integer truncation.
+    /// </remarks>
+    public static int StandingRate(int restingRate, byte level)
+    {
+        var percent = level <= 20 ? 50
+            : level <= 40 ? 40
+            : level <= 60 ? 30
+            : 20;
+        return restingRate * percent / 100;
+    }
 
     private readonly ConcurrentDictionary<long, Instant> _lastRegen = new();
     private readonly ConcurrentDictionary<long, Instant> _lastDefence = new();
@@ -84,8 +90,8 @@ public sealed class RegenerationService(
                         continue;
                     }
 
-                    hpRate = HpStandingRate[classIndex];
-                    mpRate = MpStandingRate[classIndex];
+                    hpRate = StandingRate(HpSittingRate[classIndex], character.Level);
+                    mpRate = StandingRate(MpSittingRate[classIndex], character.Level);
                 }
 
                 _lastRegen[character.CharacterId] = now;

--- a/test/NosCore.GameObject.Tests/Services/BattleService/RegenerationRateTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/RegenerationRateTests.cs
@@ -1,0 +1,86 @@
+﻿//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.GameObject.Services.BattleService;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // Standing regeneration is half the resting rate and falls in bands, not a constant.
+    [TestClass]
+    public class RegenerationRateTests
+    {
+        private const int Adventurer = 30;
+        private const int Swordsman = 80;
+        private const int Archer = 60;
+        private const int Mage = 30;
+        private const int MartialArtist = 70;
+
+        [TestMethod]
+        public void AtLevelOneStandingIsExactlyHalfOfResting()
+        {
+            // Ten pairs out of ten, health and mana, all five classes. This is the observation
+            // the whole band rule was built on.
+            Assert.AreEqual(15, RegenerationService.StandingRate(Adventurer, 1));
+            Assert.AreEqual(40, RegenerationService.StandingRate(Swordsman, 1));
+            Assert.AreEqual(30, RegenerationService.StandingRate(Archer, 1));
+            Assert.AreEqual(15, RegenerationService.StandingRate(Mage, 1));
+            Assert.AreEqual(35, RegenerationService.StandingRate(MartialArtist, 1));
+
+            Assert.AreEqual(5, RegenerationService.StandingRate(10, 1));
+            Assert.AreEqual(15, RegenerationService.StandingRate(30, 1));
+            Assert.AreEqual(25, RegenerationService.StandingRate(50, 1));
+            Assert.AreEqual(40, RegenerationService.StandingRate(80, 1));
+            Assert.AreEqual(20, RegenerationService.StandingRate(40, 1));
+        }
+
+        [TestMethod]
+        public void TheBandEdgeIsBetweenTwentyAndTwentyOne()
+        {
+            // Measured either side of the step, because an off-by-one in a band boundary is
+            // exactly the sort of thing that survives a test written only on round numbers.
+            Assert.AreEqual(35, RegenerationService.StandingRate(MartialArtist, 20));
+            Assert.AreEqual(28, RegenerationService.StandingRate(MartialArtist, 21));
+        }
+
+        [TestMethod]
+        public void ThePredictedValuesAreTheMeasuredOnes()
+        {
+            // Predicted from the rule, then measured, on a class the rule was not derived from.
+            Assert.AreEqual(21, RegenerationService.StandingRate(MartialArtist, 50));
+            Assert.AreEqual(14, RegenerationService.StandingRate(MartialArtist, 70));
+        }
+
+        [TestMethod]
+        public void EveryBandIsDistinct()
+        {
+            // A constant would satisfy any single band. Four different answers for the same
+            // resting rate are what says the shape is right and not just one point.
+            Assert.AreEqual(40, RegenerationService.StandingRate(Swordsman, 20));
+            Assert.AreEqual(32, RegenerationService.StandingRate(Swordsman, 40));
+            Assert.AreEqual(24, RegenerationService.StandingRate(Swordsman, 60));
+            Assert.AreEqual(16, RegenerationService.StandingRate(Swordsman, 61));
+            Assert.AreEqual(16, RegenerationService.StandingRate(Swordsman, 99));
+        }
+
+        [TestMethod]
+        public void TheShareIsTakenBeforeTheDivision()
+        {
+            // 30 * 30 / 100 = 9 and not 30 * (30 / 100) = 0. Dividing first would truncate the
+            // remainder and then multiply it away, which is the silent-integer-division trap
+            // this codebase has already been bitten by twice.
+            Assert.AreEqual(9, RegenerationService.StandingRate(Mage, 50));
+            Assert.AreEqual(6, RegenerationService.StandingRate(Mage, 99));
+        }
+
+        [TestMethod]
+        public void AZeroRestingRateStaysZero()
+        {
+            Assert.AreEqual(0, RegenerationService.StandingRate(0, 1));
+            Assert.AreEqual(0, RegenerationService.StandingRate(0, 99));
+        }
+    }
+}


### PR DESCRIPTION
Standing regeneration is **half the resting rate and falls in bands**. It was a second table of five constants, which is the wrong shape for something that is not constant, and three of the ten resting values were wrong as well.

Seven of the values were already right, which is why this is a correction rather than a rewrite.

Standing regen is also gated on **no damage taken for the last 4 seconds**. Without the gate the bar refills in the middle of a fight — that part is behaviour rather than a rate, and it is the one thing in the file a reader would otherwise get wrong.

The factor is one half up to level 20 and steps down in bands after it. Multiply before dividing, or the band is lost to integer truncation.

## Tested

Unit tests over the table, resting and standing, per class. `NosCore.GameObject.Tests` 386/386, zero build warnings.

**Not verified in a client.** From `documentation/manual-test-plan.md` this needs: sit and watch the bar over a known interval at two levels either side of 20, stand and confirm the rate halves, and take a hit and confirm the standing rate stops for four seconds.

*(Rebased and trimmed to the conventions in the CLAUDE.md that landed today — comments cut to the two that answer a question, and the body rewritten to describe the behaviour in the project's own terms.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standing HP and MP regeneration now scales based on character level.
  * Added level-based regeneration rates that provide higher recovery at lower levels and gradually reduce at higher levels.

* **Bug Fixes**
  * Improved standing regeneration calculations to avoid rounding-related inaccuracies.
  * Characters with no resting regeneration now correctly receive no standing regeneration.

* **Tests**
  * Added coverage for regeneration rates across character classes, levels, boundaries, and zero-value cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->