### PR TITLE
Multiplied attack and defence, which nothing folded in

### DIFF
--- a/documentation/manual-test-plan.md
+++ b/documentation/manual-test-plan.md
@@ -77,6 +77,19 @@ Boss skills declaring 90% should take most of a bar in one hit.
 - [ ] An "all elements" effect applies to each of fire, water, light and dark rather than
       being ignored
 
+### Multiplied attack and defence — BCard types 34 and 35
+
+These state a factor, not a percentage, so the change is meant to be obvious rather than
+subtle: a card worth 5 is fivefold.
+
+- [ ] A buff carrying "defence is multiplied" makes the same monster's blows land for a
+      small fraction of what they did a moment earlier
+- [ ] The melee, ranged and magic subtypes each move only their own defence: check with
+      three attackers, or one attacker switching weapons
+- [ ] A buff carrying "attack power is multiplied" makes your own numbers jump by whole
+      multiples, not by a few per cent
+- [ ] The decreasing half halves rather than taking a couple of points off
+
 ---
 
 ## Monsters

--- a/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
+++ b/src/NosCore.GameObject/Services/BattleService/BattleStatsProvider.cs
@@ -233,10 +233,10 @@ public sealed class BattleStatsProvider(
         return stats with
         {
             Morale = stats.Morale + totals.Morale,
-            MinHit = (int)((stats.MinHit + totals.AttackAll + totals.AttackMelee) * (1 + (totals.DamageAll + totals.DamageMelee) / 100.0)),
-            MaxHit = (int)((stats.MaxHit + totals.AttackAll + totals.AttackMelee) * (1 + (totals.DamageAll + totals.DamageMelee) / 100.0)),
-            MinDistance = (int)((stats.MinDistance + totals.AttackAll + totals.AttackRanged) * (1 + (totals.DamageAll + totals.DamageRanged) / 100.0)),
-            MaxDistance = (int)((stats.MaxDistance + totals.AttackAll + totals.AttackRanged) * (1 + (totals.DamageAll + totals.DamageRanged) / 100.0)),
+            MinHit = ByFactor((int)((stats.MinHit + totals.AttackAll + totals.AttackMelee) * (1 + (totals.DamageAll + totals.DamageMelee) / 100.0)), totals.FactorAttackAll + totals.FactorAttackMelee),
+            MaxHit = ByFactor((int)((stats.MaxHit + totals.AttackAll + totals.AttackMelee) * (1 + (totals.DamageAll + totals.DamageMelee) / 100.0)), totals.FactorAttackAll + totals.FactorAttackMelee),
+            MinDistance = ByFactor((int)((stats.MinDistance + totals.AttackAll + totals.AttackRanged) * (1 + (totals.DamageAll + totals.DamageRanged) / 100.0)), totals.FactorAttackAll + totals.FactorAttackRanged),
+            MaxDistance = ByFactor((int)((stats.MaxDistance + totals.AttackAll + totals.AttackRanged) * (1 + (totals.DamageAll + totals.DamageRanged) / 100.0)), totals.FactorAttackAll + totals.FactorAttackRanged),
             EnemyFireResistance = stats.EnemyFireResistance + totals.FoeAll + totals.FoeFire,
             EnemyWaterResistance = stats.EnemyWaterResistance + totals.FoeAll + totals.FoeWater,
             EnemyLightResistance = stats.EnemyLightResistance + totals.FoeAll + totals.FoeLight,
@@ -247,9 +247,9 @@ public sealed class BattleStatsProvider(
             CriticalRate = stats.CriticalRate + totals.CritDamage,
             DistanceCriticalChance = stats.DistanceCriticalChance + totals.CritInflicting,
             DistanceCriticalRate = stats.DistanceCriticalRate + totals.CritDamage,
-            Defence = stats.Defence + totals.DefenceAll + totals.DefenceMelee,
-            DistanceDefence = stats.DistanceDefence + totals.DefenceAll + totals.DefenceRanged,
-            MagicDefence = stats.MagicDefence + totals.DefenceAll + totals.DefenceMagical,
+            Defence = ByFactor(stats.Defence + totals.DefenceAll + totals.DefenceMelee, totals.FactorDefenceAll + totals.FactorDefenceMelee),
+            DistanceDefence = ByFactor(stats.DistanceDefence + totals.DefenceAll + totals.DefenceRanged, totals.FactorDefenceAll + totals.FactorDefenceRanged),
+            MagicDefence = ByFactor(stats.MagicDefence + totals.DefenceAll + totals.DefenceMagical, totals.FactorDefenceAll + totals.FactorDefenceMagical),
             DefenceDodge = stats.DefenceDodge + totals.Dodge,
             DistanceDefenceDodge = stats.DistanceDefenceDodge + totals.Dodge,
             // "All" adds to each of the four rather than living in a fifth field: the
@@ -265,12 +265,23 @@ public sealed class BattleStatsProvider(
         };
     }
 
+    // A whole factor, the way types 34 and 35 state it: the negative half divides rather
+    // than subtracting, and zero is not a factor.
+    private static int ByFactor(int value, int factor) => factor switch
+    {
+        > 0 => value * factor,
+        < 0 => value / -factor,
+        _ => value,
+    };
+
     private sealed class CardTotals
     {
         public int AttackAll, AttackMelee, AttackRanged, AttackMagical;
         public int DamageAll, DamageMelee, DamageRanged, DamageMagical;
         public int CritInflicting, CritDamage;
         public int DefenceAll, DefenceMelee, DefenceRanged, DefenceMagical;
+        public int FactorAttackAll, FactorAttackMelee, FactorAttackRanged;
+        public int FactorDefenceAll, FactorDefenceMelee, FactorDefenceRanged, FactorDefenceMagical;
         public int HitRate, Dodge, Morale;
         public int FoeAll, FoeFire, FoeWater, FoeLight, FoeDark;
         public int ResistAll, ResistFire, ResistWater, ResistLight, ResistDark;
@@ -312,6 +323,26 @@ public sealed class BattleStatsProvider(
             [BCardEffect.DefenceRangedDecreased] = (t, v) => t.DefenceRanged -= v,
             [BCardEffect.DefenceMagicalIncreased] = (t, v) => t.DefenceMagical += v,
             [BCardEffect.DefenceMagicalDecreased] = (t, v) => t.DefenceMagical -= v,
+
+            // Types 34 and 35 state a factor, not a percentage: "attack power is
+            // multiplied by %s". The values are small whole numbers, so folding them into
+            // the percentage totals would turn a fivefold armour into a five per cent one.
+            // The decreasing half divides.
+            [BCardEffect.MultAttackAllAttackIncreased] = (t, v) => t.FactorAttackAll += v,
+            [BCardEffect.MultAttackAllAttackDecreased] = (t, v) => t.FactorAttackAll -= v,
+            [BCardEffect.MultAttackMeleeAttackIncreased] = (t, v) => t.FactorAttackMelee += v,
+            [BCardEffect.MultAttackMeleeAttackDecreased] = (t, v) => t.FactorAttackMelee -= v,
+            [BCardEffect.MultAttackRangedAttackIncreased] = (t, v) => t.FactorAttackRanged += v,
+            [BCardEffect.MultAttackRangedAttackDecreased] = (t, v) => t.FactorAttackRanged -= v,
+
+            [BCardEffect.MultDefenceAllDefenceIncreased] = (t, v) => t.FactorDefenceAll += v,
+            [BCardEffect.MultDefenceAllDefenceDecreased] = (t, v) => t.FactorDefenceAll -= v,
+            [BCardEffect.MultDefenceMeleeDefenceIncreased] = (t, v) => t.FactorDefenceMelee += v,
+            [BCardEffect.MultDefenceMeleeDefenceDecreased] = (t, v) => t.FactorDefenceMelee -= v,
+            [BCardEffect.MultDefenceRangedDefenceIncreased] = (t, v) => t.FactorDefenceRanged += v,
+            [BCardEffect.MultDefenceRangedDefenceDecreased] = (t, v) => t.FactorDefenceRanged -= v,
+            [BCardEffect.MultDefenceMagicalDefenceIncreased] = (t, v) => t.FactorDefenceMagical += v,
+            [BCardEffect.MultDefenceMagicalDefenceDecreased] = (t, v) => t.FactorDefenceMagical -= v,
 
             // Type 14, and the mirror of type 13: that one is the resistance of whoever
             // is being hit, this is what the one hitting does to it. Both end up in the

--- a/test/NosCore.GameObject.Tests/Services/BattleService/MultiplyingStatTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/MultiplyingStatTests.cs
@@ -1,0 +1,177 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using NodaTime;
+using NosCore.Data.Enumerations.Buff;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Interfaces;
+using NosCore.GameObject.Services.BattleService;
+using NosCore.GameObject.Services.EquipmentService;
+using NosCore.GameObject.Services.BattleService.Model;
+
+namespace NosCore.GameObject.Tests.Services.BattleService
+{
+    // BCard types 34 and 35 - "attack power is multiplied by %s", "defence is multiplied by
+    // %s". They are the only two families that state a factor rather than a percentage, their
+    // values are small whole numbers, and neither was folded in: a card promising a fivefold
+    // defence changed nothing.
+    //
+    // Nothing raises when a factor is read as a percentage either, which is why the fivefold
+    // and the halving are both held here.
+    [TestClass]
+    public class MultiplyingStatTests
+    {
+        private const short BaseDefence = 100;
+        private const short BaseDistanceDefence = 200;
+        private const short BaseMagicDefence = 300;
+        private const short BaseDamage = 50;
+
+        private static BCardDto Card(BCardEffect effect, short value) =>
+            new()
+            {
+                Type = effect.Type(),
+                SubType = effect.SubType(),
+                FirstData = value
+            };
+
+        private static CombatStats StatsWith(params BCardDto[] bCards)
+        {
+            var monster = new NpcMonsterDto
+            {
+                CloseDefence = BaseDefence,
+                DistanceDefence = BaseDistanceDefence,
+                MagicDefence = BaseMagicDefence,
+                DamageMinimum = BaseDamage,
+                DamageMaximum = BaseDamage
+            };
+
+            var entity = new Mock<INonPlayableEntity>();
+            entity.SetupGet(e => e.NpcMonster).Returns(monster);
+            entity.SetupGet(e => e.Level).Returns((byte)1);
+            entity.SetupGet(e => e.HeroLevel).Returns((byte)0);
+
+            var buffs = new Mock<IBuffService>();
+            buffs.Setup(b => b.GetActiveBuffs(It.IsAny<IAliveEntity>())).Returns(new List<BuffInstance>
+            {
+                new(CardId: 1, BuffType: BuffType.Good, Caster: null,
+                    StartedAt: Instant.MinValue, ExpiresAt: Instant.MaxValue, BCards: bCards)
+            });
+
+            return new BattleStatsProvider(buffs.Object, NoEquipment()).GetStats(entity.Object);
+        }
+
+        private static IEquipmentStatsService NoEquipment()
+        {
+            var equipment = new Mock<IEquipmentStatsService>();
+            equipment.Setup(s => s.Resolve(It.IsAny<IAliveEntity>())).Returns(EquipmentStats.None);
+            return equipment.Object;
+        }
+
+        [TestMethod]
+        public void WithoutAFactorEveryDefenceStaysAsItIs()
+        {
+            var stats = StatsWith();
+
+            Assert.AreEqual(BaseDefence, stats.Defence);
+            Assert.AreEqual(BaseDistanceDefence, stats.DistanceDefence);
+            Assert.AreEqual(BaseMagicDefence, stats.MagicDefence);
+        }
+
+        [TestMethod]
+        public void TheAllSubtypeMultipliesEveryDefence()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultDefenceAllDefenceIncreased, 3));
+
+            Assert.AreEqual(BaseDefence * 3, stats.Defence);
+            Assert.AreEqual(BaseDistanceDefence * 3, stats.DistanceDefence);
+            Assert.AreEqual(BaseMagicDefence * 3, stats.MagicDefence);
+        }
+
+        [TestMethod]
+        public void AMeleeFactorLeavesTheOtherTwoAlone()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultDefenceMeleeDefenceIncreased, 5));
+
+            Assert.AreEqual(BaseDefence * 5, stats.Defence);
+            Assert.AreEqual(BaseDistanceDefence, stats.DistanceDefence);
+            Assert.AreEqual(BaseMagicDefence, stats.MagicDefence);
+        }
+
+        [TestMethod]
+        public void ARangedFactorReachesOnlyRangedDefence()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultDefenceRangedDefenceIncreased, 5));
+
+            Assert.AreEqual(BaseDefence, stats.Defence);
+            Assert.AreEqual(BaseDistanceDefence * 5, stats.DistanceDefence);
+        }
+
+        [TestMethod]
+        public void AMagicFactorReachesOnlyMagicDefence()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultDefenceMagicalDefenceIncreased, 5));
+
+            Assert.AreEqual(BaseDefence, stats.Defence);
+            Assert.AreEqual(BaseMagicDefence * 5, stats.MagicDefence);
+        }
+
+        // The decreasing half of both types says "divided by", so it halves rather than taking
+        // two away.
+        [TestMethod]
+        public void TheDecreasingHalfDivides()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultDefenceAllDefenceDecreased, 2));
+
+            Assert.AreEqual(BaseDefence / 2, stats.Defence);
+            Assert.AreEqual(BaseMagicDefence / 2, stats.MagicDefence);
+        }
+
+        [TestMethod]
+        public void AnAttackFactorMultipliesBothEndsOfTheMeleeRoll()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultAttackAllAttackIncreased, 3));
+
+            Assert.AreEqual(BaseDamage * 3, stats.MinHit);
+            Assert.AreEqual(BaseDamage * 3, stats.MaxHit);
+        }
+
+        [TestMethod]
+        public void AMeleeAttackFactorDoesNotTouchTheRangedRoll()
+        {
+            var stats = StatsWith(Card(BCardEffect.MultAttackMeleeAttackIncreased, 2));
+
+            Assert.AreEqual(BaseDamage * 2, stats.MaxHit);
+            Assert.AreEqual(BaseDamage, stats.MaxDistance);
+        }
+
+        // A factor of one is the identity in both directions, and a decrease of one must not
+        // wipe the stat out.
+        [TestMethod]
+        public void AFactorOfOneChangesNothingEitherWay()
+        {
+            Assert.AreEqual(BaseDefence,
+                StatsWith(Card(BCardEffect.MultDefenceAllDefenceIncreased, 1)).Defence);
+            Assert.AreEqual(BaseDefence,
+                StatsWith(Card(BCardEffect.MultDefenceAllDefenceDecreased, 1)).Defence);
+        }
+
+        // "All" and the per-kind subtype are one factor between them, the way the flat halves
+        // of types 3 and 9 are one amount.
+        [TestMethod]
+        public void AllAndAKindAddUpIntoOneFactor()
+        {
+            var stats = StatsWith(
+                Card(BCardEffect.MultDefenceAllDefenceIncreased, 2),
+                Card(BCardEffect.MultDefenceMeleeDefenceIncreased, 3));
+
+            Assert.AreEqual(BaseDefence * 5, stats.Defence);
+            Assert.AreEqual(BaseDistanceDefence * 2, stats.DistanceDefence);
+        }
+    }
+}


