### PR TITLE
The three servers die on startup when no console is attached

### DIFF
--- a/src/NosCore.Core/ConsoleTitle.cs
+++ b/src/NosCore.Core/ConsoleTitle.cs
@@ -1,0 +1,35 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NosCore.Core
+{
+    public static class ConsoleTitle
+    {
+        public static void Set(string title)
+        {
+            if (OperatingSystem.IsWindows() && HasConsole)
+            {
+                Console.Title = title;
+            }
+        }
+
+        public static void Append(string suffix)
+        {
+            if (OperatingSystem.IsWindows() && HasConsole)
+            {
+                Console.Title += suffix;
+            }
+        }
+
+        private static bool HasConsole => !Console.IsOutputRedirected && GetConsoleWindow() != IntPtr.Zero;
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetConsoleWindow();
+    }
+}

--- a/src/NosCore.LoginServer/LoginServer.cs
+++ b/src/NosCore.LoginServer/LoginServer.cs
@@ -17,8 +17,6 @@ using NosCore.Networking;
 using NosCore.Shared.I18N;
 using Polly;
 using System;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -31,17 +29,7 @@ namespace NosCore.LoginServer
     {
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-            {
-                try
-                {
-                    Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}";
-                }
-                catch (IOException)
-                {
-                    // No console attached to carry a title (service, detached process).
-                }
-            }
+            ConsoleTitle.Append($@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}");
 
             try
             {

--- a/src/NosCore.LoginServer/LoginServer.cs
+++ b/src/NosCore.LoginServer/LoginServer.cs
@@ -17,6 +17,7 @@ using NosCore.Networking;
 using NosCore.Shared.I18N;
 using Polly;
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +33,14 @@ namespace NosCore.LoginServer
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}";
+                try
+                {
+                    Console.Title += $@" - Port : {Convert.ToInt32(loginConfiguration.Value.Port)}";
+                }
+                catch (IOException)
+                {
+                    // No console attached to carry a title (service, detached process).
+                }
             }
 
             try

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -50,6 +50,7 @@ using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
 using Serilog;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -166,7 +167,14 @@ namespace NosCore.LoginServer
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
                     {
-                        Console.Title = Title;
+                        try
+                        {
+                            Console.Title = Title;
+                        }
+                        catch (IOException)
+                        {
+                            // No console attached to carry a title (service, detached process).
+                        }
                     }
 
                     InitializeConfiguration(args, services);

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -50,12 +50,10 @@ using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
 using Serilog;
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace NosCore.LoginServer
@@ -165,17 +163,7 @@ namespace NosCore.LoginServer
                 .ConfigureContainer<ContainerBuilder>(InitializeContainer)
                 .ConfigureServices((hostContext, services) =>
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-                    {
-                        try
-                        {
-                            Console.Title = Title;
-                        }
-                        catch (IOException)
-                        {
-                            // No console attached to carry a title (service, detached process).
-                        }
-                    }
+                    ConsoleTitle.Set(Title);
 
                     InitializeConfiguration(args, services);
                     services.AddI18NLogs();

--- a/src/NosCore.MasterServer/MasterServer.cs
+++ b/src/NosCore.MasterServer/MasterServer.cs
@@ -10,6 +10,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
 using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,7 +28,14 @@ namespace NosCore.MasterServer
             logger.LogInformation(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}";
+                try
+                {
+                    Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}";
+                }
+                catch (IOException)
+                {
+                    // No console attached to carry a title (service, detached process).
+                }
             }
 
             return Task.CompletedTask;

--- a/src/NosCore.MasterServer/MasterServer.cs
+++ b/src/NosCore.MasterServer/MasterServer.cs
@@ -6,12 +6,10 @@
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using NosCore.Core;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
 using Microsoft.Extensions.Logging;
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,17 +24,7 @@ namespace NosCore.MasterServer
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
             logger.LogInformation(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-            {
-                try
-                {
-                    Console.Title += $@" - WebApi : {_masterConfiguration.WebApi}";
-                }
-                catch (IOException)
-                {
-                    // No console attached to carry a title (service, detached process).
-                }
-            }
+            ConsoleTitle.Append($@" - WebApi : {_masterConfiguration.WebApi}");
 
             return Task.CompletedTask;
         }

