### PR TITLE
Drop the FastMember fork for an emitted member accessor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,6 @@
     <PackageVersion Include="NosCore.Algorithm" Version="2.1.0" />
     <PackageVersion Include="NosCore.Analyzers" Version="2.0.0" />
     <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
-    <PackageVersion Include="NosCore.FastMember" Version="1.5.0" />
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
     <PackageVersion Include="NosCore.Packets" Version="21.0.0" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />

--- a/src/NosCore.Data/Dto/StaticDtoExtension.cs
+++ b/src/NosCore.Data/Dto/StaticDtoExtension.cs
@@ -4,7 +4,6 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
-using FastMember;
 using NosCore.Shared.Enumerations;
 using System;
 using System.Collections.Generic;
@@ -37,7 +36,7 @@ namespace NosCore.Data.Dto
         public static void InjectI18N(this IStaticDto staticDto,
             IDictionary<PropertyInfo, Tuple<PropertyInfo, Type>> propertyInfos,
             IDictionary<Type, Dictionary<string, Dictionary<RegionType, II18NDto>>> langDictionary, Array regions,
-            TypeAccessor accessor)
+            MemberAccessor accessor)
         {
             foreach (var prop in propertyInfos)
             {

--- a/src/NosCore.Data/MemberAccessor.cs
+++ b/src/NosCore.Data/MemberAccessor.cs
@@ -1,0 +1,141 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Reflection.Emit;
+
+namespace NosCore.Data
+{
+    // Get and set a member by name without paying reflection's per-call cost. The generated
+    // DTOs mark their navigation properties internal, and the parsers write six of them by
+    // name, so the delegates are emitted with skipVisibility rather than compiled from an
+    // expression tree, which cannot reach a non-public member.
+    public sealed class MemberAccessor
+    {
+        private static readonly ConcurrentDictionary<Type, MemberAccessor> Accessors = new();
+
+        private readonly Dictionary<string, Func<object, object?>> _getters;
+        private readonly Dictionary<string, Action<object, object?>> _setters;
+
+        private MemberAccessor(Type type)
+        {
+            _getters = new Dictionary<string, Func<object, object?>>(StringComparer.Ordinal);
+            _setters = new Dictionary<string, Action<object, object?>>(StringComparer.Ordinal);
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            foreach (var property in type.GetProperties(flags))
+            {
+                if (property.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+
+                if (property.GetGetMethod(true) is { } getMethod)
+                {
+                    _getters[property.Name] = EmitGetter(type, property.PropertyType, getMethod, null);
+                }
+
+                if (property.GetSetMethod(true) is { } setMethod)
+                {
+                    _setters[property.Name] = EmitSetter(type, property.PropertyType, setMethod, null);
+                }
+            }
+
+            foreach (var field in type.GetFields(flags))
+            {
+                _getters[field.Name] = EmitGetter(type, field.FieldType, null, field);
+                if (!field.IsInitOnly)
+                {
+                    _setters[field.Name] = EmitSetter(type, field.FieldType, null, field);
+                }
+            }
+        }
+
+        // Both halves stay small enough to inline: building the message is a call the JIT can
+        // leave out of line, and inlining is the difference between this and plain reflection.
+        public object? this[object target, string name]
+        {
+            get
+            {
+                if (!_getters.TryGetValue(name, out var getter))
+                {
+                    ThrowUnknown(target, name, "readable");
+                }
+
+                return getter!(target);
+            }
+            set
+            {
+                if (!_setters.TryGetValue(name, out var setter))
+                {
+                    ThrowUnknown(target, name, "writable");
+                }
+
+                setter!(target, value);
+            }
+        }
+
+        public static MemberAccessor For(Type type) => Accessors.GetOrAdd(type, t => new MemberAccessor(t));
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowUnknown(object target, string name, string kind) =>
+            throw new ArgumentOutOfRangeException(nameof(name), name,
+                $"{target.GetType().Name} has no {kind} member named '{name}'.");
+
+        private static Func<object, object?> EmitGetter(Type owner, Type memberType, MethodInfo? getMethod, FieldInfo? field)
+        {
+            var method = new DynamicMethod($"get_{field?.Name ?? getMethod!.Name}", typeof(object),
+                new[] { typeof(object) }, owner.Module, skipVisibility: true);
+            var il = method.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, owner);
+            if (field != null)
+            {
+                il.Emit(OpCodes.Ldfld, field);
+            }
+            else
+            {
+                il.Emit(getMethod!.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, getMethod);
+            }
+
+            if (memberType.IsValueType)
+            {
+                il.Emit(OpCodes.Box, memberType);
+            }
+
+            il.Emit(OpCodes.Ret);
+            return (Func<object, object?>)method.CreateDelegate(typeof(Func<object, object?>));
+        }
+
+        private static Action<object, object?> EmitSetter(Type owner, Type memberType, MethodInfo? setMethod, FieldInfo? field)
+        {
+            var method = new DynamicMethod($"set_{field?.Name ?? setMethod!.Name}", null,
+                new[] { typeof(object), typeof(object) }, owner.Module, skipVisibility: true);
+            var il = method.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, owner);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(memberType.IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, memberType);
+            if (field != null)
+            {
+                il.Emit(OpCodes.Stfld, field);
+            }
+            else
+            {
+                il.Emit(setMethod!.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, setMethod);
+            }
+
+            il.Emit(OpCodes.Ret);
+            return (Action<object, object?>)method.CreateDelegate(typeof(Action<object, object?>));
+        }
+    }
+}

--- a/src/NosCore.Data/NosCore.Data.csproj
+++ b/src/NosCore.Data/NosCore.Data.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Mapster" />
     <PackageReference Include="Mapster.JsonNet" />
-    <PackageReference Include="NosCore.FastMember" />
     <PackageReference Include="NosCore.Packets" />
     <PackageReference Include="NodaTime" />
   </ItemGroup>

--- a/src/NosCore.Database/Hosting/PersistenceModule.cs
+++ b/src/NosCore.Database/Hosting/PersistenceModule.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Autofac;
-using FastMember;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NosCore.Dao;
@@ -150,7 +149,7 @@ public sealed class PersistenceModule : Autofac.Module
             if (props.Count > 0)
             {
                 var regions = Enum.GetValues(typeof(RegionType));
-                var accessors = TypeAccessor.Create(typeof(TDto));
+                var accessors = MemberAccessor.For(typeof(TDto));
                 Parallel.ForEach(items, s => ((IStaticDto)s!).InjectI18N(props, dic, regions, accessors));
             }
 

--- a/src/NosCore.MasterServer/MasterServerBootstrap.cs
+++ b/src/NosCore.MasterServer/MasterServerBootstrap.cs
@@ -4,10 +4,10 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Data;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using FastExpressionCompiler;
-using FastMember;
 using Mapster;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -232,7 +232,7 @@ namespace NosCore.MasterServer
                 var props = StaticDtoExtension.GetI18NProperties(typeof(ItemDto));
 
                 var regions = Enum.GetValues(typeof(RegionType));
-                var accessors = TypeAccessor.Create(typeof(ItemDto));
+                var accessors = MemberAccessor.For(typeof(ItemDto));
                 Parallel.ForEach(items, s => s.InjectI18N(props, dic, regions, accessors));
                 var staticMetaDataAttribute = typeof(ItemDto).GetCustomAttribute<StaticMetaDataAttribute>();
                 if ((items.Count != 0) || (staticMetaDataAttribute == null) ||

--- a/src/NosCore.Parser/Parsers/Generic/GenericParser.cs
+++ b/src/NosCore.Parser/Parsers/Generic/GenericParser.cs
@@ -4,7 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
-using FastMember;
+using NosCore.Data;
 using NosCore.Data.Enumerations.I18N;
 using NosCore.Shared.I18N;
 using Microsoft.Extensions.Logging;
@@ -24,7 +24,7 @@ namespace NosCore.Parser.Parsers.Generic
         ILogLanguageLocalizer<LogLanguageKey> logLanguage)
     where T : new()
     {
-        private readonly TypeAccessor _typeAccessor = TypeAccessor.Create(typeof(T), true);
+        private readonly MemberAccessor _typeAccessor = MemberAccessor.For(typeof(T));
 
         private IEnumerable<string> ParseTextFromFile()
         {

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -7,7 +7,6 @@
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using FastExpressionCompiler;
-using FastMember;
 using Mapster;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/test/NosCore.Database.Tests/MemberAccessorTests.cs
+++ b/test/NosCore.Database.Tests/MemberAccessorTests.cs
@@ -1,0 +1,150 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.Data;
+using NosCore.Data.StaticEntities;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace NosCore.Database.Tests
+{
+    [TestClass]
+    public class MemberAccessorTests
+    {
+        private sealed class Target
+        {
+            public long Number { get; set; }
+            public string? Text { get; set; }
+            public short? Nullable { get; set; }
+            internal List<string>? Hidden { get; set; }
+            public long ReadOnly { get; } = 7;
+            public string Field = "field";
+            public string this[int index] => index.ToString();
+        }
+
+        [TestMethod]
+        public void APublicValueRoundTrips()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target();
+
+            accessor[target, "Number"] = 42L;
+
+            Assert.AreEqual(42L, target.Number);
+            Assert.AreEqual(42L, accessor[target, "Number"]);
+        }
+
+        [TestMethod]
+        public void AReferenceAndANullRoundTrip()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target { Text = "before" };
+
+            accessor[target, "Text"] = "after";
+            Assert.AreEqual("after", accessor[target, "Text"]);
+
+            accessor[target, "Text"] = null;
+            Assert.IsNull(target.Text);
+            Assert.IsNull(accessor[target, "Text"]);
+        }
+
+        [TestMethod]
+        public void ANullableValueTypeTakesBothAValueAndNull()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target();
+
+            accessor[target, "Nullable"] = (short)5;
+            Assert.AreEqual((short)5, target.Nullable);
+
+            accessor[target, "Nullable"] = null;
+            Assert.IsNull(target.Nullable);
+        }
+
+        // The reason this exists rather than an expression tree: a compiled lambda cannot
+        // reach a non-public member, and the parsers write six internal navigation properties.
+        [TestMethod]
+        public void AnInternalMemberIsWritable()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target();
+
+            accessor[target, "Hidden"] = new List<string> { "a", "b" };
+
+            Assert.AreEqual(2, target.Hidden!.Count);
+            Assert.AreSame(target.Hidden, accessor[target, "Hidden"]);
+        }
+
+        [TestMethod]
+        public void TheInternalNavigationPropertiesTheParsersWriteAreAllWritable()
+        {
+            foreach (var (type, member) in new (Type, string)[]
+                     {
+                         (typeof(SkillDto), "BCards"), (typeof(SkillDto), "Combo"),
+                         (typeof(SkillDto), "NpcMonsterSkill"), (typeof(ItemDto), "BCards"),
+                         (typeof(ItemDto), "Drop"), (typeof(NpcMonsterDto), "Drop"),
+                         (typeof(CardDto), "BCards"), (typeof(QuestDto), "QuestObjective")
+                     })
+            {
+                var setter = type.GetProperty(member,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!.GetSetMethod(true)!;
+                Assert.IsFalse(setter.IsPublic, $"{type.Name}.{member} is expected to be non-public");
+
+                var instance = Activator.CreateInstance(type)!;
+                MemberAccessor.For(type)[instance, member] = null;
+            }
+        }
+
+        [TestMethod]
+        public void AFieldRoundTrips()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target();
+
+            accessor[target, "Field"] = "changed";
+
+            Assert.AreEqual("changed", target.Field);
+            Assert.AreEqual("changed", accessor[target, "Field"]);
+        }
+
+        [TestMethod]
+        public void AGetOnlyPropertyReadsButDoesNotWrite()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target();
+
+            Assert.AreEqual(7L, accessor[target, "ReadOnly"]);
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => accessor[target, "ReadOnly"] = 9L);
+        }
+
+        [TestMethod]
+        public void AnUnknownNameSaysSoOnBothSides()
+        {
+            var accessor = MemberAccessor.For(typeof(Target));
+            var target = new Target();
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = accessor[target, "Nope"]);
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => accessor[target, "Nope"] = 1L);
+        }
+
+        [TestMethod]
+        public void AnIndexerIsNotMistakenForAMember()
+        {
+            // Item[int] has index parameters and no name a caller would use; emitting a getter
+            // for it would throw at delegate creation rather than at first use.
+            var accessor = MemberAccessor.For(typeof(Target));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => _ = accessor[new Target(), "Item"]);
+        }
+
+        [TestMethod]
+        public void TheAccessorForATypeIsBuiltOnce()
+        {
+            Assert.AreSame(MemberAccessor.For(typeof(Target)), MemberAccessor.For(typeof(Target)));
+        }
+    }
+}


