### PR TITLE
A melee-only hit rate bonus fed the ranged rate too

### DIFF
--- a/documentation/manual-test-plan.md
+++ b/documentation/manual-test-plan.md
@@ -69,6 +69,12 @@ Boss skills declaring 90% should take most of a bar in one hit.
 - [ ] With both in play nothing locks up or throws — the attacker's guarantee is resolved
       first by design
 
+### Hit rate by scope — BCard type 4
+
+- [ ] A buff with subtype 21 makes melee attacks land more often and leaves ranged alone
+- [ ] A buff with subtype 31 makes ranged attacks land more often and leaves melee alone
+- [ ] A subtype 11 buff raises both
+
 ### Elemental resistance — BCard types 13 and 14
 
 - [ ] A buff that raises your resistance to an element reduces the elemental damage you

--- a/documentation/manual-test-plan.md
+++ b/documentation/manual-test-plan.md
@@ -69,12 +69,6 @@ Boss skills declaring 90% should take most of a bar in one hit.
 - [ ] With both in play nothing locks up or throws — the attacker's guarantee is resolved
       first by design
 
-### Hit rate by scope — BCard type 4
-
-- [ ] A buff with subtype 21 makes melee attacks land more often and leaves ranged alone
-- [ ] A buff with subtype 31 makes ranged attacks land more often and leaves melee alone
-- [ ] A subtype 11 buff raises both
-
 ### Elemental resistance — BCard types 13 and 14
 
 - [ ] A buff that raises your resistance to an element reduces the elemental damage you