--- a/src/NosCore.MasterServer/MasterServerBootstrap.cs
+++ b/src/NosCore.MasterServer/MasterServerBootstrap.cs
@@ -55,6 +55,7 @@ using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
 using Serilog;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -90,7 +91,14 @@ namespace NosCore.MasterServer
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                Console.Title = Title;
+                try
+                {
+                    Console.Title = Title;
+                }
+                catch (IOException)
+                {
+                    // No console attached to carry a title (service, detached process).
+                }
             }
             Logger.PrintHeader(ConsoleText);
 

--- a/src/NosCore.MasterServer/MasterServerBootstrap.cs
+++ b/src/NosCore.MasterServer/MasterServerBootstrap.cs
@@ -55,12 +55,10 @@ using NosCore.Shared.Enumerations;
 using NosCore.Shared.I18N;
 using Serilog;
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ConfigureJwtBearerOptions = NosCore.Core.ConfigureJwtBearerOptions;
 
@@ -89,17 +87,7 @@ namespace NosCore.MasterServer
             builder.Configuration.AddConfiguration(
                 ConfiguratorBuilder.InitializeConfiguration(args, new[] { "logger.yml", "master.yml" }));
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-            {
-                try
-                {
-                    Console.Title = Title;
-                }
-                catch (IOException)
-                {
-                    // No console attached to carry a title (service, detached process).
-                }
-            }
+            ConsoleTitle.Set(Title);
             Logger.PrintHeader(ConsoleText);
 
             builder.Host.UseSerilog();

--- a/src/NosCore.Parser/ParserBootstrap.cs
+++ b/src/NosCore.Parser/ParserBootstrap.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using NosCore.Core;
 using NosCore.Dao;
 using NosCore.Dao.Interfaces;
 using NosCore.Data.Dto;
@@ -26,7 +27,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace NosCore.Parser
@@ -131,10 +131,7 @@ namespace NosCore.Parser
                 .ConfigureContainer<ContainerBuilder>(InitializeContainer)
                 .ConfigureServices((hostContext, services) =>
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-                    {
-                        try { Console.Title = Title; } catch { /* redirected/non-interactive console */ }
-                    }
+                    ConsoleTitle.Set(Title);
 
                     InitializeConfiguration(args, services);
 

--- a/src/NosCore.Parser/ParserBootstrap.cs
+++ b/src/NosCore.Parser/ParserBootstrap.cs
@@ -58,15 +58,7 @@ namespace NosCore.Parser
                 builder => builder.UseNpgsql(parserConfiguration.Database.ConnectionString, options => { options.UseNodaTime(); }));
             services.AddOptions<ParserConfiguration>().Bind(conf).ValidateDataAnnotations();
             Logger.GetLoggerConfiguration().CreateLogger();
-            try
-            {
-                Logger.PrintHeader(ConsoleText);
-            }
-            catch (System.IO.IOException)
-            {
-                // No attached console (e.g. CLI invocation from a shell with redirected stdout) —
-                // skip the banner rather than crashing on Console.WindowWidth.
-            }
+            Logger.PrintHeader(ConsoleText);
             CultureInfo.DefaultThreadCurrentCulture = new(parserConfiguration.Language.ToString());
         }
 

--- a/src/NosCore.WorldServer/WorldServer.cs
+++ b/src/NosCore.WorldServer/WorldServer.cs
@@ -20,9 +20,7 @@ using NosCore.Networking.SessionGroup;
 using NosCore.Shared.I18N;
 using Polly;
 using System;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -48,17 +46,7 @@ namespace NosCore.WorldServer
                 Thread.Sleep(30000);
             };
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-            {
-                try
-                {
-                    Console.Title += $@" - Port : {worldConfiguration.Value.Port}";
-                }
-                catch (IOException)
-                {
-                    // No console attached to carry a title (service, detached process).
-                }
-            }
+            ConsoleTitle.Append($@" - Port : {worldConfiguration.Value.Port}");
             var connectTask = Policy
                 .Handle<Exception>()
                 .WaitAndRetryForeverAsync(retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),

