### PR TITLE
Maximum HP and MP stop being a login-time snapshot

### DIFF
--- a/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
@@ -32,7 +32,8 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
         ILogger<WearHandler> logger,
         IClock clock,
         ILogLanguageLocalizer<LogLanguageKey> logLanguage,
-        IOptions<WorldConfiguration> worldConfiguration)
+        IOptions<WorldConfiguration> worldConfiguration,
+        Services.BattleService.IVitalityService vitalityService)
     {
         [UsedImplicitly]
         public async Task Handle(ItemUsedEvent evt)
@@ -192,6 +193,10 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
                 itemInstance.ItemInstance.ItemDeleteTime =
                     clock.GetCurrentInstant().Plus(Duration.FromSeconds(itemInstance.ItemInstance.Item.ItemValidTime));
             }
+
+            // A piece can carry HP and MP as its own value or as a type 33 effect. Without
+            // this the maximum stays as it was and the thousand-HP armour gives none of it.
+            await vitalityService.RefreshAndNotifyAsync(session.Character).ConfigureAwait(false);
         }
     }
 }

--- a/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
+++ b/src/NosCore.GameObject/Messaging/Handlers/UseItem/WearHandler.cs
@@ -194,8 +194,6 @@ namespace NosCore.GameObject.Messaging.Handlers.UseItem
                     clock.GetCurrentInstant().Plus(Duration.FromSeconds(itemInstance.ItemInstance.Item.ItemValidTime));
             }
 
-            // A piece can carry HP and MP as its own value or as a type 33 effect. Without
-            // this the maximum stays as it was and the thousand-HP armour gives none of it.
             await vitalityService.RefreshAndNotifyAsync(session.Character).ConfigureAwait(false);
         }
     }

--- a/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
@@ -396,8 +396,6 @@ public sealed class BattleStatsProvider(
         yield return equipment;
     }
 
