### PR TITLE
A spaced mate name reached the client as two fields

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
     <PackageVersion Include="NosCore.Analyzers" Version="2.0.0" />
     <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
-    <PackageVersion Include="NosCore.Packets" Version="21.1.0" />
+    <PackageVersion Include="NosCore.Packets" Version="21.1.1" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
     <PackageVersion Include="NosCore.Shared" Version="6.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />

--- a/test/NosCore.GameObject.Tests/Services/MateService/MateServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/MateService/MateServiceTests.cs
@@ -14,6 +14,8 @@ using NosCore.Dao.Interfaces;
 using NosCore.Data.Dto;
 using NosCore.Data.Enumerations.Character;
 using NosCore.Data.StaticEntities;
+using NosCore.Packets;
+using NosCore.Packets.Interfaces;
 using NosCore.Packets.ServerPackets.Mates;
 using NosCore.Shared.Enumerations;
 using System.Collections.Generic;
@@ -326,6 +328,28 @@ namespace NosCore.GameObject.Tests.Services.MateService
             var mate = mates[0];
             Assert.IsTrue(walled.IsWalkable(mate.PositionX, mate.PositionY),
                 $"placed at {mate.PositionX},{mate.PositionY}, which is not walkable");
+        }
+
+        [TestMethod]
+        public async Task ASpacedMateNameReachesTheClientAsOneFieldAsync()
+        {
+            var service = Build(new[]
+            {
+                new MateDto { MateId = 1, CharacterId = CharacterId, VNum = ChickenVNum, MateType = MateType.Pet, IsTeamMember = true, Name = "Joyeux Mouton" }
+            }, Creature(ChickenVNum, "Chicken", 157, 10));
+
+            var mate = (await service.LoadAsync(CharacterId))[0];
+            var serializer = new Serializer(typeof(IPacket).Assembly.GetTypes()
+                .Where(p => p.GetInterfaces().Contains(typeof(IPacket)) && p.IsClass && !p.IsAbstract)
+                .ToList());
+
+            foreach (var packet in new IPacket[]
+                { mate.GenerateIn(RegionType.EN), mate.GenerateScp(RegionType.EN), mate.GenerateScn(RegionType.EN) })
+            {
+                var line = serializer.Serialize(new[] { packet }).TrimEnd();
+                StringAssert.Contains(line, "Joyeux^Mouton",
+                    $"the name has to travel as one field: {line}");
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #2281, which merged before this landed.

## The defect

A mate whose name contains a space reaches the client as two fields. Serialized on master, a mate named `Joyeux Mouton`:

```
in    2 333 2000001 0 0 0 0 0 0 0 3 42 1 0 -1 Joyeux Mouton 0 -1 0 0 ...
sc_p  0 333 2000001 0 0 0 ... 1 15 0 Joyeux Mouton 0
sc_n  0 333 2000001 0 0 0 ... 1 15 Joyeux Mouton -1 0 -1 -1 -1 -1
```

Every field after the name is shifted by one. It is reachable without renaming anything: the fallback when a mate was never renamed is the creature's own name, and plenty of those carry a space.

## Why the serializer does not cover it

`Serializer.StringSerializer` holds a `Replace(splitter, "^")`, but the splitter it is handed is `index.SpecialSeparator`, which is null for an ordinary property. `IsNullOrEmpty(splitter)` is then true and the value is returned untouched; the space between fields is added afterwards, by `PacketSerializer`, and never enters the substitution. So a plain space-separated field keeps its own spaces, and none of the three properties the mate name goes into declares a special separator.

Worth a separate look, not changed here: if that `Replace` is meant to guard the field separator rather than a special one, fixing it in `NosCore.Packets` would let this line and every other manual substitution in the tree go away.

## What changed

`MateExtensions.DisplayName` puts the substitution back, in one place, so all three generators get it.

## What was tested

- `ASpacedMateNameReachesTheClientAsOneFieldAsync` builds a real `Serializer` over the packet assembly and asserts on the **serialized line** for `in`, `sc_p` and `sc_n`. The existing tests asserted on the packet object, which is why the shift went unnoticed.
- Red first: with the substitution removed the new test fails on all three lines with the output quoted above; with it back, all three carry `Joyeux^Mouton`.
- `TheCreatureNameIsUsedWhenTheMateWasNeverRenamedAsync` now expects the escaped form.
- `dotnet build NosCore.sln` at 0 warnings, `dotnet test` green with the CI filter (533 in NosCore.GameObject.Tests).
- **Not played.** We do not run a NosCore server, so no client has been in front of this. The claim rests on the serialized lines above, not on a screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mate names containing spaces so they are transmitted and displayed as a single field.
  * Updated localized and custom creature names to use the correct serialized format.

* **Tests**
  * Added coverage verifying that spaced mate names reach the client correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->