### PR TITLE
The specialist card's skills, told by the file and not by arithmetic

### DIFF
--- a/src/NosCore.GameObject/Services/SkillService/ISkillService.cs
+++ b/src/NosCore.GameObject/Services/SkillService/ISkillService.cs
@@ -7,12 +7,6 @@ namespace NosCore.GameObject.Services.SkillService
     {
         Task LoadSkill(ICharacterEntity character);
 
-        /// <summary>
-        /// Loads the worn specialist card's skills and sends them to the client.
-        ///
-        /// They are a set apart from the class ones: while transformed only those are used,
-        /// and taking the card off makes them disappear.
-        /// </summary>
         Task LoadSpecialistSkillsAsync(ICharacterEntity character, short morph, byte spLevel);
 
         /// <summary>Removes the specialist skills and sends the class list back.</summary>

--- a/src/NosCore.GameObject/Services/SkillService/ISkillService.cs
+++ b/src/NosCore.GameObject/Services/SkillService/ISkillService.cs
@@ -7,6 +7,17 @@ namespace NosCore.GameObject.Services.SkillService
     {
         Task LoadSkill(ICharacterEntity character);
 
+        /// <summary>
+        /// Loads the worn specialist card's skills and sends them to the client.
+        ///
+        /// They are a set apart from the class ones: while transformed only those are used,
+        /// and taking the card off makes them disappear.
+        /// </summary>
+        Task LoadSpecialistSkillsAsync(ICharacterEntity character, short morph, byte spLevel);
+
+        /// <summary>Removes the specialist skills and sends the class list back.</summary>
+        Task UnloadSpecialistSkillsAsync(ICharacterEntity character);
+
         Task<bool> LearnClassSkillsAsync(ICharacterEntity character);
 
         /// <summary>

--- a/src/NosCore.GameObject/Services/SkillService/SkillService.cs
+++ b/src/NosCore.GameObject/Services/SkillService/SkillService.cs
@@ -36,13 +36,13 @@ namespace NosCore.GameObject.Services.SkillService
             await SendSkillListAsync(character, useSpecialist: false);
         }
 
-        private const int FirstSpecialistClass = 31;
+        private const int PyjamaSpecialistClass = 32;
 
         public async Task LoadSpecialistSkillsAsync(ICharacterEntity character, short morph, byte spLevel)
         {
             RemoveSpecialistSkills(character);
 
-            foreach (var skill in skills.Where(s => s.Class > FirstSpecialistClass
+            foreach (var skill in skills.Where(s => s.Class >= PyjamaSpecialistClass
                                                     && s.UpgradeType == morph
                                                     && s.LevelMinimum <= spLevel))
             {
@@ -68,7 +68,7 @@ namespace NosCore.GameObject.Services.SkillService
         private static void RemoveSpecialistSkills(ICharacterEntity character)
         {
             foreach (var entry in character.Skills
-                         .Where(s => s.Value.Skill?.Class >= FirstSpecialistClass)
+                         .Where(s => s.Value.Skill?.Class >= PyjamaSpecialistClass)
                          .ToList())
             {
                 character.Skills.TryRemove(entry.Key, out _);
@@ -78,7 +78,7 @@ namespace NosCore.GameObject.Services.SkillService
         private async Task SendSkillListAsync(ICharacterEntity character, bool useSpecialist)
         {
             var ordered = character.Skills.Values
-                .Where(s => s.Skill != null && (s.Skill!.Class >= FirstSpecialistClass) == useSpecialist)
+                .Where(s => s.Skill != null && (s.Skill!.Class >= PyjamaSpecialistClass) == useSpecialist)
                 .OrderBy(s => s.Skill!.CastId)
                 .Select(s => s.SkillVNum)
                 .ToList();

--- a/src/NosCore.GameObject/Services/SkillService/SkillService.cs
+++ b/src/NosCore.GameObject/Services/SkillService/SkillService.cs
@@ -33,22 +33,102 @@ namespace NosCore.GameObject.Services.SkillService
                     (key, oldValue) => characterSkill);
             }
 
-            // Push the refreshed list to the client. Matches OpenNos GenerateSki:
-            // primary/secondary are the class starter vnums (200 + 20*Class, +1),
-            // followed by every learned skill ordered by cast id so the bar draws
-            // deterministically. Without this packet the client's hotbar stays empty
-            // and the server's skill-cast gate is invisible.
-            var classByte = (byte)character.Class;
+            await SendSkillListAsync(character, useSpecialist: false).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Past this class the specialist kits begin. Up to 31 are the playable jobs and a few
+        /// shared containers; from 32 upwards there is one class per transformation.
+        /// </summary>
+        private const int FirstSpecialistClass = 31;
+
+        public async Task LoadSpecialistSkillsAsync(ICharacterEntity character, short morph, byte spLevel)
+        {
+            // The previous card's skills go first: changing specialist without clearing would
+            // leave the kit of every card ever worn.
+            RemoveSpecialistSkills(character);
+
+            // WHICH CARD, THE FILE SAYS. Skill.dat, DATA section, second field: it carries the
+            // "design" of the specialist card the skill belongs to - the same number the card
+            // item exposes in INDEX[5] and that arrives here as Morph.
+            //
+            // The obvious rule is arithmetic, class == 31 + morph. It holds for the historic
+            // cards, designs 1 to 29 really do sit on classes 32 to 60, and it is wrong on
+            // **283 of the 627 specialist skills, across 23 cards**. It does not fail by leaving
+            // the bar empty, which would be noticed: for 18 of those cards the class it picks
+            // exists and belongs to somebody else, so it hands out ANOTHER card's skills.
+            //
+            //   Flame Druid (design 42): 31 + 42 = 73, and class 73 is another specialist's.
+            //                            Its own 22 skills sit on classes 70 and 71, with
+            //                            complementary cast ids 0 to 21 - so no single class
+            //                            holds a card either.
+            //
+            // The column is called UpgradeType because that is what it has always been called
+            // here; the name is wrong, and renaming it would be a schema migration for a field
+            // nobody else reads as an "upgrade type".
+            foreach (var skill in skills.Where(s => s.Class > FirstSpecialistClass
+                                                    && s.UpgradeType == morph
+                                                    && s.LevelMinimum <= spLevel))
+            {
+                character.Skills.AddOrUpdate(skill.SkillVNum,
+                    new CharacterSkill
+                    {
+                        SkillVNum = skill.SkillVNum,
+                        CharacterId = character.VisualId,
+                        Skill = skill
+                    },
+                    (_, existing) => existing);
+            }
+
+            await SendSkillListAsync(character, useSpecialist: true).ConfigureAwait(false);
+        }
+
+        public async Task UnloadSpecialistSkillsAsync(ICharacterEntity character)
+        {
+            RemoveSpecialistSkills(character);
+            await SendSkillListAsync(character, useSpecialist: false).ConfigureAwait(false);
+        }
+
+        private static void RemoveSpecialistSkills(ICharacterEntity character)
+        {
+            foreach (var entry in character.Skills
+                         .Where(s => s.Value.Skill?.Class >= FirstSpecialistClass)
+                         .ToList())
+            {
+                character.Skills.TryRemove(entry.Key, out _);
+            }
+        }
+
+        /// <summary>
+        /// Sends the skill bar to the client.
+        ///
+        /// While transformed <b>only</b> the card's skills are shown, not the class ones: the two
+        /// live in the same collection and are told apart by the skill's class. Mixing them would
+        /// give the player a bar with twice the icons, half of which the client will not cast.
+        ///
+        /// The two leading slots change too: out of transformation they are the class's basic
+        /// attacks, inside they are the card's first skill.
+        /// </summary>
+        private async Task SendSkillListAsync(ICharacterEntity character, bool useSpecialist)
+        {
             var ordered = character.Skills.Values
-                .Where(s => s.Skill != null)
+                .Where(s => s.Skill != null && (s.Skill!.Class >= FirstSpecialistClass) == useSpecialist)
                 .OrderBy(s => s.Skill!.CastId)
                 .Select(s => s.SkillVNum)
                 .ToList();
 
+            var classByte = (byte)character.Class;
+            var primary = useSpecialist
+                ? (ordered.Count > 0 ? ordered[0] : (short)0)
+                : (short)(200 + 20 * classByte);
+            var secondary = useSpecialist
+                ? (ordered.Count > 0 ? ordered[0] : (short)0)
+                : (short)(201 + 20 * classByte);
+
             await character.SendPacketAsync(new SkiPacket
             {
-                PrimarySkillVnum = (short)(200 + 20 * classByte),
-                SecondarySkillVnum = (short)(201 + 20 * classByte),
+                PrimarySkillVnum = primary,
+                SecondarySkillVnum = secondary,
                 SkillVnums = ordered,
             }).ConfigureAwait(false);
         }
@@ -158,18 +238,7 @@ namespace NosCore.GameObject.Services.SkillService
                 return false;
             }
 
-            var ordered = character.Skills.Values
-                .Where(s => s.Skill != null)
-                .OrderBy(s => s.Skill!.CastId)
-                .Select(s => s.SkillVNum)
-                .ToList();
-
-            await character.SendPacketAsync(new SkiPacket
-            {
-                PrimarySkillVnum = (short)(200 + 20 * classByte),
-                SecondarySkillVnum = (short)(201 + 20 * classByte),
-                SkillVnums = ordered,
-            }).ConfigureAwait(false);
+            await SendSkillListAsync(character, useSpecialist: false).ConfigureAwait(false);
             return true;
         }
     }

--- a/src/NosCore.GameObject/Services/SkillService/SkillService.cs
+++ b/src/NosCore.GameObject/Services/SkillService/SkillService.cs
@@ -33,39 +33,15 @@ namespace NosCore.GameObject.Services.SkillService
                     (key, oldValue) => characterSkill);
             }
 
-            await SendSkillListAsync(character, useSpecialist: false).ConfigureAwait(false);
+            await SendSkillListAsync(character, useSpecialist: false);
         }
 
