### PR TITLE
The guri handler chain refuses to compile at runtime

### DIFF
--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -244,8 +244,6 @@ namespace NosCore.WorldServer
 
                     services.AddI18NLogs();
                     services.AddTransient(typeof(IGameLanguageLocalizer), typeof(GameLanguageLocalizer));
-                    // A lambda factory here is opaque to Wolverine's code generation, which
-                    // then falls back to service location and refuses to compile the chain.
                     services.AddTransient(typeof(ILogLanguageLocalizer<LanguageKey>),
                         typeof(LogLanguageLocalizer<LanguageKey, LocalizedResources>));
 

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -244,9 +244,10 @@ namespace NosCore.WorldServer
 
                     services.AddI18NLogs();
                     services.AddTransient(typeof(IGameLanguageLocalizer), typeof(GameLanguageLocalizer));
+                    // A lambda factory here is opaque to Wolverine's code generation, which
+                    // then falls back to service location and refuses to compile the chain.
                     services.AddTransient(typeof(ILogLanguageLocalizer<LanguageKey>),
-                        x => new LogLanguageLocalizer<LanguageKey, LocalizedResources>(
-                            x.GetRequiredService<IStringLocalizer<LocalizedResources>>()));
+                        typeof(LogLanguageLocalizer<LanguageKey, LocalizedResources>));
 
                     // IClock is wired as a singleton here because SystemClock is an external
                     // NodaTime type with no container-friendly constructor.


### PR DESCRIPTION
## What

Every `guri` packet the client sends fails in the WorldServer:

```
Wolverine.Configuration.InvalidServiceLocationException: Found service locations while
generating code for Message Handler for GuriPacketReceivedEvent, but
ServiceLocationPolicy.NotAllowed is in effect.
Service location(s):
Service NosCore.Core.I18N.IGameLanguageLocalizer:
Dependency: ServiceType: ILogLanguageLocalizer`1[LanguageKey] Lifetime: Transient
            ImplementationFactory: WorldServerBootstrap+<>c.<BuildHost>b__5_2
The service registration for ILogLanguageLocalizer<LanguageKey> is an 'opaque' lambda
factory with the Transient lifetime and requires service location
```

followed by a cascade of `Frame chain is being re-arranged` from the code generator.

So **emoticons, speakers, titles and MFA input all go nowhere**, and the log fills with stack traces on every attempt.

## Why it reaches that registration

`SpeakerHandler` takes `IGameLanguageLocalizer`, which depends on `ILogLanguageLocalizer<LanguageKey>`. That one is registered as a lambda factory, which the generator cannot inline — so it falls back to service location, which Wolverine 6 refuses.

Registering the concrete type instead lets it inline the constructor, the same as every other registration alongside it.

## Testing

- Builds with **0 warnings**; full suite green — **991 tests**.
- **Found on a running server**, from a client sending `guri`. The WorldServer had reached `Listening on port 1337` and the failure appeared only once the packet arrived, which is why unit tests never saw it: the chain is compiled on first message.
- **Needs a client to confirm the fix.** From `documentation/manual-test-plan.md` there is no `guri` section; the check is: use an emoticon, or any action that sends `guri`, and the WorldServer log should stay clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal service registration for improved dependency handling.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->