### PR TITLE
master does not compile: VitalityService still uses AdditionalTypes

### DIFF
--- a/src/NosCore.GameObject/Services/BattleService/VitalityService.cs
+++ b/src/NosCore.GameObject/Services/BattleService/VitalityService.cs
@@ -47,44 +47,36 @@ public sealed class VitalityService(
 
         foreach (var card in cards)
         {
-            if ((BCardType.CardType)card.Type == BCardType.CardType.Quest)
-            {
-                var first = BattleStatsProvider.ScaleByLevel(card, character.Level);
-                switch ((AdditionalTypes.Quest)card.SubType)
-                {
-                    case AdditionalTypes.Quest.AdditionalHpPercent:
-                        additionalHpPercent += first;
-                        additionalHpCap = Math.Max(additionalHpCap, card.SecondData);
-                        break;
-                    case AdditionalTypes.Quest.AdditionalMpPercent:
-                        additionalMpPercent += first;
-                        additionalMpCap = Math.Max(additionalMpCap, card.SecondData);
-                        break;
-                }
-
-                continue;
-            }
-
-            if ((BCardType.CardType)card.Type != BCardType.CardType.MaxHpmp)
+            var type = (BCardType.CardType)card.Type;
+            if (type != BCardType.CardType.Quest && type != BCardType.CardType.MaxHpmp)
             {
                 continue;
             }
 
             var value = BattleStatsProvider.ScaleByLevel(card, character.Level);
-            switch ((AdditionalTypes.MaxHpmp)card.SubType)
+            switch (card.Effect())
             {
-                case AdditionalTypes.MaxHpmp.MaximumHpIncreased: hp += value; break;
-                case AdditionalTypes.MaxHpmp.MaximumHpDecreased: hp -= value; break;
-                case AdditionalTypes.MaxHpmp.MaximumMpIncreased: mp += value; break;
-                case AdditionalTypes.MaxHpmp.MaximumMpDecreased: mp -= value; break;
-                case AdditionalTypes.MaxHpmp.IncreasesMaximumHp: hpPercent += value; break;
-                case AdditionalTypes.MaxHpmp.DecreasesMaximumHp: hpPercent -= value; break;
-                case AdditionalTypes.MaxHpmp.IncreasesMaximumMp: mpPercent += value; break;
-                case AdditionalTypes.MaxHpmp.DecreasesMaximumMp: mpPercent -= value; break;
+                case BCardEffect.QuestAdditionalHpPercent:
+                    additionalHpPercent += value;
+                    additionalHpCap = Math.Max(additionalHpCap, card.SecondData);
+                    break;
+                case BCardEffect.QuestAdditionalMpPercent:
+                    additionalMpPercent += value;
+                    additionalMpCap = Math.Max(additionalMpCap, card.SecondData);
+                    break;
+
+                case BCardEffect.MaxHpmpMaximumHpIncreased: hp += value; break;
+                case BCardEffect.MaxHpmpMaximumHpDecreased: hp -= value; break;
+                case BCardEffect.MaxHpmpMaximumMpIncreased: mp += value; break;
+                case BCardEffect.MaxHpmpMaximumMpDecreased: mp -= value; break;
+                case BCardEffect.MaxHpmpIncreasesMaximumHp: hpPercent += value; break;
+                case BCardEffect.MaxHpmpDecreasesMaximumHp: hpPercent -= value; break;
+                case BCardEffect.MaxHpmpIncreasesMaximumMp: mpPercent += value; break;
+                case BCardEffect.MaxHpmpDecreasesMaximumMp: mpPercent -= value; break;
 
                 // Subtype 51 moves both maxima together.
-                case AdditionalTypes.MaxHpmp.MaximumHpmpIncreased: hp += value; mp += value; break;
-                case AdditionalTypes.MaxHpmp.MaximumHpmpDecreased: hp -= value; mp -= value; break;
+                case BCardEffect.MaxHpmpMaximumHpmpIncreased: hp += value; mp += value; break;
+                case BCardEffect.MaxHpmpMaximumHpmpDecreased: hp -= value; mp -= value; break;
             }
         }
 

--- a/test/NosCore.GameObject.Tests/Services/BattleService/VitalityServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/VitalityServiceTests.cs
@@ -60,8 +60,8 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             new BCardDto
             {
                 ItemVNum = BlessedHatVnum,
-                Type = (byte)BCardType.CardType.MaxHpmp,
-                SubType = (byte)AdditionalTypes.MaxHpmp.MaximumHpIncreased,
+                Type = BCardEffect.MaxHpmpMaximumHpIncreased.Type(),
+                SubType = BCardEffect.MaxHpmpMaximumHpIncreased.SubType(),
                 FirstData = 500
             }
         };


### PR DESCRIPTION
Master has not built since #2321. `dotnet build` fails with fourteen instances of

```
error CS0246: The type or namespace name 'AdditionalTypes' could not be found
```

all in `src/NosCore.GameObject/Services/BattleService/VitalityService.cs`.

### How it happened

#2325 deleted `AdditionalTypes.cs` and replaced the `(type, subtype)` pair with a single `BCardEffect` key. #2321 merged right after it, carrying a `VitalityService` written against the old API. Each was green on its own branch; together they do not compile. Nothing in either diff touches the other file, which is why neither review could have caught it.

### The change

`card.Effect()` instead of casting `card.SubType` to a per-type enum, and the flattened members — `BCardEffect.QuestAdditionalHpPercent`, `BCardEffect.MaxHpmpMaximumHpIncreased`, and so on. The two switches collapse into one because the key already carries the type; the early filter stays in front so `ScaleByLevel` is still only called for the two types that matter.

The test moved the same way and no longer names a subtype by hand:

```csharp
Type = BCardEffect.MaxHpmpMaximumHpIncreased.Type(),
SubType = BCardEffect.MaxHpmpMaximumHpIncreased.SubType(),
```

Behaviour is unchanged — every case maps one to one, and the two `Quest` cases keep their `SecondData` cap.

### Tested

- `dotnet build NosCore.sln` — 0 errors, 0 warnings.
- `dotnet test NosCore.sln --filter TestCategory!=OPTIONAL-TEST` — **1013 passed, 0 failed**, including the 7 `VitalityServiceTests`.
- Without the filter, `EveryDeclaredEffectIsNamed` fails on 231 unnamed effects. That is the opt-in test #2325 added and it is what #2329 is for — it is excluded in CI and it fails on master today with or without this change.
- **Not played.** The NosCore servers are not run here, so this is the compiler and the test suite, nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined vitality effect processing for quest and maximum HP/MP cards.
  * Preserved existing health and mana bonuses, reductions, percentage effects, caps, and paired maximum-stat changes.

* **Tests**
  * Updated test setup to use the corresponding maximum HP/MP effect definitions without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->