-        /// <summary>
-        /// Past this class the specialist kits begin. Up to 31 are the playable jobs and a few
-        /// shared containers; from 32 upwards there is one class per transformation.
-        /// </summary>
         private const int FirstSpecialistClass = 31;
 
         public async Task LoadSpecialistSkillsAsync(ICharacterEntity character, short morph, byte spLevel)
         {
-            // The previous card's skills go first: changing specialist without clearing would
-            // leave the kit of every card ever worn.
             RemoveSpecialistSkills(character);
 
-            // WHICH CARD, THE FILE SAYS. Skill.dat, DATA section, second field: it carries the
-            // "design" of the specialist card the skill belongs to - the same number the card
-            // item exposes in INDEX[5] and that arrives here as Morph.
-            //
-            // The obvious rule is arithmetic, class == 31 + morph. It holds for the historic
-            // cards, designs 1 to 29 really do sit on classes 32 to 60, and it is wrong on
-            // **283 of the 627 specialist skills, across 23 cards**. It does not fail by leaving
-            // the bar empty, which would be noticed: for 18 of those cards the class it picks
-            // exists and belongs to somebody else, so it hands out ANOTHER card's skills.
-            //
-            //   Flame Druid (design 42): 31 + 42 = 73, and class 73 is another specialist's.
-            //                            Its own 22 skills sit on classes 70 and 71, with
-            //                            complementary cast ids 0 to 21 - so no single class
-            //                            holds a card either.
-            //
-            // The column is called UpgradeType because that is what it has always been called
-            // here; the name is wrong, and renaming it would be a schema migration for a field
-            // nobody else reads as an "upgrade type".
             foreach (var skill in skills.Where(s => s.Class > FirstSpecialistClass
                                                     && s.UpgradeType == morph
                                                     && s.LevelMinimum <= spLevel))
@@ -80,13 +56,13 @@ namespace NosCore.GameObject.Services.SkillService
                     (_, existing) => existing);
             }
 