### PR DESCRIPTION
Closes #1126.

## Why the fork exists, and why the official package cannot replace it

`NosCore.FastMember` is a fork whose only reason to exist is `TypeAccessor.Create(type, true)` reaching a **non-public** setter. That is not vestigial — `NosCore.Data` grants `InternalsVisibleTo("NosCore.Parser")`, and six DTO navigation properties are `internal` and written by name from the parsers:

`BCards`, `Combo`, `Drop`, `NpcMonsterSkill`, `QuestObjective`, `QuestQuestReward`

So #1126 could never have been "switch to the official package" — stock FastMember would silently stop writing those six.

Upstream is not coming. Package `1.5.0` was published **2019-05-24**, the last commit is January 2022, and the two PRs fixing exactly this (#85, and erwan-joly's #86) have been open since 2020.

There is also no library to move to. Fasterflect's last release is 2020, Sigil's 2019; the only actively published one, ReflectionMagic, is a DLR wrapper — slower than reflection, not faster. The category emptied out because .NET absorbed it into source generators and `[UnsafeAccessor]`, neither of which is a drop-in by-name accessor.

## What replaces it

`MemberAccessor` emits the same `DynamicMethod` with `skipVisibility: true` that the fork does, cached per type. The consumed surface was small — `Create` plus a by-name indexer — so the four call sites change by one line each: `GenericParser`, `StaticDtoExtension`, `PersistenceModule`, `MasterServerBootstrap`. `WorldServerBootstrap` just loses a stale `using`.

An expression tree would have been simpler but cannot do this: a compiled lambda is visibility-checked, which is the whole reason the fork emits IL.

## Numbers

`ItemDto.Price`, 5M sets, best of four rounds discarding the first, all three measured **in the same process** (an earlier cross-run comparison of mine flattered the emitted path and I would rather correct it than quote it):

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `MemberAccessor` | 24.2ns | 25.8ns | 25.8ns |
| FastMember fork | 25.4ns | 26.4ns | 26.6ns |
| cached reflection | 33.6ns | 33.4ns | 38.2ns |

Even with the fork, ~1.35× ahead of reflection. **The win here is losing a dead dependency, not the nanosecond** — a full import is roughly 1M sets, so all of this is milliseconds either way.

## Caveat

`Reflection.Emit` rules out NativeAOT. Not a constraint today (Autofac and Wolverine's runtime codegen already are), but if AOT ever becomes a goal the answer is a source generator — and `DtoGenerator` already generates these DTOs, so it is well placed to emit a by-name switch with free internal access.

## Tests

11 new, covering the internal setter specifically (including asserting those six navigation properties really are non-public before writing them), plus value/reference/nullable round-trips, fields, get-only, unknown names, indexers, and caching.

Solution builds. GameObject 495, PacketHandlers 410, Parser 124, Database 11, Core 10, WebApi 17 — all green under the CI filter.