--- a/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -241,8 +241,8 @@ public sealed class BattleStatsProvider(
             EnemyWaterResistance = stats.EnemyWaterResistance + totals.FoeAll + totals.FoeWater,
             EnemyLightResistance = stats.EnemyLightResistance + totals.FoeAll + totals.FoeLight,
             EnemyDarkResistance = stats.EnemyDarkResistance + totals.FoeAll + totals.FoeDark,
-            HitRate = stats.HitRate + totals.HitRate,
-            DistanceRate = stats.DistanceRate + totals.HitRate,
+            HitRate = stats.HitRate + totals.HitRate + totals.HitRateMelee,
+            DistanceRate = stats.DistanceRate + totals.HitRate + totals.HitRateRanged,
             CriticalChance = stats.CriticalChance + totals.CritInflicting,
             CriticalRate = stats.CriticalRate + totals.CritDamage,
             DistanceCriticalChance = stats.DistanceCriticalChance + totals.CritInflicting,
@@ -282,7 +282,7 @@ public sealed class BattleStatsProvider(
         public int DefenceAll, DefenceMelee, DefenceRanged, DefenceMagical;
         public int FactorAttackAll, FactorAttackMelee, FactorAttackRanged;
         public int FactorDefenceAll, FactorDefenceMelee, FactorDefenceRanged, FactorDefenceMagical;
-        public int HitRate, Dodge, Morale;
+        public int HitRate, HitRateMelee, HitRateRanged, Dodge, Morale;
         public int FoeAll, FoeFire, FoeWater, FoeLight, FoeDark;
         public int ResistAll, ResistFire, ResistWater, ResistLight, ResistDark;
         public int ElementAll, ElementFire, ElementWater, ElementLight, ElementDark;
@@ -360,6 +360,10 @@ public sealed class BattleStatsProvider(
 
             [BCardEffect.TargetAllHitRateIncreased] = (t, v) => t.HitRate += v,
             [BCardEffect.TargetAllHitRateDecreased] = (t, v) => t.HitRate -= v,
+            [BCardEffect.TargetMeleeHitRateIncreased] = (t, v) => t.HitRateMelee += v,
+            [BCardEffect.TargetMeleeHitRateDecreased] = (t, v) => t.HitRateMelee -= v,
+            [BCardEffect.TargetRangedHitRateIncreased] = (t, v) => t.HitRateRanged += v,
+            [BCardEffect.TargetRangedHitRateDecreased] = (t, v) => t.HitRateRanged -= v,
 
             [BCardEffect.DodgeAndDefencePercentDodgeIncreased] = (t, v) => t.Dodge += v,
             [BCardEffect.DodgeAndDefencePercentDodgeDecreased] = (t, v) => t.Dodge -= v,

--- a/test/NosCore.GameObject.Tests/Services/BattleService/HitRateByRangeTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/HitRateByRangeTests.cs
@@ -1,0 +1,114 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NodaTime;
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.GameObject.Services.BattleService;
+using NosCore.GameObject.Services.BattleService.Model;
+using NosCore.GameObject.Services.EquipmentService;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    [TestClass]
+    public class HitRateByRangeTests
+    {
+        private const int BaseHitRate = 40;
+        private const int BaseDistanceRate = 70;
+
+        private static BCardDto Target(BCardEffect effect, short value) =>
+            new()
+            {
+                Type = effect.Type(),
+                SubType = effect.SubType(),
+                FirstData = value
+            };
+
+        private static CombatStats StatsWith(params BCardDto[] bCards)
+        {
+            var monster = new NpcMonsterDto
+            {
+                Concentrate = BaseHitRate,
+                DistanceDefence = BaseDistanceRate
+            };
+
+            var entity = new Mock<INonPlayableEntity>();
+            entity.SetupGet(e => e.NpcMonster).Returns(monster);
+            entity.SetupGet(e => e.Level).Returns((byte)1);
+            entity.SetupGet(e => e.HeroLevel).Returns((byte)0);
+
+            var buffs = new Mock<IBuffService>();
+            buffs.Setup(b => b.GetActiveBuffs(It.IsAny<IAliveEntity>())).Returns(new List<BuffInstance>
+            {
+                new(CardId: 1, BuffType: BuffType.Good, Caster: null,
+                    StartedAt: Instant.MinValue, ExpiresAt: Instant.MaxValue, BCards: bCards)
+            });
+
+            var equipment = new Mock<IEquipmentStatsService>();
+            equipment.Setup(s => s.Resolve(It.IsAny<IAliveEntity>())).Returns(EquipmentStats.None);
+
+            return new BattleStatsProvider(buffs.Object, equipment.Object).GetStats(entity.Object);
+        }
+
+        [TestMethod]
+        public void AMeleeHitRateBonusLeavesTheRangedRateAlone()
+        {
+            var baseline = StatsWith();
+            var stats = StatsWith(Target(BCardEffect.TargetMeleeHitRateIncreased, 25));
+
+            Assert.AreEqual(baseline.HitRate + 25, stats.HitRate);
+            Assert.AreEqual(baseline.DistanceRate, stats.DistanceRate);
+        }
+
+        [TestMethod]
+        public void ARangedHitRateBonusLeavesTheMeleeRateAlone()
+        {
+            var baseline = StatsWith();
+            var stats = StatsWith(Target(BCardEffect.TargetRangedHitRateIncreased, 25));
+
+            Assert.AreEqual(baseline.DistanceRate + 25, stats.DistanceRate);
+            Assert.AreEqual(baseline.HitRate, stats.HitRate);
+        }
+
+        [TestMethod]
+        public void TheAllSubtypeStillFeedsBothRates()
+        {
+            var baseline = StatsWith();
+            var stats = StatsWith(Target(BCardEffect.TargetAllHitRateIncreased, 25));
+
+            Assert.AreEqual(baseline.HitRate + 25, stats.HitRate);
+            Assert.AreEqual(baseline.DistanceRate + 25, stats.DistanceRate);
+        }
+
+        [TestMethod]
+        public void TheDecreasingHalvesSubtract()
+        {
+            var baseline = StatsWith();
+            var stats = StatsWith(
+                Target(BCardEffect.TargetMeleeHitRateDecreased, 10),
+                Target(BCardEffect.TargetRangedHitRateDecreased, 15));
+
+            Assert.AreEqual(baseline.HitRate - 10, stats.HitRate);
+            Assert.AreEqual(baseline.DistanceRate - 15, stats.DistanceRate);
+        }
+
+        [TestMethod]
+        public void AllAndMeleeStack()
+        {
+            var baseline = StatsWith();
+            var stats = StatsWith(
+                Target(BCardEffect.TargetAllHitRateIncreased, 10),
+                Target(BCardEffect.TargetMeleeHitRateIncreased, 5));
+
+            Assert.AreEqual(baseline.HitRate + 15, stats.HitRate);
+            Assert.AreEqual(baseline.DistanceRate + 10, stats.DistanceRate);
+        }
+    }
+}


### PR DESCRIPTION
## What

BCard type 4 declares three scopes and only the first was folded in — into **both** rates at once:

| subtype | client text |
|---|---|
| 11 / 12 | "Hit rate of **all** attacks is increased by %s." |
| 21 / 22 | "Hit rate of **melee** attacks is increased by %s." |
| 31 / 32 | "Hit rate of **ranged** attacks is increased by %s." |

So a melee-only bonus did nothing, and neither did a ranged-only one: **13 declarations** of 4/21 and 4/31 across items and cards had no effect at all.

Type 2 sitting next to it already keeps the three defences apart the same way, so this is the offensive half of a split that was half done, written to match.

## What is left out, and why

**4/41-42**, concentration during a magic attack. `CombatStats` has no field for it, and exposing one that nothing reads would be worse than the gap.

## Testing

- Builds with **0 warnings**; full suite green — **996 tests**, five of them new.
- The new tests assert the negative half as well as the positive: a melee bonus must leave `DistanceRate` **unchanged**, and a ranged bonus must leave `HitRate` unchanged. A leak into the other field raises nothing, so that is the assertion that earns its place.
- **Not verified in a client.** What somebody with a client would need to check - kept here rather than in `manual-test-plan.md`, since it belongs to this one change:

  - [ ] A buff with subtype 21 makes melee attacks land more often and leaves ranged alone
  - [ ] A buff with subtype 31 makes ranged attacks land more often and leaves melee alone
  - [ ] A subtype 11 buff raises both

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Melee and ranged hit-rate bonuses are now applied only to their respective attack ranges.
  * Bonuses affecting all attack ranges continue to apply to both melee and ranged calculations.
  * Increasing and decreasing hit-rate effects now stack and subtract correctly.

* **Tests**
  * Added coverage for melee, ranged, all-range, decreasing, and stacked hit-rate effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