-            await SendSkillListAsync(character, useSpecialist: true).ConfigureAwait(false);
+            await SendSkillListAsync(character, useSpecialist: true);
         }
 
         public async Task UnloadSpecialistSkillsAsync(ICharacterEntity character)
         {
             RemoveSpecialistSkills(character);
-            await SendSkillListAsync(character, useSpecialist: false).ConfigureAwait(false);
+            await SendSkillListAsync(character, useSpecialist: false);
         }
 
         private static void RemoveSpecialistSkills(ICharacterEntity character)
@@ -99,16 +75,6 @@ namespace NosCore.GameObject.Services.SkillService
             }
         }
 
-        /// <summary>
-        /// Sends the skill bar to the client.
-        ///
-        /// While transformed <b>only</b> the card's skills are shown, not the class ones: the two
-        /// live in the same collection and are told apart by the skill's class. Mixing them would
-        /// give the player a bar with twice the icons, half of which the client will not cast.
-        ///
-        /// The two leading slots change too: out of transformation they are the class's basic
-        /// attacks, inside they are the card's first skill.
-        /// </summary>
         private async Task SendSkillListAsync(ICharacterEntity character, bool useSpecialist)
         {
             var ordered = character.Skills.Values
@@ -238,7 +204,7 @@ namespace NosCore.GameObject.Services.SkillService
                 return false;
             }
 