--- a/src/NosCore.WorldServer/WorldServer.cs
+++ b/src/NosCore.WorldServer/WorldServer.cs
@@ -20,6 +20,7 @@ using NosCore.Networking.SessionGroup;
 using NosCore.Shared.I18N;
 using Polly;
 using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -49,7 +50,14 @@ namespace NosCore.WorldServer
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
             {
-                Console.Title += $@" - Port : {worldConfiguration.Value.Port}";
+                try
+                {
+                    Console.Title += $@" - Port : {worldConfiguration.Value.Port}";
+                }
+                catch (IOException)
+                {
+                    // No console attached to carry a title (service, detached process).
+                }
             }
             var connectTask = Policy
                 .Handle<Exception>()

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -74,6 +74,7 @@ using NosCore.Shared.I18N;
 using Serilog;
 using Wolverine;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -234,7 +235,14 @@ namespace NosCore.WorldServer
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
                     {
-                        Console.Title = Title;
+                        try
+                        {
+                            Console.Title = Title;
+                        }
+                        catch (IOException)
+                        {
+                            // No console attached to carry a title (service, detached process).
+                        }
                     }
 
                     InitializeConfiguration(args, services);

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -74,12 +74,10 @@ using NosCore.Shared.I18N;
 using Serilog;
 using Wolverine;
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace NosCore.WorldServer
@@ -233,17 +231,7 @@ namespace NosCore.WorldServer
                 .ConfigureContainer<ContainerBuilder>(InitializeContainer)
                 .ConfigureServices((hostContext, services) =>
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected)
-                    {
-                        try
-                        {
-                            Console.Title = Title;
-                        }
-                        catch (IOException)
-                        {
-                            // No console attached to carry a title (service, detached process).
-                        }
-                    }
+                    ConsoleTitle.Set(Title);
 
                     InitializeConfiguration(args, services);
 


### PR DESCRIPTION
## What

`Console.Title` throws `IOException` when the process has no console — a Windows service, a detached process, a container. All three servers set it on the startup path, **ahead of the listener**, so the process exits before it ever opens its port.

`ParserBootstrap` already guards its own console call for exactly this reason. This does the same at the six sites the servers touch.

## Why it is six sites and not one

| file | what it sets |
|---|---|
| `LoginServer.cs` | appends the port |
| `LoginServerBootstrap.cs` | sets the title |
| `MasterServer.cs` | appends the WebApi address |
| `MasterServerBootstrap.cs` | sets the title |
| `WorldServer.cs` | appends the port |
| `WorldServerBootstrap.cs` | sets the title |

## What was measured

A throwaway probe against `NosCore.Shared` 6.0.1, two scenarios:

| scenario | `Console.Title` | `Console.WindowWidth` | `Logger.PrintHeader` |
|---|---|---|---|
| stdout piped, console still attached | OK | throws `IOException` | OK |
| no console at all (WinExe) | **throws `IOException`** | throws `IOException` | OK |

Two things follow, and the second is why this PR is smaller than it started:

- `Console.Title` is the real failure, and only in the no-console case — a plain pipe does not trigger it;
- `Logger.PrintHeader` throws in **neither** case on 6.0.1, so it is left alone. The existing guard in `ParserBootstrap` is harmless but no longer load-bearing; not touched here.

## Testing

- `NosCore.sln` builds with **0 warnings**; full suite green — **991 tests**.
- The failure was reproduced against the framework API with the probe above, **not** against a running server.
- **Not played in game.** The change is on the startup path only and has no in-game behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent console title management across server and parser components.
  * Console titles now display configured service names and append relevant port or API details.

* **Improvements**
  * Console title updates now behave consistently across supported platforms and console environments.
  * Improved handling when output is redirected, ensuring startup information remains reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->