### PR TITLE
A cast could put a character inside a wall

### DIFF
--- a/src/NosCore.GameObject/Services/BattleService/BattleService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleService.cs
@@ -245,8 +245,6 @@ namespace NosCore.GameObject.Services.BattleService
             }
         }
 
-        // WalkPacketHandler refuses a destination that is not walkable; this path wrote the same
-        // two fields with no check, so a cast could put a character inside a wall.
         private static void UpdateAttackerPosition(IAliveEntity origin, HitArguments arguments)
         {
             if (arguments is not { MapX: not null, MapY: not null })

--- a/src/NosCore.GameObject/Services/BattleService/BattleService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleService.cs
@@ -245,13 +245,22 @@ namespace NosCore.GameObject.Services.BattleService
             }
         }
 
+        // WalkPacketHandler refuses a destination that is not walkable; this path wrote the same
+        // two fields with no check, so a cast could put a character inside a wall.
         private static void UpdateAttackerPosition(IAliveEntity origin, HitArguments arguments)
         {
-            if (arguments is { MapX: not null, MapY: not null })
+            if (arguments is not { MapX: not null, MapY: not null })
             {
-                origin.PositionX = arguments.MapX.Value;
-                origin.PositionY = arguments.MapY.Value;
+                return;
             }
+
+            if (origin.MapInstance?.Map.IsWalkable(arguments.MapX.Value, arguments.MapY.Value) == false)
+            {
+                return;
+            }
+
+            origin.PositionX = arguments.MapX.Value;
+            origin.PositionY = arguments.MapY.Value;
         }
 
         // NoAttack is a state-only gate (locked / sleeping / vehicled); the faction


### PR DESCRIPTION
`u_s` carries a position, and `UpdateAttackerPosition` wrote it straight into `PositionX`/`PositionY`. `WalkPacketHandler` refuses a destination that is not walkable; this path had no such check, so the same movement was allowed by one road and refused by the other.

The guard is the walk path's own `IsWalkable`, so the two agree by construction rather than by two copies of a rule.

**Tested:** `NosCore.GameObject.Tests` 442/442 and `NosCore.PacketHandlers.Tests` 410/410, solution builds with zero warnings. Not played - I do not start the servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Characters are no longer moved onto non-walkable tiles during battle positioning.
  * Invalid or unavailable destination coordinates now leave the attacker’s position unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->