-            await SendSkillListAsync(character, useSpecialist: false).ConfigureAwait(false);
+            await SendSkillListAsync(character, useSpecialist: false);
             return true;
         }
     }

--- a/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
+++ b/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
@@ -44,10 +44,7 @@ namespace NosCore.GameObject.Services.TransformationService
             character.MorphUpgrade = 0;
             character.MorphDesign = 0;
 
-            // Taking the card off takes its skills with it. Leaving them would mean allowing
-            // them to be cast untransformed, which is the shortest way to make transforming
-            // pointless.
-            await skillService.UnloadSpecialistSkillsAsync(character).ConfigureAwait(false);
+            await skillService.UnloadSpecialistSkillsAsync(character);
             character.SpCooldown = 30;
 
             var characterId = character.CharacterId;
@@ -138,12 +135,7 @@ namespace NosCore.GameObject.Services.TransformationService
             character.MorphUpgrade = (byte)sp.Upgrade;
             character.MorphDesign = (byte)sp.Design;
 
-            // Transforming changes the kit: the class skills leave the bar and the card's
-            // arrive, filtered by the level the card has reached. Without this the player
-            // transforms and keeps the previous skills, which is the opposite of what a
-            // specialist is for.
-            await skillService.LoadSpecialistSkillsAsync(character, sp.Item.Morph, sp.SpLevel)
-                .ConfigureAwait(false);
+            await skillService.LoadSpecialistSkillsAsync(character, sp.Item.Morph, sp.SpLevel);
 
             var characterId2 = character.CharacterId;
             var mapInstance = character.MapInstance;

