### PR TITLE
docs: no ConfigureAwait, and what to do when a merge is already in a PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ for f in $(git diff --name-only origin/master...HEAD | grep '\.cs$'); do
 done
 ```
 
+**No `ConfigureAwait`.** Every host here is a generic-host console app, so there is no
+synchronization context to come back to and `ConfigureAwait(false)` does nothing but add
+noise to the line. Do not add it; the calls still in the tree are not a precedent.
+
 **Keep semantic types.** Do not flatten a `bool` or an enum to a number because the wire
 value happens to be `0` or `1`; the serializer handles the conversion.
 
@@ -125,7 +129,17 @@ check the table's length too, since inherited tables are often truncated at an o
 - **Never commit to `master`.** Branch, PR, CI green, then merge — including one-line
   chores.
 - **Rebase, never merge.** Linear history: `git rebase origin/master`, `--force-with-lease`
-  on push. Never merge `master` into a branch.
+  on push. Never merge `master` into a branch — not to pick up a fix, not to resolve a
+  conflict, not to make the PR mergeable again. A `Merge remote-tracking branch` or
+  `merge: origin/master` commit in a PR is a defect, and the fix is to rebase it out rather
+  than leave it. Check before pushing:
+
+  ```bash
+  git log --oneline --merges origin/master..HEAD   # must print nothing
+  ```
+
+  Rebasing a long branch across a renamed API repeats the same conflict on every commit;
+  `git config rerere.enabled true` resolves it once and replays the rest.
 - Base new work on `origin/master`, and keep iterating on the same branch rather than
   opening a new one per follow-up.
 - Opening a PR unprompted is fine; **wait for approval before merging** unless the request


### PR DESCRIPTION
Two rules, one new and one that existed but was not landing.

## No `ConfigureAwait`

Every host in this repo is a generic-host console app, so there is no synchronization context to return to and `ConfigureAwait(false)` is a no-op that only lengthens the line. It has been coming up in review repeatedly — #2304 carries a `review: drop the ConfigureAwait(false) calls` commit — so it belongs in the conventions instead.

There are 168 calls already in the tree (47 in `Parser.cs` alone). This does not remove them; it says they are not a precedent. Happy to do the cleanup separately if you want it.

## Rebase, never merge

The rule was already there and every one of the seven open PRs still had a merge commit, so restating it verbatim would not have helped. What it was missing is the case people actually hit: the branch is behind, or the PR has gone un-mergeable, and a merge is the quickest way out. It now names those cases, says a merge commit already in a PR is a defect to be rebased out rather than left, and gives the check:

```bash
git log --oneline --merges origin/master..HEAD   # must print nothing
```

It also points at `rerere`, because the thing that makes rebasing feel worse than merging is a long branch replaying the same conflict on every commit.