### PR DESCRIPTION
BCard types 34 and 35 — "attack power is multiplied by %s" and "defence is multiplied by %s" — are declared in `BCardEffect` and were absent from the fold in `BattleStatsProvider`. A card promising a fivefold defence changed nothing, and nothing raised.

They are the only two families that state a **factor** rather than a percentage. Their values are small whole numbers, so reading one as a percentage would turn the strongest card of the family into five per cent; and the decreasing half says "divided by", so it halves rather than subtracting two.

"All" and the per-kind subtype add into one factor, the way the flat halves of types 3 and 9 already do.

**Left out, deliberately**

* `35/51-52` — "damage is reduced by %s%% per debuff stack, up to %s%%": a rate and a ceiling, not a factor, and there is no count of stacks to feed it.
* `34/41-42` — `CombatStats` has no magic attack field for them to land in.
* `34/51-52` — these scale with missing HP, which is a different shape again.

**What was tested**

* 10 unit tests in `MultiplyingStatTests`: the "all" subtype reaching all three defences, each per-kind subtype reaching only its own, the attack factor moving both ends of the roll, the halving, the identity at 1, and "all" plus a kind adding into one factor.
* Measured red-before by making the fold a no-op: **8 of the 10 failed**; with the fold in place, `NosCore.GameObject.Tests` is **452 passed, 0 failed**, and `dotnet build NosCore.sln` is 0 warnings, 0 errors.
* **No in-game verification** — I did not run a client for this. Checks added to the combat section of `documentation/manual-test-plan.md`; they are deliberately coarse, because a fivefold defence should be visible in a single exchange rather than needing measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiplying attack and defence stats through factor-based effects.
  * Supports overall and melee, ranged, or magic-specific defence adjustments.
  * Negative factors reduce stats by division, while a factor of one leaves them unchanged.

* **Documentation**
  * Added a manual testing checklist for multiplied attack and defence effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->