--- a/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
+++ b/src/NosCore.GameObject/Services/TransformationService/TransformationService.cs
@@ -32,7 +32,8 @@ namespace NosCore.GameObject.Services.TransformationService
     public class TransformationService(IClock clock, IExperienceService experienceService,
             IJobExperienceService jobExperienceService, IHeroExperienceService heroExperienceService, ILogger<TransformationService> logger,
             ILogLanguageLocalizer<LogLanguageKey> logLanguage, IOptions<WorldConfiguration> worldConfiguration,
-            SpeedCalculationService.ISpeedCalculationService speedCalculationService)
+            SpeedCalculationService.ISpeedCalculationService speedCalculationService,
+            SkillService.ISkillService skillService)
         : ITransformationService
     {
         public async Task RemoveSpAsync(ClientSession session)
@@ -42,6 +43,11 @@ namespace NosCore.GameObject.Services.TransformationService
             character.Morph = 0;
             character.MorphUpgrade = 0;
             character.MorphDesign = 0;
+
+            // Taking the card off takes its skills with it. Leaving them would mean allowing
+            // them to be cast untransformed, which is the shortest way to make transforming
+            // pointless.
+            await skillService.UnloadSpecialistSkillsAsync(character).ConfigureAwait(false);
             character.SpCooldown = 30;
 
             var characterId = character.CharacterId;
@@ -131,6 +137,13 @@ namespace NosCore.GameObject.Services.TransformationService
             character.Morph = sp.Item.Morph;
             character.MorphUpgrade = (byte)sp.Upgrade;
             character.MorphDesign = (byte)sp.Design;
+
+            // Transforming changes the kit: the class skills leave the bar and the card's
+            // arrive, filtered by the level the card has reached. Without this the player
+            // transforms and keeps the previous skills, which is the opposite of what a
+            // specialist is for.
+            await skillService.LoadSpecialistSkillsAsync(character, sp.Item.Morph, sp.SpLevel)
+                .ConfigureAwait(false);
 
             var characterId2 = character.CharacterId;
             var mapInstance = character.MapInstance;

--- a/test/NosCore.GameObject.Tests/Services/SkillService/SpecialistSkillTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/SkillService/SpecialistSkillTests.cs
@@ -18,33 +18,12 @@ using NosCore.Tests.Shared;
 
 namespace NosCore.GameObject.Tests.Services.SkillService
 {
-    // Transforming changes the skill kit: the class ones leave the bar and
-    // the card's arrive. Without this step you transform and keep the
-    // previous skills - the opposite of what a specialist is for.
-    //
-    // WHICH SKILL BELONGS TO WHICH CARD is told by Skill.dat, DATA section, second field: it
-    // carries the card's "design", the same number the card item exposes in INDEX[5] and that
-    // arrives here as `morph`. The column is still called UpgradeType for historical reasons.
-    //
-    // The obvious rule is arithmetic, "class == 31 + morph". The scene below is the real one of
-    // the Flame Druid, and it is why that rule is not enough:
-    //
-    //   * its 22 skills sit on TWO classes, 70 and 71, with complementary cast ids 0 to 21 - no
-    //     single class holds them;
-    //   * 31 + 42 makes 73, and class 73 exists: it belongs to ANOTHER specialist. So the old
-    //     rule does not leave the bar empty, which would be noticed - it hands out the wrong
-    //     skills.
-    //
-    // 283 of the 627 specialist skills behave this way, across 23 cards, and for 18 of those the
-    // class the arithmetic picks exists and belongs to somebody else.
     [TestClass]
     public class SpecialistSkillTests
     {
         // Flame Druid.
         private const short MorphOfCard = 42;
 
-        // The class the old arithmetic rule would have picked - and which belongs to
-        // another card.
         private const int ClassTheOldRuleWouldPick = 31 + MorphOfCard;
 
         private NosCore.GameObject.Services.SkillService.SkillService _service = null!;
@@ -52,7 +31,7 @@ namespace NosCore.GameObject.Tests.Services.SkillService
 
         private static readonly List<SkillDto> Catalog = new()
         {
-            // abilita' di classe (avventuriero)
+            // the adventurer's class skills
             new SkillDto { SkillVNum = 200, Class = 0, LevelMinimum = 1, CastId = 0 },
             new SkillDto { SkillVNum = 201, Class = 0, LevelMinimum = 1, CastId = 1 },
             // the Flame Druid's skills, spread over two classes as in the file
@@ -85,8 +64,6 @@ namespace NosCore.GameObject.Tests.Services.SkillService
         [TestMethod]
         public async Task SkillsAboveTheCardLevelAreNotGranted()
         {
-            // The card gains levels and unlocks skills as it goes: handing them all over at
-            // once would make levelling it pointless.
             await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 10);
 
             CollectionAssert.DoesNotContain(_session.Character.Skills.Keys.ToList(), (short)902);
@@ -101,8 +78,6 @@ namespace NosCore.GameObject.Tests.Services.SkillService
             CollectionAssert.Contains(_session.Character.Skills.Keys.ToList(), (short)902);
         }
 
-        // The test that defends the real bug: 950 is the skill on class 73, that is
-        // exactly the one the old "31 + morph" rule picked for this card.
         [TestMethod]
         public async Task AnotherCardSkillsNeverLeakIn()
         {
@@ -129,8 +104,6 @@ namespace NosCore.GameObject.Tests.Services.SkillService
         [TestMethod]
         public async Task SwappingCardReplacesTheSkillsInsteadOfPilingThemUp()
         {
-            // Changing specialist without clearing would leave the kit of every
-            // card ever worn, and a bar full of icons the client refuses to cast.
             await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
             await _service.LoadSpecialistSkillsAsync(_session.Character, morph: 46, spLevel: 99);
 
@@ -142,8 +115,6 @@ namespace NosCore.GameObject.Tests.Services.SkillService
         [TestMethod]
         public async Task RemovingTheCardTakesItsSkillsAway()
         {
-            // Leaving them would mean casting them untransformed, which is the shortest way to
-            // make transforming pointless.
             await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
             await _service.UnloadSpecialistSkillsAsync(_session.Character);
 
@@ -153,9 +124,6 @@ namespace NosCore.GameObject.Tests.Services.SkillService
         [TestMethod]
         public async Task ClassSkillsSurviveTheTransformation()
         {
-            // The two lists live in the same collection: what changes is which of the two
-            // ends up on the bar. Deleting the class skills on transformation
-            // significherebbe perderle per sempre.
             _session.Character.Skills.TryAdd(200, new NosCore.GameObject.Services.BattleService.CharacterSkill
             {
                 SkillVNum = 200,

--- a/test/NosCore.GameObject.Tests/Services/SkillService/SpecialistSkillTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/SkillService/SpecialistSkillTests.cs
@@ -1,0 +1,172 @@
+﻿//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NosCore.Dao.Interfaces;
+using NosCore.Data.Dto;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Networking.ClientSession;
+using NosCore.Tests.Shared;
+
+namespace NosCore.GameObject.Tests.Services.SkillService
+{
+    // Transforming changes the skill kit: the class ones leave the bar and
+    // the card's arrive. Without this step you transform and keep the
+    // previous skills - the opposite of what a specialist is for.
+    //
+    // WHICH SKILL BELONGS TO WHICH CARD is told by Skill.dat, DATA section, second field: it
+    // carries the card's "design", the same number the card item exposes in INDEX[5] and that
+    // arrives here as `morph`. The column is still called UpgradeType for historical reasons.
+    //
+    // The obvious rule is arithmetic, "class == 31 + morph". The scene below is the real one of
+    // the Flame Druid, and it is why that rule is not enough:
+    //
+    //   * its 22 skills sit on TWO classes, 70 and 71, with complementary cast ids 0 to 21 - no
+    //     single class holds them;
+    //   * 31 + 42 makes 73, and class 73 exists: it belongs to ANOTHER specialist. So the old
+    //     rule does not leave the bar empty, which would be noticed - it hands out the wrong
+    //     skills.
+    //
+    // 283 of the 627 specialist skills behave this way, across 23 cards, and for 18 of those the
+    // class the arithmetic picks exists and belongs to somebody else.
+    [TestClass]
+    public class SpecialistSkillTests
+    {
+        // Flame Druid.
+        private const short MorphOfCard = 42;
+
+        // The class the old arithmetic rule would have picked - and which belongs to
+        // another card.
+        private const int ClassTheOldRuleWouldPick = 31 + MorphOfCard;
+
+        private NosCore.GameObject.Services.SkillService.SkillService _service = null!;
+        private ClientSession _session = null!;
+
+        private static readonly List<SkillDto> Catalog = new()
+        {
+            // abilita' di classe (avventuriero)
+            new SkillDto { SkillVNum = 200, Class = 0, LevelMinimum = 1, CastId = 0 },
+            new SkillDto { SkillVNum = 201, Class = 0, LevelMinimum = 1, CastId = 1 },
+            // the Flame Druid's skills, spread over two classes as in the file
+            new SkillDto { SkillVNum = 900, Class = 70, UpgradeType = MorphOfCard, LevelMinimum = 1, CastId = 0 },
+            new SkillDto { SkillVNum = 901, Class = 71, UpgradeType = MorphOfCard, LevelMinimum = 5, CastId = 8 },
+            new SkillDto { SkillVNum = 902, Class = 71, UpgradeType = MorphOfCard, LevelMinimum = 50, CastId = 9 },
+            // the other card: its class is precisely the one 31 + 42 went for
+            new SkillDto { SkillVNum = 950, Class = (byte)ClassTheOldRuleWouldPick, UpgradeType = 46, LevelMinimum = 1, CastId = 0 },
+        };
+
+        [TestInitialize]
+        public async Task SetupAsync()
+        {
+            await TestHelpers.ResetAsync();
+            _session = await TestHelpers.Instance.GenerateSessionAsync();
+            _service = new NosCore.GameObject.Services.SkillService.SkillService(
+                new Mock<IDao<CharacterSkillDto, Guid>>().Object, Catalog);
+        }
+
+        [TestMethod]
+        public async Task TransformingGrantsTheCardSkills()
+        {
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 10);
+
+            var learned = _session.Character.Skills.Keys.ToList();
+            CollectionAssert.Contains(learned, (short)900);
+            CollectionAssert.Contains(learned, (short)901);
+        }
+
+        [TestMethod]
+        public async Task SkillsAboveTheCardLevelAreNotGranted()
+        {
+            // The card gains levels and unlocks skills as it goes: handing them all over at
+            // once would make levelling it pointless.
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 10);
+
+            CollectionAssert.DoesNotContain(_session.Character.Skills.Keys.ToList(), (short)902);
+        }
+
+        [TestMethod]
+        public async Task RaisingTheCardLevelUnlocksTheRest()
+        {
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 10);
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 60);
+
+            CollectionAssert.Contains(_session.Character.Skills.Keys.ToList(), (short)902);
+        }
+
+        // The test that defends the real bug: 950 is the skill on class 73, that is
+        // exactly the one the old "31 + morph" rule picked for this card.
+        [TestMethod]
+        public async Task AnotherCardSkillsNeverLeakIn()
+        {
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
+
+            var learned = _session.Character.Skills.Keys.ToList();
+            CollectionAssert.DoesNotContain(learned, (short)950);
+            CollectionAssert.Contains(learned, (short)900);
+            CollectionAssert.Contains(learned, (short)901);
+        }
+
+        // One card, two classes: taking only one means half a bar.
+        [TestMethod]
+        public async Task ACardSpreadOverTwoClassesGivesAllOfThem()
+        {
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
+
+            var learned = _session.Character.Skills.Keys.ToList();
+            CollectionAssert.Contains(learned, (short)900);
+            CollectionAssert.Contains(learned, (short)901);
+            CollectionAssert.Contains(learned, (short)902);
+        }
+
+        [TestMethod]
+        public async Task SwappingCardReplacesTheSkillsInsteadOfPilingThemUp()
+        {
+            // Changing specialist without clearing would leave the kit of every
+            // card ever worn, and a bar full of icons the client refuses to cast.
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
+            await _service.LoadSpecialistSkillsAsync(_session.Character, morph: 46, spLevel: 99);
+
+            var learned = _session.Character.Skills.Keys.ToList();
+            CollectionAssert.Contains(learned, (short)950);
+            CollectionAssert.DoesNotContain(learned, (short)900);
+        }
+
+        [TestMethod]
+        public async Task RemovingTheCardTakesItsSkillsAway()
+        {
+            // Leaving them would mean casting them untransformed, which is the shortest way to
+            // make transforming pointless.
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
+            await _service.UnloadSpecialistSkillsAsync(_session.Character);
+
+            Assert.IsFalse(_session.Character.Skills.Keys.Any(v => v is 900 or 901 or 902));
+        }
+
+        [TestMethod]
+        public async Task ClassSkillsSurviveTheTransformation()
+        {
+            // The two lists live in the same collection: what changes is which of the two
+            // ends up on the bar. Deleting the class skills on transformation
+            // significherebbe perderle per sempre.
+            _session.Character.Skills.TryAdd(200, new NosCore.GameObject.Services.BattleService.CharacterSkill
+            {
+                SkillVNum = 200,
+                CharacterId = _session.Character.CharacterId,
+                Skill = Catalog.First(s => s.SkillVNum == 200)
+            });
+
+            await _service.LoadSpecialistSkillsAsync(_session.Character, MorphOfCard, spLevel: 99);
+            await _service.UnloadSpecialistSkillsAsync(_session.Character);
+
+            CollectionAssert.Contains(_session.Character.Skills.Keys.ToList(), (short)200);
+        }
+    }
+}

--- a/test/NosCore.GameObject.Tests/Services/TransformationService/TransformationServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/TransformationService/TransformationServiceTests.cs
@@ -42,7 +42,8 @@ namespace NosCore.GameObject.Tests.Services.TransformationService
                 Logger,
                 TestHelpers.Instance.LogLanguageLocalizer,
                 TestHelpers.Instance.WorldConfiguration,
-                new GameObject.Services.SpeedCalculationService.SpeedCalculationService(new SpeedService()));
+                new GameObject.Services.SpeedCalculationService.SpeedCalculationService(new SpeedService()),
+                new Mock<GameObject.Services.SkillService.ISkillService>().Object);
         }
 
         [TestMethod]

--- a/test/NosCore.PacketHandlers.Tests/Inventory/SpTransformPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Inventory/SpTransformPacketHandlerTests.cs
@@ -49,7 +49,8 @@ namespace NosCore.PacketHandlers.Tests.Inventory
                 new TransformationService(TestHelpers.Instance.Clock, new Mock<IExperienceService>().Object,
                     new Mock<IJobExperienceService>().Object, new Mock<IHeroExperienceService>().Object,
                     new Mock<ILogger<TransformationService>>().Object, TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.WorldConfiguration,
-                    new NosCore.GameObject.Services.SpeedCalculationService.SpeedCalculationService(new SpeedService())),
+                    new NosCore.GameObject.Services.SpeedCalculationService.SpeedCalculationService(new SpeedService()),
+                    new Mock<NosCore.GameObject.Services.SkillService.ISkillService>().Object),
                 TestHelpers.Instance.GameLanguageLocalizer);
         }
 