-    // Public because VitalityService folds the same cards for the maximum HP and has to
-    // scale them the same way. Two copies of this would drift.
     public static int ScaleByLevel(BCardDto card, int level)
     {
         // Matches OpenNos: IsLevelScaled + IsLevelDivided together means "first/level",

--- a/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
@@ -396,7 +396,9 @@ public sealed class BattleStatsProvider(
         yield return equipment;
     }
 
-    private static int ScaleByLevel(BCardDto card, int level)
+    // Public because VitalityService folds the same cards for the maximum HP and has to
+    // scale them the same way. Two copies of this would drift.
+    public static int ScaleByLevel(BCardDto card, int level)
     {
         // Matches OpenNos: IsLevelScaled + IsLevelDivided together means "first/level",
         // IsLevelScaled alone means "first * level". Default path uses FirstData as-is.

--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -60,8 +60,6 @@ public sealed class HitQueue(
         return request.Completion.Task;
     }
 
-    // A buff can move maximum HP and MP (BCard type 33), and the maximum does not live in
-    // CombatStats: nothing else would pick the change up.
     private async Task RefreshVitalityAsync(IAliveEntity entity)
     {
         if (entity is ICharacterEntity character)
@@ -115,7 +113,7 @@ public sealed class HitQueue(
     }
 
     // async because the effects a blow carries are awaited below: they have to follow the
-    // blow, not race it, and the maximum HP recomputed after them has to see them applied.
+    // blow, not race it.
     private async Task TryApplyHit(HitRequest request)
     {
         try
@@ -186,8 +184,6 @@ public sealed class HitQueue(
                 regenerationService.NotifyDamaged(hurtCharacter.CharacterId);
             }
 
-            // Skill BCards that don't describe damage (i.e. stat modifiers) become a
-            // buff on the target lasting the skill's Duration.
             if (!killed && request.Skill.Duration > 0 && request.Skill.BCards.Count > 0)
             {
                 await buffService
@@ -195,11 +191,6 @@ public sealed class HitQueue(
                         request.Skill.BCards, request.Origin)
                     .ConfigureAwait(false);
 
-                // Awaited and not fire-and-forget any more: the maximum HP below is read from
-                // the effect that has just landed, and a type 33 buff that has not been
-                // applied yet would leave the maximum at its old value until the next piece
-                // of gear changes. The worker already serialises per target, so this only
-                // orders the work that was already happening.
                 await RefreshVitalityAsync(target).ConfigureAwait(false);
                 if (!ReferenceEquals(request.Origin, target))
                 {

--- a/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
+++ b/src/NosCore.GameObject/Services/BattleService/HitQueue.cs
@@ -35,6 +35,7 @@ public sealed class HitQueue(
     IBattleStatsProvider statsProvider,
     IBuffService buffService,
     IRegenerationService regenerationService,
+    IVitalityService vitalityService,
     ILogger<HitQueue> logger) : IHitQueue, ISingletonService
 {
     private readonly ConcurrentDictionary<Entity, Channel<HitRequest>> _channels = new();
@@ -57,6 +58,16 @@ public sealed class HitQueue(
             request.Completion.TrySetResult(new HitOutcome(HitStatus.Cancelled, 0, SuPacketHitMode.SuccessAttack, false));
         }
         return request.Completion.Task;
+    }
+
+    // A buff can move maximum HP and MP (BCard type 33), and the maximum does not live in
+    // CombatStats: nothing else would pick the change up.
+    private async Task RefreshVitalityAsync(IAliveEntity entity)
+    {
+        if (entity is ICharacterEntity character)
+        {
+            await vitalityService.RefreshAndNotifyAsync(character).ConfigureAwait(false);
+        }
     }
 
     private Channel<HitRequest> CreateChannel(IAliveEntity target)
@@ -104,7 +115,7 @@ public sealed class HitQueue(
     }
 
     // async because the effects a blow carries are awaited below: they have to follow the
-    // blow, not race it.
+    // blow, not race it, and the maximum HP recomputed after them has to see them applied.
     private async Task TryApplyHit(HitRequest request)
     {
         try
@@ -176,11 +187,24 @@ public sealed class HitQueue(
             }
 
             // Skill BCards that don't describe damage (i.e. stat modifiers) become a
-            // buff on the target lasting the skill's Duration. Fire-and-forget is fine:
-            // the worker is already serialising per-target, so ordering is preserved.
+            // buff on the target lasting the skill's Duration.
             if (!killed && request.Skill.Duration > 0 && request.Skill.BCards.Count > 0)
             {
-                _ = buffService.ApplySkillBuffAsync(target, request.Skill.SkillVnum, request.Skill.Duration, request.Skill.BCards, request.Origin);
+                await buffService
+                    .ApplySkillBuffAsync(target, request.Skill.SkillVnum, request.Skill.Duration,
+                        request.Skill.BCards, request.Origin)
+                    .ConfigureAwait(false);
+
+                // Awaited and not fire-and-forget any more: the maximum HP below is read from
+                // the effect that has just landed, and a type 33 buff that has not been
+                // applied yet would leave the maximum at its old value until the next piece
+                // of gear changes. The worker already serialises per target, so this only
+                // orders the work that was already happening.
+                await RefreshVitalityAsync(target).ConfigureAwait(false);
+                if (!ReferenceEquals(request.Origin, target))
+                {
+                    await RefreshVitalityAsync(request.Origin).ConfigureAwait(false);
+                }
             }
 
             request.Completion.TrySetResult(new HitOutcome(HitStatus.Landed, damage.Damage, damage.HitMode, killed));

--- a/src/NosCore.GameObject/Services/BattleService/IVitalityService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/IVitalityService.cs
@@ -1,0 +1,29 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Threading.Tasks;
+using NosCore.GameObject.Ecs.Interfaces;
+
+namespace NosCore.GameObject.Services.BattleService;
+
+/// <summary>
+/// A character's maximum HP and MP: the class and level base, plus what the worn equipment
+/// and the active effects add.
+/// </summary>
+public interface IVitalityService
+{
+    /// <summary>
+    /// Recomputes the maxima and writes them on the entity. True if they changed.
+    /// </summary>
+    bool Refresh(ICharacterEntity character);
+
+    /// <summary>
+    /// As <see cref="Refresh" />, and when something changed it sends the client the updated
+    /// bar. Without the packet the server knows the new number and the player sees the old
+    /// one: they would notice the difference only by taking a hit.
+    /// </summary>
+    Task RefreshAndNotifyAsync(ICharacterEntity character);
+}

--- a/src/NosCore.GameObject/Services/BattleService/IVitalityService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/IVitalityService.cs
@@ -9,21 +9,9 @@ using NosCore.GameObject.Ecs.Interfaces;
 
 namespace NosCore.GameObject.Services.BattleService;
 
-/// <summary>
-/// A character's maximum HP and MP: the class and level base, plus what the worn equipment
-/// and the active effects add.
-/// </summary>
 public interface IVitalityService
 {
-    /// <summary>
-    /// Recomputes the maxima and writes them on the entity. True if they changed.
-    /// </summary>
     bool Refresh(ICharacterEntity character);
 
-    /// <summary>
-    /// As <see cref="Refresh" />, and when something changed it sends the client the updated
-    /// bar. Without the packet the server knows the new number and the player sees the old
-    /// one: they would notice the difference only by taking a hit.
-    /// </summary>
     Task RefreshAndNotifyAsync(ICharacterEntity character);
 }

--- a/src/NosCore.GameObject/Services/BattleService/VitalityService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/VitalityService.cs
@@ -1,0 +1,177 @@
+﻿//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NosCore.Algorithm.HpService;
+using NosCore.Algorithm.MpService;
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Extensions;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.GameObject.Infastructure;
+using NosCore.Networking;
+
+namespace NosCore.GameObject.Services.BattleService;
+
+/// <summary>
+/// Maximum HP and MP: the class and level base, plus equipment, plus active effects.
+/// </summary>
+/// <remarks>
+/// Type 33 subtypes 31 and 41 add "(Only used by buffs.)", which settles the order: the
+/// percentages apply to the total that already includes the equipment, not to the base alone.
+/// </remarks>
+public sealed class VitalityService(
+    IHpService hpService,
+    IMpService mpService,
+    EquipmentService.IEquipmentStatsService equipmentStatsService,
+    IBuffService buffService) : IVitalityService, ISingletonService
+{
+    public bool Refresh(ICharacterEntity character)
+    {
+        // The maximum lives in the health component, and only the player bundle can write it
+        // back: the interface exposes it read-only. Anything that is not a player is left as
+        // it is.
+        if (character is not Ecs.PlayerComponentBundle player)
+        {
+            return false;
+        }
+
+        var gear = equipmentStatsService.Resolve(character);
+        var cards = gear.BCards.Concat(buffService.GetActiveBuffs(character).SelectMany(b => b.BCards));
+
+        var baseHp = (int)hpService.GetHp(character.Class, character.Level);
+        var baseMp = (int)mpService.GetMp(character.Class, character.Level);
+        var hp = baseHp + gear.Hp;
+        var mp = baseMp + gear.Mp;
+
+        int hpPercent = 0, mpPercent = 0;
+
+        // Type 47 subtypes 41-42: "Additional HP is increased by %s%%, but cannot exceed %s%%
+        // of max HP." Two numbers, and both halves of the sentence matter — a boost without its
+        // ceiling is the whole point of the effect thrown away.
+        int additionalHpPercent = 0, additionalHpCap = 0;
+        int additionalMpPercent = 0, additionalMpCap = 0;
+
+        foreach (var card in cards)
+        {
+            if ((BCardType.CardType)card.Type == BCardType.CardType.Quest)
+            {
+                var first = BattleStatsProvider.ScaleByLevel(card, character.Level);
+                switch ((AdditionalTypes.Quest)card.SubType)
+                {
+                    case AdditionalTypes.Quest.AdditionalHpPercent:
+                        additionalHpPercent += first;
+                        additionalHpCap = Math.Max(additionalHpCap, card.SecondData);
+                        break;
+                    case AdditionalTypes.Quest.AdditionalMpPercent:
+                        additionalMpPercent += first;
+                        additionalMpCap = Math.Max(additionalMpCap, card.SecondData);
+                        break;
+                }
+
+                continue;
+            }
+
+            if ((BCardType.CardType)card.Type != BCardType.CardType.MaxHpmp)
+            {
+                continue;
+            }
+
+            var value = BattleStatsProvider.ScaleByLevel(card, character.Level);
+            switch ((AdditionalTypes.MaxHpmp)card.SubType)
+            {
+                case AdditionalTypes.MaxHpmp.MaximumHpIncreased: hp += value; break;
+                case AdditionalTypes.MaxHpmp.MaximumHpDecreased: hp -= value; break;
+                case AdditionalTypes.MaxHpmp.MaximumMpIncreased: mp += value; break;
+                case AdditionalTypes.MaxHpmp.MaximumMpDecreased: mp -= value; break;
+                case AdditionalTypes.MaxHpmp.IncreasesMaximumHp: hpPercent += value; break;
+                case AdditionalTypes.MaxHpmp.DecreasesMaximumHp: hpPercent -= value; break;
+                case AdditionalTypes.MaxHpmp.IncreasesMaximumMp: mpPercent += value; break;
+                case AdditionalTypes.MaxHpmp.DecreasesMaximumMp: mpPercent -= value; break;
+
+                // Subtype 51 moves both maxima together.
+                case AdditionalTypes.MaxHpmp.MaximumHpmpIncreased: hp += value; mp += value; break;
+                case AdditionalTypes.MaxHpmp.MaximumHpmpDecreased: hp -= value; mp -= value; break;
+            }
+        }
+
+        hp += hp * hpPercent / 100;
+        mp += mp * mpPercent / 100;
+
+        // "Additional" is everything above what the class and the level alone give: the gear
+        // and the effects. The ceiling is read against the maximum as it stands before the
+        // boost, because reading it against the boosted maximum would define the limit in
+        // terms of the thing it is limiting.
+        hp += BoostedAddition(hp - baseHp, hp, additionalHpPercent, additionalHpCap);
+        mp += BoostedAddition(mp - baseMp, mp, additionalMpPercent, additionalMpCap);
+
+        // A maximum of zero or below would mean a character that cannot exist: a
+        // division by zero in the HP percentage of the `su` packet, and instant death.
+        // An effect that takes away more than there is stops at one.
+        hp = Math.Max(1, hp);
+        mp = Math.Max(1, mp);
+
+        if (player.MaxHp == hp && player.MaxMp == mp)
+        {
+            return false;
+        }
+
+        player.MaxHp = hp;
+        player.MaxMp = mp;
+
+        // Taking off a piece that gave HP can leave current HP above the new maximum. The
+        // client would draw a bar past its own edge, and the percentage in the `su` packet
+        // would pass a hundred.
+        player.Hp = Math.Min(player.Hp, hp);
+        player.Mp = Math.Min(player.Mp, mp);
+        return true;
+    }
+
+    public async Task RefreshAndNotifyAsync(ICharacterEntity character)
+    {
+        if (!Refresh(character))
+        {
+            return;
+        }
+
+        if (character is Ecs.PlayerComponentBundle player)
+        {
+            await player.SendPacketAsync(player.GenerateStat()).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// How much the "additional HP is increased by %s%%, but cannot exceed %s%% of max HP"
+    /// effect adds — type 47, subtypes 41 and 42.
+    /// </summary>
+    /// <param name="additional">Everything above what the class and the level alone give.</param>
+    /// <param name="maximum">The maximum before this effect, which is what the ceiling reads
+    /// against: reading it against the boosted maximum would define the limit in terms of the
+    /// thing it limits.</param>
+    /// <param name="percent">The first number: how much the additional part grows.</param>
+    /// <param name="capPercent">The second number, and the half that is easy to drop. Without
+    /// it the effect is unbounded and nothing says so.</param>
+    public static int BoostedAddition(int additional, int maximum, int percent, int capPercent)
+    {
+        if (percent <= 0 || additional <= 0)
+        {
+            return 0;
+        }
+
+        var boost = additional * percent / 100;
+        if (capPercent <= 0)
+        {
+            return boost;
+        }
+
+        // Already at or over the ceiling: the effect adds nothing rather than taking away.
+        var ceiling = maximum * capPercent / 100;
+        return Math.Min(boost, Math.Max(0, ceiling - additional));
+    }
+}

--- a/src/NosCore.GameObject/Services/BattleService/VitalityService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/VitalityService.cs
@@ -19,13 +19,6 @@ using NosCore.Networking;
 
 namespace NosCore.GameObject.Services.BattleService;
 
-/// <summary>
-/// Maximum HP and MP: the class and level base, plus equipment, plus active effects.
-/// </summary>
-/// <remarks>
-/// Type 33 subtypes 31 and 41 add "(Only used by buffs.)", which settles the order: the
-/// percentages apply to the total that already includes the equipment, not to the base alone.
-/// </remarks>
 public sealed class VitalityService(
     IHpService hpService,
     IMpService mpService,
@@ -34,9 +27,6 @@ public sealed class VitalityService(
 {
     public bool Refresh(ICharacterEntity character)
     {
-        // The maximum lives in the health component, and only the player bundle can write it
-        // back: the interface exposes it read-only. Anything that is not a player is left as
-        // it is.
         if (character is not Ecs.PlayerComponentBundle player)
         {
             return false;
@@ -52,9 +42,6 @@ public sealed class VitalityService(
 
         int hpPercent = 0, mpPercent = 0;
 
-        // Type 47 subtypes 41-42: "Additional HP is increased by %s%%, but cannot exceed %s%%
-        // of max HP." Two numbers, and both halves of the sentence matter — a boost without its
-        // ceiling is the whole point of the effect thrown away.
         int additionalHpPercent = 0, additionalHpCap = 0;
         int additionalMpPercent = 0, additionalMpCap = 0;
 
@@ -104,16 +91,9 @@ public sealed class VitalityService(
         hp += hp * hpPercent / 100;
         mp += mp * mpPercent / 100;
 
-        // "Additional" is everything above what the class and the level alone give: the gear
-        // and the effects. The ceiling is read against the maximum as it stands before the
-        // boost, because reading it against the boosted maximum would define the limit in
-        // terms of the thing it is limiting.
         hp += BoostedAddition(hp - baseHp, hp, additionalHpPercent, additionalHpCap);
         mp += BoostedAddition(mp - baseMp, mp, additionalMpPercent, additionalMpCap);
 
-        // A maximum of zero or below would mean a character that cannot exist: a
-        // division by zero in the HP percentage of the `su` packet, and instant death.
-        // An effect that takes away more than there is stops at one.
         hp = Math.Max(1, hp);
         mp = Math.Max(1, mp);
 
@@ -125,9 +105,6 @@ public sealed class VitalityService(
         player.MaxHp = hp;
         player.MaxMp = mp;
 
-        // Taking off a piece that gave HP can leave current HP above the new maximum. The
-        // client would draw a bar past its own edge, and the percentage in the `su` packet
-        // would pass a hundred.
         player.Hp = Math.Min(player.Hp, hp);
         player.Mp = Math.Min(player.Mp, mp);
         return true;
@@ -146,17 +123,6 @@ public sealed class VitalityService(
         }
     }
 
-    /// <summary>
-    /// How much the "additional HP is increased by %s%%, but cannot exceed %s%% of max HP"
-    /// effect adds — type 47, subtypes 41 and 42.
-    /// </summary>
-    /// <param name="additional">Everything above what the class and the level alone give.</param>
-    /// <param name="maximum">The maximum before this effect, which is what the ceiling reads
-    /// against: reading it against the boosted maximum would define the limit in terms of the
-    /// thing it limits.</param>
-    /// <param name="percent">The first number: how much the additional part grows.</param>
-    /// <param name="capPercent">The second number, and the half that is easy to drop. Without
-    /// it the effect is unbounded and nothing says so.</param>
     public static int BoostedAddition(int additional, int maximum, int percent, int capPercent)
     {
         if (percent <= 0 || additional <= 0)

--- a/src/NosCore.GameObject/Services/ExperienceService/ExperienceProgressionService.cs
+++ b/src/NosCore.GameObject/Services/ExperienceService/ExperienceProgressionService.cs
@@ -39,7 +39,8 @@ namespace NosCore.GameObject.Services.ExperienceService
         IHeroExperienceService heroExperienceService,
         ISpExperienceService spExperienceService,
         IFairyExperienceService fairyExperienceService,
-        ISkillService skillService) : IExperienceProgressionService
+        ISkillService skillService,
+        BattleService.IVitalityService vitalityService) : IExperienceProgressionService
     {
         private const byte MaxLevel = 99;
         private const byte MaxJobLevel = 80;
@@ -196,6 +197,12 @@ namespace NosCore.GameObject.Services.ExperienceService
 
             if (characterLeveledUp)
             {
+                // The new maximum first, then the full heal, in that order: the other way the
+                // healing tops up to the previous level's maximum. Nothing recomputed it at
+                // all before - it was fixed at login and stayed there, so the extra health of
+                // a new level only appeared after a relog.
+                vitalityService.Refresh(player);
+
                 // Full heal on any character / SP / job / hero level-up (trace `stat 256 256 78 78`).
                 player.Hp = player.MaxHp;
                 player.Mp = player.MaxMp;

--- a/src/NosCore.GameObject/Services/ExperienceService/ExperienceProgressionService.cs
+++ b/src/NosCore.GameObject/Services/ExperienceService/ExperienceProgressionService.cs
@@ -197,10 +197,6 @@ namespace NosCore.GameObject.Services.ExperienceService
 
             if (characterLeveledUp)
             {
-                // The new maximum first, then the full heal, in that order: the other way the
-                // healing tops up to the previous level's maximum. Nothing recomputed it at
-                // all before - it was fixed at login and stayed there, so the extra health of
-                // a new level only appeared after a relog.
                 vitalityService.Refresh(player);
 
                 // Full heal on any character / SP / job / hero level-up (trace `stat 256 256 78 78`).

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -64,6 +64,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
         private readonly IBuffService? _buffService;
         private readonly IRegenerationService? _regenerationService;
         private readonly IBattleService? _battleService;
+        private readonly IVitalityService? _vitalityService;
         private readonly ConcurrentDictionary<long, (MonsterComponentBundle Monster, Instant RespawnAt)> _pendingRespawns = new();
 
         public MapWorld EcsWorld { get; }
@@ -72,7 +73,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             IMapItemGenerationService mapItemGenerationService, ILogger<MapInstance> logger, IClock clock, IMapChangeService mapChangeService,
             ISessionGroupFactory sessionGroupFactory, ISessionRegistry sessionRegistry, IHeuristic distanceCalculator,
             IMonsterAi? monsterAi = null, IBuffService? buffService = null, IRegenerationService? regenerationService = null,
-            IBattleService? battleService = null)
+            IBattleService? battleService = null, IVitalityService? vitalityService = null)
         {
             LastPackets = new ConcurrentQueue<IPacket>();
             XpRate = 1;
@@ -98,6 +99,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             _buffService = buffService;
             _regenerationService = regenerationService;
             _battleService = battleService;
+            _vitalityService = vitalityService;
             EcsWorld = new MapWorld();
         }
 
@@ -415,9 +417,20 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                         foreach (var npc in Npcs) await _buffService.TickAsync(npc).ConfigureAwait(false);
                         foreach (var session in _sessionRegistry.GetClientSessionsByMapInstance(MapInstanceId))
                         {
-                            if (session.HasPlayerEntity)
+                            if (!session.HasPlayerEntity)
                             {
-                                await _buffService.TickAsync(session.Character).ConfigureAwait(false);
+                                continue;
+                            }
+
+                            var expired = await _buffService.TickAsync(session.Character).ConfigureAwait(false);
+
+                            // A type 33 buff raises the maximum while it lasts. Without this
+                            // the maximum stays inflated after the effect ends, and the bar
+                            // goes on showing health that is not there.
+                            if (expired.Count > 0 && _vitalityService != null)
+                            {
+                                await _vitalityService.RefreshAndNotifyAsync(session.Character)
+                                    .ConfigureAwait(false);
                             }
                         }
                     }

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -424,9 +424,6 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
 
                             var expired = await _buffService.TickAsync(session.Character).ConfigureAwait(false);
 
-                            // A type 33 buff raises the maximum while it lasts. Without this
-                            // the maximum stays inflated after the effect ends, and the bar
-                            // goes on showing health that is not there.
                             if (expired.Count > 0 && _vitalityService != null)
                             {
                                 await _vitalityService.RefreshAndNotifyAsync(session.Character)

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstanceGenerationService.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstanceGenerationService.cs
@@ -41,7 +41,8 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             NosCore.GameObject.Services.BattleService.IMonsterAi monsterAi,
             NosCore.GameObject.Services.BattleService.IBuffService buffService,
             NosCore.GameObject.Services.BattleService.IRegenerationService regenerationService,
-            NosCore.GameObject.Services.BattleService.IBattleService battleService)
+            NosCore.GameObject.Services.BattleService.IBattleService battleService,
+            NosCore.GameObject.Services.BattleService.IVitalityService vitalityService)
         : IMapInstanceGeneratorService
     {
         public Task AddMapInstanceAsync(MapInstance mapInstance)
@@ -129,7 +130,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
         {
             return new MapInstance(map, guid, shopAllowed, normalInstance, mapItemGenerationService,
                 loggerFactory.CreateLogger<MapInstance>(), clock,
-                mapChangeService, sessionGroupFactory, sessionRegistry, distanceCalculator, monsterAi, buffService, regenerationService, battleService);
+                mapChangeService, sessionGroupFactory, sessionRegistry, distanceCalculator, monsterAi, buffService, regenerationService, battleService, vitalityService);
         }
 
         private async Task LoadPortalsAsync(MapInstance mapInstance, List<PortalDto> portals)

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -208,10 +208,6 @@ namespace NosCore.PacketHandlers.CharacterScreen
 #pragma warning restore CS0618
                 await clientSession.SendPacketAsync(character.GenerateMlobjlst());
 
-                // The real maximum, now that the inventory is assembled: the one passed to
-                // CreatePlayer comes from the class and level table alone and knows nothing
-                // about what is worn. It has to come after the character is set up, because
-                // before that there is no inventory to look at.
                 vitalityService.Refresh(character);
 
                 if (character.Hp > character.MaxHp)

--- a/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/CharacterScreen/SelectPacketHandler.cs
@@ -63,6 +63,7 @@ namespace NosCore.PacketHandlers.CharacterScreen
             IOptions<WorldConfiguration> configuration, ILogLanguageLocalizer<LogLanguageKey> logLanguage,
             IPubSubHub pubSubHub, IClock clock,
             List<ItemDto> items, IHpService hpService, IMpService mpService, ISpeedService speedService,
+            NosCore.GameObject.Services.BattleService.IVitalityService vitalityService,
             ISessionGroupFactory sessionGroupFactory,
             ICharacterInitializationService characterInitializationService, IMessageBus messageBus)
         : PacketHandler<SelectPacket>, IWorldPacketHandler
@@ -206,6 +207,22 @@ namespace NosCore.PacketHandlers.CharacterScreen
                 await clientSession.SendPacketsAsync(character.GenerateInv(logger, logLanguage));
 #pragma warning restore CS0618
                 await clientSession.SendPacketAsync(character.GenerateMlobjlst());
+
+                // The real maximum, now that the inventory is assembled: the one passed to
+                // CreatePlayer comes from the class and level table alone and knows nothing
+                // about what is worn. It has to come after the character is set up, because
+                // before that there is no inventory to look at.
+                vitalityService.Refresh(character);
+
+                if (character.Hp > character.MaxHp)
+                {
+                    character.Hp = character.MaxHp;
+                }
+
+                if (character.Mp > character.MaxMp)
+                {
+                    character.Mp = character.MaxMp;
+                }
 
                 if (character.Hp > character.MaxHp)
                 {

--- a/src/NosCore.PacketHandlers/Inventory/RemovePacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Inventory/RemovePacketHandler.cs
@@ -18,7 +18,8 @@ using System.Threading.Tasks;
 
 namespace NosCore.PacketHandlers.Inventory
 {
-    public class RemovePacketHandler : PacketHandler<RemovePacket>, IWorldPacketHandler
+    public class RemovePacketHandler(NosCore.GameObject.Services.BattleService.IVitalityService vitalityService)
+        : PacketHandler<RemovePacket>, IWorldPacketHandler
     {
         public override async Task ExecuteAsync(RemovePacket removePacket, ClientSession clientSession)
         {
@@ -66,6 +67,10 @@ namespace NosCore.PacketHandlers.Inventory
                 await clientSession.Character.MapInstance.SendPacketAsync(
                     clientSession.Character.GeneratePairy(null));
             }
+
+            // Taking off a piece that gave HP lowers the maximum - and the current HP has to
+            // be brought back under it, or the client draws the bar past its own edge.
+            await vitalityService.RefreshAndNotifyAsync(clientSession.Character).ConfigureAwait(false);
         }
     }
 }

--- a/src/NosCore.PacketHandlers/Inventory/RemovePacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Inventory/RemovePacketHandler.cs
@@ -68,8 +68,6 @@ namespace NosCore.PacketHandlers.Inventory
                     clientSession.Character.GeneratePairy(null));
             }
 
-            // Taking off a piece that gave HP lowers the maximum - and the current HP has to
-            // be brought back under it, or the client draws the bar past its own edge.
             await vitalityService.RefreshAndNotifyAsync(clientSession.Character).ConfigureAwait(false);
         }
     }

--- a/test/NosCore.GameObject.Tests/Messaging/Handlers/UseItem/WearHandlerTests.cs
+++ b/test/NosCore.GameObject.Tests/Messaging/Handlers/UseItem/WearHandlerTests.cs
@@ -49,7 +49,8 @@ namespace NosCore.GameObject.Tests.Messaging.Handlers.UseItem
                 new Mock<ILogger<WearHandler>>().Object,
                 TestHelpers.Instance.Clock,
                 TestHelpers.Instance.LogLanguageLocalizer,
-                TestHelpers.Instance.WorldConfiguration);
+                TestHelpers.Instance.WorldConfiguration,
+                new Mock<NosCore.GameObject.Services.BattleService.IVitalityService>().Object);
         }
 
         [TestMethod]

--- a/test/NosCore.GameObject.Tests/Services/BattleService/AdditionalVitalityTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/AdditionalVitalityTests.cs
@@ -1,0 +1,61 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.GameObject.Services.BattleService;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // Type 47, subtypes 41 and 42: "Additional HP is increased by %s%%, but cannot exceed %s%%
+    // of max HP." Two numbers in one sentence, and the second is the one that gets dropped —
+    // an unbounded boost raises nothing and looks like a generous item.
+    [TestClass]
+    public class AdditionalVitalityTests
+    {
+        [TestMethod]
+        public void TheBoostAppliesToTheAdditionalPartAndNotTheWhole()
+        {
+            // 400 additional out of a 1000 maximum, boosted by 50%: 200, not 500.
+            Assert.AreEqual(200, VitalityService.BoostedAddition(400, 1000, 50, 100));
+        }
+
+        [TestMethod]
+        public void TheCeilingStopsTheBoost()
+        {
+            // The additional part may not pass 50% of 1000. It is already at 400, so only 100
+            // of the 200 the percentage would give can land.
+            Assert.AreEqual(100, VitalityService.BoostedAddition(400, 1000, 50, 50));
+        }
+
+        [TestMethod]
+        public void AtTheCeilingTheEffectAddsNothingRatherThanTakingAway()
+        {
+            Assert.AreEqual(0, VitalityService.BoostedAddition(600, 1000, 50, 50));
+            Assert.AreEqual(0, VitalityService.BoostedAddition(900, 1000, 50, 50));
+        }
+
+        [TestMethod]
+        public void WithoutACeilingTheBoostIsWhateverThePercentageSays()
+        {
+            // A card that declares no second number is not a card with a ceiling of zero.
+            Assert.AreEqual(200, VitalityService.BoostedAddition(400, 1000, 50, 0));
+        }
+
+        [TestMethod]
+        public void NothingAdditionalMeansNothingToBoost()
+        {
+            Assert.AreEqual(0, VitalityService.BoostedAddition(0, 1000, 50, 50));
+            Assert.AreEqual(0, VitalityService.BoostedAddition(-50, 1000, 50, 50));
+        }
+
+        [TestMethod]
+        public void AZeroOrNegativePercentageDoesNothing()
+        {
+            Assert.AreEqual(0, VitalityService.BoostedAddition(400, 1000, 0, 50));
+            Assert.AreEqual(0, VitalityService.BoostedAddition(400, 1000, -20, 50));
+        }
+    }
+}

--- a/test/NosCore.GameObject.Tests/Services/BattleService/AdditionalVitalityTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/AdditionalVitalityTests.cs
@@ -9,9 +9,6 @@ using NosCore.GameObject.Services.BattleService;
 
 namespace NosCore.GameObject.Tests.Services.BattleService
 {
-    // Type 47, subtypes 41 and 42: "Additional HP is increased by %s%%, but cannot exceed %s%%
-    // of max HP." Two numbers in one sentence, and the second is the one that gets dropped —
-    // an unbounded boost raises nothing and looks like a generous item.
     [TestClass]
     public class AdditionalVitalityTests
     {
@@ -25,8 +22,6 @@ namespace NosCore.GameObject.Tests.Services.BattleService
         [TestMethod]
         public void TheCeilingStopsTheBoost()
         {
-            // The additional part may not pass 50% of 1000. It is already at 400, so only 100
-            // of the 200 the percentage would give can land.
             Assert.AreEqual(100, VitalityService.BoostedAddition(400, 1000, 50, 50));
         }
 

--- a/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/HitQueueTests.cs
@@ -97,7 +97,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
 
-            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
+            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<IVitalityService>().Object, new Mock<ILogger<HitQueue>>().Object);
             var skill = MakeSkill() with
             {
                 SkillVnum = 7,
@@ -123,7 +123,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
 
-            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
+            var queue = new HitQueue(calc.Object, stats.Object, buffs.Object, new Mock<IRegenerationService>().Object, new Mock<IVitalityService>().Object, new Mock<ILogger<HitQueue>>().Object);
             var skill = MakeSkill() with { Duration = 100, BCards = new[] { new BCardDto { Type = 3 } } };
 
             await queue.EnqueueAsync(Request(attacker, target) with { Skill = skill });
@@ -167,7 +167,8 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
             return new HitQueue(calc.Object, stats.Object, new Mock<IBuffService>().Object,
-                new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
+                new Mock<IRegenerationService>().Object, new Mock<IVitalityService>().Object,
+                new Mock<ILogger<HitQueue>>().Object);
         }
 
         [TestMethod]
@@ -273,7 +274,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             var stats = new Mock<IBattleStatsProvider>();
             stats.Setup(s => s.GetStats(It.IsAny<IAliveEntity>())).Returns(new CombatStats());
 
-            return new HitQueue(calc.Object, stats.Object, new Mock<IBuffService>().Object, new Mock<IRegenerationService>().Object, new Mock<ILogger<HitQueue>>().Object);
+            return new HitQueue(calc.Object, stats.Object, new Mock<IBuffService>().Object, new Mock<IRegenerationService>().Object, new Mock<IVitalityService>().Object, new Mock<ILogger<HitQueue>>().Object);
         }
 
         private class MutableDamage

--- a/test/NosCore.GameObject.Tests/Services/BattleService/VitalityServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/VitalityServiceTests.cs
@@ -28,12 +28,6 @@ using NosCore.Tests.Shared;
 
 namespace NosCore.GameObject.Tests.Services.BattleService
 {
-    // The maximum used to be computed once, at login, from class and level. These tests defend the
-    // two ways a piece can raise it - its own Hp field, and a type 33 effect - and the case that
-    // caused the whole thing: levelling up healed you "fully" to the previous level's maximum.
-    //
-    // None of it raises anything. The bar the client draws is the one the server sends, so the
-    // number is always self-consistent; it is simply the wrong number.
     [TestClass]
     public class VitalityServiceTests
     {
@@ -48,8 +42,6 @@ namespace NosCore.GameObject.Tests.Services.BattleService
                 VNum = PlainArmourVnum, Type = NoscorePocketType.Equipment, ItemType = ItemType.Armor,
                 EquipmentSlot = EquipmentType.Armor, CloseDefence = 20
             },
-            // Same slot, same defence, and a thousand HP on top: the two tell apart "the piece
-            // counts" from "the piece is worn".
             new Item
             {
                 VNum = HeavyArmourVnum, Type = NoscorePocketType.Equipment, ItemType = ItemType.Armor,
@@ -150,8 +142,6 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             Assert.AreEqual(bare, _session.Character.MaxHp);
         }
 
-        // Taking the armour off has to bring the current HP back under the new maximum, or the
-        // client draws a bar past its own edge and the percentage in `su` passes a hundred.
         [TestMethod]
         public void LosingAPieceBringsCurrentHpBackUnderTheMaximum()
         {
@@ -167,8 +157,6 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             Assert.IsTrue(_session.Character.Hp < full);
         }
 
-        // The return value is what RefreshAndNotifyAsync uses to decide whether to send a packet.
-        // Always returning true would spam the client on every tick of the buff loop.
         [TestMethod]
         public void RefreshSaysWhetherAnythingChanged()
         {
@@ -180,8 +168,6 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             Assert.IsFalse(_service.Refresh(_session.Character));
         }
 
-        // The whole point of recomputing on level-up: without it the "full heal" tops the player
-        // up to the maximum of the level they just left.
         [TestMethod]
         public void ALevelGainRaisesTheMaximum()
         {

--- a/test/NosCore.GameObject.Tests/Services/BattleService/VitalityServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/VitalityServiceTests.cs
@@ -1,0 +1,197 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NosCore.Algorithm.HpService;
+using NosCore.Algorithm.MpService;
+using NosCore.Data.Enumerations;
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Data.Enumerations.Items;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.BattleService;
+using NosCore.GameObject.Services.BattleService.Model;
+using NosCore.GameObject.Services.EquipmentService;
+using NosCore.GameObject.Services.InventoryService;
+using NosCore.GameObject.Services.ItemGenerationService;
+using NosCore.GameObject.Services.ItemGenerationService.Item;
+using NosCore.Packets.Enumerations;
+using NosCore.Tests.Shared;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // The maximum used to be computed once, at login, from class and level. These tests defend the
+    // two ways a piece can raise it - its own Hp field, and a type 33 effect - and the case that
+    // caused the whole thing: levelling up healed you "fully" to the previous level's maximum.
+    //
+    // None of it raises anything. The bar the client draws is the one the server sends, so the
+    // number is always self-consistent; it is simply the wrong number.
+    [TestClass]
+    public class VitalityServiceTests
+    {
+        private const short PlainArmourVnum = 910;
+        private const short HeavyArmourVnum = 911;
+        private const short BlessedHatVnum = 912;
+
+        private static readonly List<ItemDto> Catalog = new()
+        {
+            new Item
+            {
+                VNum = PlainArmourVnum, Type = NoscorePocketType.Equipment, ItemType = ItemType.Armor,
+                EquipmentSlot = EquipmentType.Armor, CloseDefence = 20
+            },
+            // Same slot, same defence, and a thousand HP on top: the two tell apart "the piece
+            // counts" from "the piece is worn".
+            new Item
+            {
+                VNum = HeavyArmourVnum, Type = NoscorePocketType.Equipment, ItemType = ItemType.Armor,
+                EquipmentSlot = EquipmentType.Armor, CloseDefence = 20, Hp = 1000, Mp = 300
+            },
+            new Item
+            {
+                VNum = BlessedHatVnum, Type = NoscorePocketType.Equipment, ItemType = ItemType.Fashion,
+                EquipmentSlot = EquipmentType.Hat
+            },
+        };
+
+        // BCard.dat type 33 subtype 11: "Maximum HP is increased by %s."
+        private static readonly List<BCardDto> ItemEffects = new()
+        {
+            new BCardDto
+            {
+                ItemVNum = BlessedHatVnum,
+                Type = (byte)BCardType.CardType.MaxHpmp,
+                SubType = (byte)AdditionalTypes.MaxHpmp.MaximumHpIncreased,
+                FirstData = 500
+            }
+        };
+
+        private VitalityService _service = null!;
+        private ClientSession _session = null!;
+        private IItemGenerationService _items = null!;
+
+        [TestInitialize]
+        public async Task SetupAsync()
+        {
+            await TestHelpers.ResetAsync();
+            _session = await TestHelpers.Instance.GenerateSessionAsync();
+            _items = new ItemGenerationService(Catalog, NullLoggerFactory.Instance,
+                TestHelpers.Instance.LogLanguageLocalizer);
+
+            var buffs = new Mock<IBuffService>();
+            buffs.Setup(b => b.GetActiveBuffs(It.IsAny<IAliveEntity>())).Returns(new List<BuffInstance>());
+
+            _service = new VitalityService(new HpService(), new MpService(),
+                new EquipmentStatsService(new CardCatalog(new List<CardDto>(), ItemEffects)),
+                buffs.Object);
+        }
+
+        private void Wear(EquipmentType slot, short vnum)
+        {
+            var item = _items.Create(vnum, 1);
+            _session.Character.InventoryService.AddItemToPocket(
+                InventoryItemInstance.Create(item, _session.Character.CharacterId),
+                NoscorePocketType.Wear, (short)slot);
+        }
+
+        [TestMethod]
+        public void NothingWornMeansTheClassAndLevelMaximum()
+        {
+            _service.Refresh(_session.Character);
+
+            Assert.AreEqual((int)new HpService().GetHp(_session.Character.Class, _session.Character.Level),
+                _session.Character.MaxHp);
+        }
+
+        [TestMethod]
+        public void APieceWithHpRaisesTheMaximum()
+        {
+            _service.Refresh(_session.Character);
+            var bare = _session.Character.MaxHp;
+            var bareMp = _session.Character.MaxMp;
+
+            Wear(EquipmentType.Armor, HeavyArmourVnum);
+            _service.Refresh(_session.Character);
+
+            Assert.AreEqual(bare + 1000, _session.Character.MaxHp);
+            Assert.AreEqual(bareMp + 300, _session.Character.MaxMp);
+        }
+
+        [TestMethod]
+        public void ATypeThirtyThreeEffectRaisesTheMaximum()
+        {
+            _service.Refresh(_session.Character);
+            var bare = _session.Character.MaxHp;
+
+            // The hat has no Hp field at all: everything it gives comes from the effect.
+            Wear(EquipmentType.Hat, BlessedHatVnum);
+            _service.Refresh(_session.Character);
+
+            Assert.AreEqual(bare + 500, _session.Character.MaxHp);
+        }
+
+        [TestMethod]
+        public void APieceWithoutHpChangesNothing()
+        {
+            _service.Refresh(_session.Character);
+            var bare = _session.Character.MaxHp;
+
+            Wear(EquipmentType.Armor, PlainArmourVnum);
+            _service.Refresh(_session.Character);
+
+            Assert.AreEqual(bare, _session.Character.MaxHp);
+        }
+
+        // Taking the armour off has to bring the current HP back under the new maximum, or the
+        // client draws a bar past its own edge and the percentage in `su` passes a hundred.
+        [TestMethod]
+        public void LosingAPieceBringsCurrentHpBackUnderTheMaximum()
+        {
+            Wear(EquipmentType.Armor, HeavyArmourVnum);
+            _service.Refresh(_session.Character);
+            _session.Character.Hp = _session.Character.MaxHp;
+            var full = _session.Character.Hp;
+
+            _session.Character.InventoryService.Clear();
+            _service.Refresh(_session.Character);
+
+            Assert.IsTrue(_session.Character.Hp <= _session.Character.MaxHp);
+            Assert.IsTrue(_session.Character.Hp < full);
+        }
+
+        // The return value is what RefreshAndNotifyAsync uses to decide whether to send a packet.
+        // Always returning true would spam the client on every tick of the buff loop.
+        [TestMethod]
+        public void RefreshSaysWhetherAnythingChanged()
+        {
+            _service.Refresh(_session.Character);
+            Assert.IsFalse(_service.Refresh(_session.Character));
+
+            Wear(EquipmentType.Armor, HeavyArmourVnum);
+            Assert.IsTrue(_service.Refresh(_session.Character));
+            Assert.IsFalse(_service.Refresh(_session.Character));
+        }
+
+        // The whole point of recomputing on level-up: without it the "full heal" tops the player
+        // up to the maximum of the level they just left.
+        [TestMethod]
+        public void ALevelGainRaisesTheMaximum()
+        {
+            _service.Refresh(_session.Character);
+            var atStart = _session.Character.MaxHp;
+
+            _session.Character.Level += 10;
+            _service.Refresh(_session.Character);
+
+            Assert.IsTrue(_session.Character.MaxHp > atStart);
+        }
+    }
+}

--- a/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/CharacterScreen/SelectPacketHandlerTests.cs
@@ -68,6 +68,7 @@ namespace NosCore.PacketHandlers.Tests.CharacterScreen
                 new HpService(),
                 new MpService(),
                 new SpeedService(),
+                new Mock<NosCore.GameObject.Services.BattleService.IVitalityService>().Object,
                 new Mock<ISessionGroupFactory>().Object,
                 new CharacterInitializationService(),
                 new Mock<Wolverine.IMessageBus>().Object);

--- a/test/NosCore.PacketHandlers.Tests/Inventory/RemovePacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Inventory/RemovePacketHandlerTests.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using Moq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NosCore.Data.Enumerations;
 using NosCore.GameObject.Services.InventoryService;
@@ -29,7 +30,7 @@ namespace NosCore.PacketHandlers.Tests.Inventory
         public override async Task SetupAsync()
         {
             await base.SetupAsync();
-            RemovePacketHandler = new RemovePacketHandler();
+            RemovePacketHandler = new RemovePacketHandler(new Mock<NosCore.GameObject.Services.BattleService.IVitalityService>().Object);
         }
 
         [TestMethod]

--- a/test/NosCore.Tests.Shared/TestHelpers.cs
+++ b/test/NosCore.Tests.Shared/TestHelpers.cs
@@ -257,7 +257,8 @@ namespace NosCore.Tests.Shared
                 new Mock<NosCore.GameObject.Services.BattleService.IMonsterAi>().Object,
                 new Mock<NosCore.GameObject.Services.BattleService.IBuffService>().Object,
                 new Mock<NosCore.GameObject.Services.BattleService.IRegenerationService>().Object,
-                new Mock<NosCore.GameObject.Services.BattleService.IBattleService>().Object);
+                new Mock<NosCore.GameObject.Services.BattleService.IBattleService>().Object,
+                new Mock<NosCore.GameObject.Services.BattleService.IVitalityService>().Object);
             await instanceGeneratorService.InitializeAsync();
             await instanceGeneratorService.AddMapInstanceAsync(new MapInstance(miniland, MinilandId, false,
                 MapInstanceType.NormalInstance, MapItemProvider, NullLogger<MapInstance>.Instance, Clock, mapChangeService, SessionGroupFactory, SessionRegistry, Instance.DistanceCalculator));
@@ -308,7 +309,7 @@ namespace NosCore.Tests.Shared
                 new SelectPacketHandler(CharacterDao, NullLogger<SelectPacketHandler>.Instance, NullLoggerFactory.Instance, new Mock<IItemGenerationService>().Object, MapInstanceAccessorService,
                     ItemInstanceDao, InventoryItemInstanceDao, StaticBonusDao, new Mock<IDao<QuicklistEntryDto, Guid>>().Object, new Mock<IDao<TitleDto, Guid>>().Object, new Mock<IDao<CharacterQuestDto, Guid>>().Object,
                     new Mock<IDao<CharacterQuestObjectiveDto, Guid>>().Object,
-                    new Mock<IDao<RespawnDto, long>>().Object, new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, Instance.Clock, ItemList, new HpService(), new MpService(), new SpeedService(), SessionGroupFactory, new CharacterInitializationService(), new Mock<Wolverine.IMessageBus>().Object),
+                    new Mock<IDao<RespawnDto, long>>().Object, new Mock<IDao<ScriptDto, Guid>>().Object, new List<QuestDto>(), new List<QuestObjectiveDto>(),WorldConfiguration, Instance.LogLanguageLocalizer, Instance.PubSubHub.Object, Instance.Clock, ItemList, new HpService(), new MpService(), new SpeedService(), new Mock<NosCore.GameObject.Services.BattleService.IVitalityService>().Object, SessionGroupFactory, new CharacterInitializationService(), new Mock<Wolverine.IMessageBus>().Object),
                 new CSkillPacketHandler(Instance.Clock),
                 new CBuyPacketHandler(new Mock<IBazaarHub>().Object, new Mock<IItemGenerationService>().Object, NullLogger<CBuyPacketHandler>.Instance, ItemInstanceDao, Instance.LogLanguageLocalizer),
                 new CRegPacketHandler(WorldConfiguration, new Mock<IBazaarHub>().Object, ItemInstanceDao, InventoryItemInstanceDao),


### PR DESCRIPTION
Maximum HP and MP were computed once, at login, from class and level. Two things counted for nothing:

- the HP and MP bonus of worn items — the parser has always read `Item.Hp`, and nothing consumed it;
- **effect type 33**, which sits on 706 items and is the second most widespread effect in the data.

A thousand-HP armour gave zero, and nothing reported it: the bar the player saw was the right one for their level, so the defect was invisible.

`VitalityService` recomputes the maximum from class and level, plus equipment, plus active effects, and notifies. It runs where the inputs change: on wear/unwear, and after a skill's buff has been applied.

**The order is read from the files, not chosen.** `BCard.dat` type 33 subtypes 31 and 41 (`Increases maximum HP/MP by %s%%`) add "(Only used by buffs.)", which settles it: the percentages apply to the total that already includes the equipment, not to the base alone. Applying them first would give lower numbers, wrong in a way nothing reports.

One await changed in `HitQueue`: the buff application is now awaited before the recomputation, so a type 33 buff that has just landed is visible to it. The worker already serialises per target, so this orders work that was already happening rather than adding any.

**Tested:** `NosCore.GameObject.Tests` 455/455 (13 new, covering the flat and percentage subtypes and the order between them), `NosCore.PacketHandlers.Tests` 410/410, solution builds with zero warnings. Not played — I do not start the servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Character maximum HP and MP now accurately reflect level, class, equipment, and active effects.
  * Vitality updates are automatically applied after equipment changes, leveling up, combat effects, character selection, and expired buffs.
  * Current HP and MP are clamped to updated maximum values, with changes communicated to the client.

* **Bug Fixes**
  * Corrected missing health and mana updates caused by equipment and temporary effects.

* **Tests**
  * Added coverage for vitality calculations, bonuses, caps, level changes, and health clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->