### PR TITLE
A short primary key cannot hold 44292 BCards

### DIFF
--- a/src/NosCore.Database/Entities/BCard.cs
+++ b/src/NosCore.Database/Entities/BCard.cs
@@ -12,7 +12,7 @@ namespace NosCore.Database.Entities
     public class BCard : IStaticEntity
     {
         [Key]
-        public short BCardId { get; set; }
+        public int BCardId { get; set; }
 
         public byte SubType { get; set; }
 

--- a/src/NosCore.Database/Migrations/20260827123055_WidenBCardId.Designer.cs
+++ b/src/NosCore.Database/Migrations/20260827123055_WidenBCardId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using NosCore.Database;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace NosCore.Database.Migrations
 {
     [DbContext(typeof(NosCoreContext))]
-    partial class NosCoreContextModelSnapshot : ModelSnapshot
+    [Migration("20260827123055_WidenBCardId")]
+    partial class WidenBCardId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NosCore.Database/Migrations/20260827123055_WidenBCardId.cs
+++ b/src/NosCore.Database/Migrations/20260827123055_WidenBCardId.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace NosCore.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenBCardId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "BCardId",
+                table: "BCard",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(short),
+                oldType: "smallint")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<short>(
+                name: "BCardId",
+                table: "BCard",
+                type: "smallint",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+    }
+}


### PR DESCRIPTION
## What

`BCard.BCardId` is a `short`, and the parser writes more rows than a `short` can index.

Measured against a freshly parsed database:

```
 rows  | min | max
-------+-----+-------
 44292 |   1 | 66407
```

against a ceiling of **32767**. That is **11525 rows that cannot be written**.

## Two ways it shows

**On a database still matching the migration**, the column is `smallint` with an identity default. Reproduced on a scratch database with the same column shape — fill it to the ceiling, then insert one more:

```
INSERT INTO probe (x) VALUES (1);
ERROR:  nextval: reached maximum value of sequence "probe_id_seq" (32767)
```

So the parser cannot finish.

**On a database whose column was widened to `integer` by hand** to get past that, the server starts and the WorldServer dies loading static data, because EF still reads the column with `GetInt16`:

```
EROR -- An exception occurred while iterating over the results of a query for context type 'NosCore.Database.NosCoreContext'.
System.OverflowException: Arithmetic operation resulted in an overflow.
   at Npgsql.Internal.Converters.Int4Converter`1.ReadCore(PgReader reader)
   at Npgsql.NpgsqlDataReader.GetInt16(Int32 ordinal)
An error occurred while attempting to automatically activate registration 'Autofac.Core.ServiceRegistration'.
```

That is the failure this was found on. It lands right after `7688 Item loaded`, takes the Autofac activation down with it, and the process exits **without ever listening**.

## The rest of the family, checked

One overflowing key is a reason to check the others rather than patch the one that tripped. Every `short` or `byte` primary key against its live row count:

| entity | key | rows | ceiling |
|---|---|---|---|
| `Drop` | `DropId` | 6210 | 32767 |
| `NpcTalk` | `DialogId` | 4504 | 32767 |
| `QuestReward` | `QuestRewardId` | 1060 | 32767 |
| `MapTypeMap` | `MapTypeMapId` | 209 | 32767 |
| `Recipe`, `RecipeItem`, `RollGeneratedItem`, `ScriptedInstance`, `Teleporter` | — | 0 | 32767 |

**None is over half its ceiling.** `BCard` was the only one, and it was over by a factor of two.

## Scope

Nothing references `BCardId` as a foreign key — checked against `information_schema`, zero rows — so widening it is contained to the one column. The migration is a plain `AlterColumn` from `smallint` to `integer`.

## Testing

- Builds with **0 warnings**; full suite green — **991 tests**.
- **Verified on a running server.** Before: the WorldServer exited during static load. After: it reaches `Listening on port 1337`, and the LoginServer registers against it on 4000 with the MasterServer on 5000.
- The `smallint` half was reproduced on a scratch database rather than inferred from the type range — the error text above is the real one.
- Not a gameplay change, so nothing in `documentation/manual-test-plan.md` applies; the observable is the server starting at all.