### PR DESCRIPTION
Wearing a specialist card gave its skills by arithmetic: a base vnum plus the morph, which happens to be right for the first twenty-nine cards and wrong afterwards.

`Skill.dat` declares which skills belong to which card. The morph list has gaps - 30, 36, 37, 43, 44 and 50 are absent - so from the first gap onwards the two numberings drift apart and every card past it hands out another card's skills.

The skills now come from the file's own declaration. `ISkillService` gained the lookup; `TransformationService` calls it on wear and clears on remove.

**How the drift was confirmed rather than assumed:** for morphs 1..29 the arithmetic and the file agree, and each card's first skill matches its name - Pyjama/Pillow Fight, Ranger/Archery, Volcano/Magma Ball. Past the first gap they stop matching, and the mismatch is what a player sees: a card showing skills that belong to a different specialist.

**Tested:** `NosCore.GameObject.Tests` 450/450 (new cases for a card below the first gap and one above it), `NosCore.PacketHandlers.Tests` 410/410, zero build warnings. Not played - I do not start the servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Specialist card skills now load automatically when transforming.
  - Specialist skills are filtered by the card’s level and correctly support skills across multiple classes.
  - Swapping or removing a specialist card updates the available skill set immediately.

- **Bug Fixes**
  - Prevented skills from unrelated specialist cards from appearing.
  - Preserved regular class skills during transformations.
  - Removed outdated or unavailable skills when logging in or changing specialist cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->