### PR TITLE
feat(di): replace startup reflection scans with NosCore.DiGenerator

### DIFF
--- a/NosCore.sln
+++ b/NosCore.sln
@@ -49,6 +49,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NosCore.EcsGenerator", "tools\NosCore.EcsGenerator\NosCore.EcsGenerator.csproj", "{78731E48-C6CA-4614-B617-65B55A85CAE0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NosCore.DiGenerator", "tools\NosCore.DiGenerator\NosCore.DiGenerator.csproj", "{E4AD945D-BF33-40FB-8F3A-3F706850ED76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -287,6 +289,18 @@ Global
 		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x64.Build.0 = Release|Any CPU
 		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x86.ActiveCfg = Release|Any CPU
 		{78731E48-C6CA-4614-B617-65B55A85CAE0}.Release|x86.Build.0 = Release|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Debug|x64.Build.0 = Debug|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Debug|x86.Build.0 = Debug|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Release|x64.ActiveCfg = Release|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Release|x64.Build.0 = Release|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Release|x86.ActiveCfg = Release|Any CPU
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -311,6 +325,7 @@ Global
 		{4A4D1876-74CC-46B7-BB93-B3E0E4D25AE5} = {D4E0F6CD-9F21-4140-AC42-CD021D98B980}
 		{4E68313F-69F8-4125-B87E-665D6F7DFD5D} = {EFA0F8A7-CBF2-4542-82A9-931BB0111FED}
 		{78731E48-C6CA-4614-B617-65B55A85CAE0} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{E4AD945D-BF33-40FB-8F3A-3F706850ED76} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B673C11-52EF-455B-BFC6-8CFEBC340972}

--- a/src/NosCore.GameObject/Infastructure/IPacketHandler.cs
+++ b/src/NosCore.GameObject/Infastructure/IPacketHandler.cs
@@ -6,6 +6,7 @@
 
 using NosCore.GameObject.Networking.ClientSession;
 using NosCore.Packets.Interfaces;
+using System;
 using System.Threading.Tasks;
 
 namespace NosCore.GameObject.Infastructure
@@ -13,6 +14,11 @@ namespace NosCore.GameObject.Infastructure
     public interface IPacketHandler
     {
         Task ExecuteAsync(IPacket packet, ClientSession clientSession);
+
+        // The packet this handler consumes. Supplied by PacketHandler<TPacket> so the
+        // registry can key on it directly instead of walking BaseType.GenericTypeArguments,
+        // which silently skipped any handler whose inheritance chain didn't match.
+        Type PacketType { get; }
     }
 
     public interface ILoginPacketHandler
@@ -30,6 +36,8 @@ namespace NosCore.GameObject.Infastructure
 
     public abstract class PacketHandler<TPacket> : IPacketHandler<TPacket> where TPacket : IPacket
     {
+        public Type PacketType => typeof(TPacket);
+
         public abstract Task ExecuteAsync(TPacket packet, ClientSession clientSession);
 
         public Task ExecuteAsync(IPacket packet, ClientSession clientSession)

--- a/src/NosCore.GameObject/Infastructure/IPacketHandler.cs
+++ b/src/NosCore.GameObject/Infastructure/IPacketHandler.cs
@@ -15,9 +15,8 @@ namespace NosCore.GameObject.Infastructure
     {
         Task ExecuteAsync(IPacket packet, ClientSession clientSession);
 
-        // The packet this handler consumes. Supplied by PacketHandler<TPacket> so the
-        // registry can key on it directly instead of walking BaseType.GenericTypeArguments,
-        // which silently skipped any handler whose inheritance chain didn't match.
+        // Supplied by PacketHandler<TPacket>; walking BaseType.GenericTypeArguments instead
+        // silently skipped handlers whose inheritance chain did not match.
         Type PacketType { get; }
     }
 

--- a/src/NosCore.GameObject/Messaging/WolverineDependencyRegistrar.cs
+++ b/src/NosCore.GameObject/Messaging/WolverineDependencyRegistrar.cs
@@ -4,15 +4,11 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
-using System;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using NosCore.Core;
 using NosCore.Core.Services.IdService;
 using NosCore.GameObject.Ecs;
-using NosCore.GameObject.Infastructure;
-using NosCore.GameObject.InterChannelCommunication.Hubs.ChannelHub;
-using NosCore.GameObject.Messaging.Handlers.Nrun;
+using NosCore.GameObject.Generated;
 using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.ExchangeService;
 using NosCore.GameObject.Services.GroupService;
@@ -60,67 +56,21 @@ public static class WolverineDependencyRegistrar
         services.AddSingleton<IExchangeRequestRegistry, ExchangeRequestRegistry>();
         services.AddSingleton<ISessionGroupFactory, SessionGroupFactory>();
 
-        // Inter-channel hub clients — one instance per concrete HubClient, each
-        // exposed as all of its implemented interfaces so features that depend on
-        // a specific hub contract (IFriendHub, IBlacklistHub, …) resolve cleanly.
-        foreach (var hubType in typeof(ChannelHubClient).Assembly.GetTypes()
-            .Where(t => t.Name.EndsWith("HubClient") && t.IsClass && !t.IsAbstract))
-        {
-            foreach (var iface in hubType.GetInterfaces())
-            {
-                services.AddSingleton(iface, hubType);
-            }
-            services.AddSingleton(hubType);
-        }
-
-        // Convention-based scan for the rest of the game-object services. Naming
-        // tells us WHAT a class is, not HOW to resolve it — so lifetime comes from
-        // the ISingletonService marker interface (implemented by classes that own
-        // shared state: caches, queues, per-entity maps). Everything else is
-        // transient so short-lived handlers don't accidentally share mutable state.
+        // Inter-channel hub clients, the INrunEventHandler / IQuestTypeHandler
+        // implementations and the convention-named game-object services
+        // (*Service, *Provider, *Resolver, *Calculator, *Catalog, *Queue, *Ai) are all
+        // emitted as explicit AddSingleton/AddTransient calls by NosCore.DiGenerator,
+        // which applies the same rules at compile time that this method used to apply
+        // by reflection at startup.
         //
-        // Matched suffixes cover the vocabulary we actually use across the codebase:
-        // *Service, *Provider, *Resolver, *Calculator, *Catalog, *Queue, *Ai.
-        // New classes can add a suffix here if they want auto-discovery, or they
-        // can be registered explicitly above.
-        var gameObjectAssembly = typeof(WolverineDependencyRegistrar).Assembly;
-
-        foreach (var impl in gameObjectAssembly.GetTypes()
-            .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
-            .Where(t => typeof(INrunEventHandler).IsAssignableFrom(t)))
-        {
-            services.AddTransient(typeof(INrunEventHandler), impl);
-            services.AddTransient(impl);
-        }
-
-        foreach (var impl in gameObjectAssembly.GetTypes()
-            .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
-            .Where(t => typeof(Services.QuestService.IQuestTypeHandler).IsAssignableFrom(t)))
-        {
-            services.AddTransient(typeof(Services.QuestService.IQuestTypeHandler), impl);
-            services.AddTransient(impl);
-        }
-
-        var suffixes = new[] { "Service", "Provider", "Resolver", "Calculator", "Catalog", "Queue", "Ai" };
-        foreach (var impl in gameObjectAssembly.GetTypes()
-            .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
-            .Where(t => suffixes.Any(suffix => t.Name.EndsWith(suffix))))
-        {
-            var lifetime = typeof(ISingletonService).IsAssignableFrom(impl)
-                ? ServiceLifetime.Singleton
-                : ServiceLifetime.Transient;
-
-            foreach (var iface in impl.GetInterfaces()
-                .Where(i => i != typeof(ISingletonService) && !IsSystemInterface(i)))
-            {
-                services.Add(new ServiceDescriptor(iface, impl, lifetime));
-            }
-            services.Add(new ServiceDescriptor(impl, impl, lifetime));
-        }
+        // Lifetime still comes from the ISingletonService marker — implement it on
+        // classes that own shared state (caches, queues, per-entity maps); everything
+        // else stays transient so short-lived handlers don't share mutable state. A
+        // class carrying the marker whose name matches no suffix now fails the build
+        // with NOSDI001 instead of being silently skipped.
+        //
+        // DependencyInjectionParityTests diffs the generated list against the scan it
+        // replaced, so the two cannot drift apart unnoticed.
+        services.AddGeneratedGameObjectServices();
     }
-
-    // Filter out framework interfaces (IDisposable, IAsyncDisposable, IEquatable, …)
-    // so the scan only registers domain-facing contracts.
-    private static bool IsSystemInterface(Type iface)
-        => iface.Namespace?.StartsWith("System", StringComparison.Ordinal) == true;
 }

--- a/src/NosCore.GameObject/Messaging/WolverineDependencyRegistrar.cs
+++ b/src/NosCore.GameObject/Messaging/WolverineDependencyRegistrar.cs
@@ -56,21 +56,8 @@ public static class WolverineDependencyRegistrar
         services.AddSingleton<IExchangeRequestRegistry, ExchangeRequestRegistry>();
         services.AddSingleton<ISessionGroupFactory, SessionGroupFactory>();
 
-        // Inter-channel hub clients, the INrunEventHandler / IQuestTypeHandler
-        // implementations and the convention-named game-object services
-        // (*Service, *Provider, *Resolver, *Calculator, *Catalog, *Queue, *Ai) are all
-        // emitted as explicit AddSingleton/AddTransient calls by NosCore.DiGenerator,
-        // which applies the same rules at compile time that this method used to apply
-        // by reflection at startup.
-        //
-        // Lifetime still comes from the ISingletonService marker — implement it on
-        // classes that own shared state (caches, queues, per-entity maps); everything
-        // else stays transient so short-lived handlers don't share mutable state. A
-        // class carrying the marker whose name matches no suffix now fails the build
-        // with NOSDI001 instead of being silently skipped.
-        //
-        // DependencyInjectionParityTests diffs the generated list against the scan it
-        // replaced, so the two cannot drift apart unnoticed.
+        // NosCore.DiGenerator emits these registrations at compile time. Lifetime still comes
+        // from ISingletonService; a marked class matching no suffix now fails with NOSDI001.
         services.AddGeneratedGameObjectServices();
     }
 }

--- a/src/NosCore.GameObject/NosCore.GameObject.csproj
+++ b/src/NosCore.GameObject/NosCore.GameObject.csproj
@@ -37,6 +37,9 @@
     <ProjectReference Include="..\..\tools\NosCore.EcsGenerator\NosCore.EcsGenerator.csproj"
         OutputItemType="Analyzer"
         ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\tools\NosCore.DiGenerator\NosCore.DiGenerator.csproj"
+        OutputItemType="Analyzer"
+        ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/NosCore.GameObject/Services/PacketHandlerService/PacketHandlerRegistry.cs
+++ b/src/NosCore.GameObject/Services/PacketHandlerService/PacketHandlerRegistry.cs
@@ -21,11 +21,7 @@ namespace NosCore.GameObject.Services.PacketHandlerService
         {
             foreach (var handler in packetsHandlers)
             {
-                var type = handler.GetType().BaseType?.GenericTypeArguments[0];
-                if (type == null)
-                {
-                    continue;
-                }
+                var type = handler.PacketType;
 
                 if (!_attributeDic.ContainsKey(type))
                 {
@@ -36,10 +32,17 @@ namespace NosCore.GameObject.Services.PacketHandlerService
                     }
                 }
 
-                if (!_handlersByPacketType.ContainsKey(type))
+                // Two handlers claiming the same packet used to be swallowed here, with
+                // whichever the container happened to yield first winning. NOSDI003 now
+                // fails the build instead, so reaching this at runtime means a handler
+                // was registered dynamically outside the generated lists.
+                if (_handlersByPacketType.TryGetValue(type, out var existing))
                 {
-                    _handlersByPacketType.Add(type, handler);
+                    throw new InvalidOperationException(
+                        $"Two handlers claim {type.Name}: {existing.GetType().Name} and {handler.GetType().Name}.");
                 }
+
+                _handlersByPacketType.Add(type, handler);
             }
         }
 

--- a/src/NosCore.GameObject/Services/PacketHandlerService/PacketHandlerRegistry.cs
+++ b/src/NosCore.GameObject/Services/PacketHandlerService/PacketHandlerRegistry.cs
@@ -32,10 +32,8 @@ namespace NosCore.GameObject.Services.PacketHandlerService
                     }
                 }
 
-                // Two handlers claiming the same packet used to be swallowed here, with
-                // whichever the container happened to yield first winning. NOSDI003 now
-                // fails the build instead, so reaching this at runtime means a handler
-                // was registered dynamically outside the generated lists.
+                // NOSDI003 fails the build on a duplicate, so reaching this means a handler was
+                // registered dynamically outside the generated lists.
                 if (_handlersByPacketType.TryGetValue(type, out var existing))
                 {
                     throw new InvalidOperationException(

--- a/src/NosCore.LoginServer/LoginServerBootstrap.cs
+++ b/src/NosCore.LoginServer/LoginServerBootstrap.cs
@@ -39,6 +39,7 @@ using NosCore.Networking;
 using NosCore.Networking.Encoding;
 using NosCore.Networking.Encoding.Filter;
 using NosCore.Networking.SessionRef;
+using NosCore.PacketHandlers.Generated;
 using NosCore.PacketHandlers.Login;
 using NosCore.Packets;
 using NosCore.Packets.Attributes;
@@ -128,8 +129,7 @@ namespace NosCore.LoginServer
                 };
             });
 
-            containerBuilder.RegisterTypes(typeof(NoS0575PacketHandler).Assembly.GetTypes().Where(type => typeof(IPacketHandler).IsAssignableFrom(type) && typeof(ILoginPacketHandler).IsAssignableFrom(type)).ToArray())
-                .Where(t => typeof(IPacketHandler).IsAssignableFrom(t) && typeof(ILoginPacketHandler).IsAssignableFrom(t))
+            containerBuilder.RegisterTypes(GeneratedPacketHandlers.LoginHandlerTypes)
                 .AsImplementedInterfaces();
 
             var listofpacket = typeof(IPacket).Assembly.GetTypes()

--- a/src/NosCore.PacketHandlers/NosCore.PacketHandlers.csproj
+++ b/src/NosCore.PacketHandlers/NosCore.PacketHandlers.csproj
@@ -3,7 +3,13 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <NosCoreGeneratePacketHandlerLists>true</NosCoreGeneratePacketHandlerLists>
   </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="NosCoreGeneratePacketHandlerLists" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\..\build\</OutputPath>
@@ -26,6 +32,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NosCore.GameObject\NosCore.GameObject.csproj" />
+    <ProjectReference Include="..\..\tools\NosCore.DiGenerator\NosCore.DiGenerator.csproj"
+        OutputItemType="Analyzer"
+        ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -60,6 +60,7 @@ using NosCore.Networking.Encoding;
 using NosCore.Networking.Encoding.Filter;
 using NosCore.Networking.SessionGroup;
 using NosCore.Networking.SessionRef;
+using NosCore.PacketHandlers.Generated;
 using NosCore.PacketHandlers.Login;
 using NosCore.Packets;
 using NosCore.Packets.Attributes;
@@ -160,8 +161,7 @@ namespace NosCore.WorldServer
             });
 
             //NosCore.Controllers
-            containerBuilder.RegisterTypes(typeof(NoS0575PacketHandler).Assembly.GetTypes()
-                    .Where(type => typeof(IPacketHandler).IsAssignableFrom(type) && typeof(IWorldPacketHandler).IsAssignableFrom(type)).ToArray())
+            containerBuilder.RegisterTypes(GeneratedPacketHandlers.WorldHandlerTypes)
                 .AsImplementedInterfaces();
 
             //NosCore.Core

--- a/test/NosCore.GameObject.Tests/DependencyInjectionParityTests.cs
+++ b/test/NosCore.GameObject.Tests/DependencyInjectionParityTests.cs
@@ -18,12 +18,8 @@ using System.Linq;
 
 namespace NosCore.GameObject.Tests
 {
-    // Guards the swap from runtime reflection scanning to NosCore.DiGenerator.
-    //
-    // LegacyScan below is a verbatim copy of what WolverineDependencyRegistrar used
-    // to do at startup. It stays here, in the test project only, as the oracle the
-    // generated registration list is diffed against. If a future change to the
-    // generator drops or duplicates a service, this test fails with the exact delta.
+    // LegacyScan is a verbatim copy of the startup scan the generator replaced, kept as
+    // the oracle its output is diffed against.
     [TestClass]
     public class DependencyInjectionParityTests
     {
@@ -50,14 +46,8 @@ namespace NosCore.GameObject.Tests
             Assert.AreEqual(string.Empty, message, message);
         }
 
-        // Where a contract has several implementations the last registration wins for
-        // GetRequiredService, and the generator orders by name rather than by the
-        // metadata order the old scan happened to produce. That reordering is only safe
-        // for contracts nobody resolves singly, so the fan-in set is pinned here: the
-        // two handler contracts are resolved as IEnumerable<T>, and IAsyncDisposable is
-        // an artefact of the *HubClient scan applying no namespace filter (nothing
-        // resolves it). A new entry in this list means some contract silently became
-        // order-dependent and needs an explicit registration instead.
+        // The generator orders by name, so last-wins resolution only stays safe for contracts
+        // nobody resolves singly. A new entry here means one silently became order-dependent.
         [TestMethod]
         public void OnlyKnownContractsHaveMultipleImplementations()
         {
@@ -129,18 +119,14 @@ namespace NosCore.GameObject.Tests
                 results.Add(new Descriptor(Name(impl), Name(impl), lifetime));
             }
 
-            // The generator cannot emit a convention registration for an unbound generic
-            // type, and MSDI would reject the descriptor anyway, so exclude them from the
-            // oracle rather than pretending the old scan produced something usable.
+            // MSDI rejects unbound generics, so the oracle excludes them too.
             return results.Where(d => !d.ImplementationType.Contains('`'));
         }
 
         private static bool IsSystemInterface(Type iface)
             => iface.Namespace?.StartsWith("System", StringComparison.Ordinal) == true;
 
-        // Formats a Type the way Roslyn's FullyQualifiedFormat does (minus global::),
-        // so a constructed generic reads as Ns.IFoo<Ns.A, Ns.B> on both sides instead
-        // of reflection's IFoo`2[[A, Asm, Version=...]] form.
+        // Matches Roslyn's FullyQualifiedFormat so both sides read as Ns.IFoo<Ns.A>.
         private static string Name(Type type)
         {
             if (!type.IsGenericType)

--- a/test/NosCore.GameObject.Tests/DependencyInjectionParityTests.cs
+++ b/test/NosCore.GameObject.Tests/DependencyInjectionParityTests.cs
@@ -36,12 +36,19 @@ namespace NosCore.GameObject.Tests
                 .Select(d => new Descriptor(d.ServiceType, d.ImplementationType, d.Lifetime))
                 .ToList();
 
-            var missing = legacy.Except(generated).OrderBy(d => d.ServiceType).ToList();
-            var extra = generated.Except(legacy).OrderBy(d => d.ServiceType).ToList();
+            // Counted, not just matched: a duplicate gained or lost is still a difference.
+            var legacyCounts = legacy.GroupBy(d => d).ToDictionary(g => g.Key, g => g.Count());
+            var generatedCounts = generated.GroupBy(d => d).ToDictionary(g => g.Key, g => g.Count());
 
-            var message = string.Join(Environment.NewLine,
-                missing.Select(d => $"MISSING from generated: {d.ServiceType} -> {d.ImplementationType} ({d.Lifetime})")
-                    .Concat(extra.Select(d => $"EXTRA in generated:  {d.ServiceType} -> {d.ImplementationType} ({d.Lifetime})")));
+            var message = string.Join(Environment.NewLine, legacyCounts.Keys.Union(generatedCounts.Keys)
+                .Select(d => (Descriptor: d,
+                    Legacy: legacyCounts.TryGetValue(d, out var l) ? l : 0,
+                    Generated: generatedCounts.TryGetValue(d, out var g) ? g : 0))
+                .Where(x => x.Legacy != x.Generated)
+                .OrderBy(x => x.Descriptor.ServiceType)
+                .Select(x =>
+                    $"{x.Descriptor.ServiceType} -> {x.Descriptor.ImplementationType} ({x.Descriptor.Lifetime}): " +
+                    $"scan {x.Legacy}, generated {x.Generated}"));
 
             Assert.AreEqual(string.Empty, message, message);
         }

--- a/test/NosCore.GameObject.Tests/DependencyInjectionParityTests.cs
+++ b/test/NosCore.GameObject.Tests/DependencyInjectionParityTests.cs
@@ -1,0 +1,161 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.GameObject.Ecs;
+using NosCore.GameObject.Generated;
+using NosCore.GameObject.Infastructure;
+using NosCore.GameObject.InterChannelCommunication.Hubs.ChannelHub;
+using NosCore.GameObject.Messaging.Handlers.Nrun;
+using NosCore.GameObject.Services.QuestService;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NosCore.GameObject.Tests
+{
+    // Guards the swap from runtime reflection scanning to NosCore.DiGenerator.
+    //
+    // LegacyScan below is a verbatim copy of what WolverineDependencyRegistrar used
+    // to do at startup. It stays here, in the test project only, as the oracle the
+    // generated registration list is diffed against. If a future change to the
+    // generator drops or duplicates a service, this test fails with the exact delta.
+    [TestClass]
+    public class DependencyInjectionParityTests
+    {
+        private static readonly string[] ConventionSuffixes =
+            { "Service", "Provider", "Resolver", "Calculator", "Catalog", "Queue", "Ai" };
+
+        private readonly record struct Descriptor(string ServiceType, string ImplementationType, ServiceLifetime Lifetime);
+
+        [TestMethod]
+        public void GeneratedRegistrationsMatchTheReflectionScanTheyReplaced()
+        {
+            var legacy = LegacyScan().ToList();
+            var generated = GeneratedServiceRegistrations.Descriptors
+                .Select(d => new Descriptor(d.ServiceType, d.ImplementationType, d.Lifetime))
+                .ToList();
+
+            var missing = legacy.Except(generated).OrderBy(d => d.ServiceType).ToList();
+            var extra = generated.Except(legacy).OrderBy(d => d.ServiceType).ToList();
+
+            var message = string.Join(Environment.NewLine,
+                missing.Select(d => $"MISSING from generated: {d.ServiceType} -> {d.ImplementationType} ({d.Lifetime})")
+                    .Concat(extra.Select(d => $"EXTRA in generated:  {d.ServiceType} -> {d.ImplementationType} ({d.Lifetime})")));
+
+            Assert.AreEqual(string.Empty, message, message);
+        }
+
+        // Where a contract has several implementations the last registration wins for
+        // GetRequiredService, and the generator orders by name rather than by the
+        // metadata order the old scan happened to produce. That reordering is only safe
+        // for contracts nobody resolves singly, so the fan-in set is pinned here: the
+        // two handler contracts are resolved as IEnumerable<T>, and IAsyncDisposable is
+        // an artefact of the *HubClient scan applying no namespace filter (nothing
+        // resolves it). A new entry in this list means some contract silently became
+        // order-dependent and needs an explicit registration instead.
+        [TestMethod]
+        public void OnlyKnownContractsHaveMultipleImplementations()
+        {
+            var expected = new[]
+            {
+                "NosCore.GameObject.Messaging.Handlers.Nrun.INrunEventHandler",
+                "NosCore.GameObject.Services.QuestService.IQuestTypeHandler",
+                "System.IAsyncDisposable"
+            };
+
+            var actual = GeneratedServiceRegistrations.Descriptors
+                .Where(d => d.ServiceType != d.ImplementationType)
+                .GroupBy(d => d.ServiceType)
+                .Where(g => g.Select(d => d.ImplementationType).Distinct().Count() > 1)
+                .Select(g => g.Key)
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToList();
+
+            CollectionAssert.AreEqual(expected.OrderBy(s => s, StringComparer.Ordinal).ToList(), actual,
+                $"fan-in contracts changed:{Environment.NewLine}{string.Join(Environment.NewLine, actual)}");
+        }
+
+        private static IEnumerable<Descriptor> LegacyScan()
+        {
+            var results = new List<Descriptor>();
+            var gameObjectAssembly = typeof(MapWorld).Assembly;
+
+            foreach (var hubType in typeof(ChannelHubClient).Assembly.GetTypes()
+                .Where(t => t.Name.EndsWith("HubClient", StringComparison.Ordinal) && t.IsClass && !t.IsAbstract))
+            {
+                foreach (var iface in hubType.GetInterfaces())
+                {
+                    results.Add(new Descriptor(Name(iface), Name(hubType), ServiceLifetime.Singleton));
+                }
+
+                results.Add(new Descriptor(Name(hubType), Name(hubType), ServiceLifetime.Singleton));
+            }
+
+            foreach (var impl in gameObjectAssembly.GetTypes()
+                .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
+                .Where(t => typeof(INrunEventHandler).IsAssignableFrom(t)))
+            {
+                results.Add(new Descriptor(Name(typeof(INrunEventHandler)), Name(impl), ServiceLifetime.Transient));
+                results.Add(new Descriptor(Name(impl), Name(impl), ServiceLifetime.Transient));
+            }
+
+            foreach (var impl in gameObjectAssembly.GetTypes()
+                .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
+                .Where(t => typeof(IQuestTypeHandler).IsAssignableFrom(t)))
+            {
+                results.Add(new Descriptor(Name(typeof(IQuestTypeHandler)), Name(impl), ServiceLifetime.Transient));
+                results.Add(new Descriptor(Name(impl), Name(impl), ServiceLifetime.Transient));
+            }
+
+            foreach (var impl in gameObjectAssembly.GetTypes()
+                .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic)
+                .Where(t => ConventionSuffixes.Any(suffix => t.Name.EndsWith(suffix, StringComparison.Ordinal))))
+            {
+                var lifetime = typeof(ISingletonService).IsAssignableFrom(impl)
+                    ? ServiceLifetime.Singleton
+                    : ServiceLifetime.Transient;
+
+                foreach (var iface in impl.GetInterfaces()
+                    .Where(i => i != typeof(ISingletonService) && !IsSystemInterface(i)))
+                {
+                    results.Add(new Descriptor(Name(iface), Name(impl), lifetime));
+                }
+
+                results.Add(new Descriptor(Name(impl), Name(impl), lifetime));
+            }
+
+            // The generator cannot emit a convention registration for an unbound generic
+            // type, and MSDI would reject the descriptor anyway, so exclude them from the
+            // oracle rather than pretending the old scan produced something usable.
+            return results.Where(d => !d.ImplementationType.Contains('`'));
+        }
+
+        private static bool IsSystemInterface(Type iface)
+            => iface.Namespace?.StartsWith("System", StringComparison.Ordinal) == true;
+
+        // Formats a Type the way Roslyn's FullyQualifiedFormat does (minus global::),
+        // so a constructed generic reads as Ns.IFoo<Ns.A, Ns.B> on both sides instead
+        // of reflection's IFoo`2[[A, Asm, Version=...]] form.
+        private static string Name(Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return type.FullName!.Replace('+', '.');
+            }
+
+            var definition = type.GetGenericTypeDefinition().FullName!.Replace('+', '.');
+            var tick = definition.IndexOf('`');
+            if (tick >= 0)
+            {
+                definition = definition.Substring(0, tick);
+            }
+
+            return $"{definition}<{string.Join(", ", type.GetGenericArguments().Select(Name))}>";
+        }
+    }
+}

--- a/test/NosCore.PacketHandlers.Tests/PacketHandlerRegistrationParityTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/PacketHandlerRegistrationParityTests.cs
@@ -1,0 +1,71 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.GameObject.Infastructure;
+using NosCore.PacketHandlers.Generated;
+using NosCore.PacketHandlers.Login;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NosCore.PacketHandlers.Tests
+{
+    // Guards the swap from the bootstraps' reflection scan to the lists emitted by
+    // NosCore.DiGenerator. LegacyScan is what WorldServerBootstrap and
+    // LoginServerBootstrap used to run against NosCore.PacketHandlers at startup.
+    [TestClass]
+    public class PacketHandlerRegistrationParityTests
+    {
+        [TestMethod]
+        public void GeneratedWorldHandlerListMatchesTheReflectionScan()
+            => AssertMatches(LegacyScan(typeof(IWorldPacketHandler)), GeneratedPacketHandlers.WorldHandlerTypes);
+
+        [TestMethod]
+        public void GeneratedLoginHandlerListMatchesTheReflectionScan()
+            => AssertMatches(LegacyScan(typeof(ILoginPacketHandler)), GeneratedPacketHandlers.LoginHandlerTypes);
+
+        // PacketType replaced a BaseType.GenericTypeArguments[0] walk that returned null
+        // - and silently dropped the handler - whenever the chain didn't match.
+        [TestMethod]
+        public void EveryHandlerReportsThePacketItsBaseClassWasClosedOver()
+        {
+            var mismatched = GeneratedPacketHandlers.WorldHandlerTypes
+                .Concat(GeneratedPacketHandlers.LoginHandlerTypes)
+                .Select(t => new
+                {
+                    Type = t,
+                    Declared = (Type?)t.GetProperty(nameof(IPacketHandler.PacketType))!
+                        .GetValue(System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(t)),
+                    FromBase = t.BaseType?.GenericTypeArguments.FirstOrDefault()
+                })
+                .Where(x => x.Declared != x.FromBase)
+                .Select(x => $"{x.Type.Name}: PacketType={x.Declared?.Name}, base={x.FromBase?.Name}")
+                .ToList();
+
+            Assert.AreEqual(0, mismatched.Count, string.Join(Environment.NewLine, mismatched));
+        }
+
+        private static void AssertMatches(IEnumerable<Type> legacy, IEnumerable<Type> generated)
+        {
+            var expected = legacy.OrderBy(t => t.FullName, StringComparer.Ordinal).ToList();
+            var actual = generated.OrderBy(t => t.FullName, StringComparer.Ordinal).ToList();
+
+            var missing = expected.Except(actual).Select(t => $"MISSING: {t.FullName}");
+            var extra = actual.Except(expected).Select(t => $"EXTRA:   {t.FullName}");
+            var message = string.Join(Environment.NewLine, missing.Concat(extra));
+
+            Assert.AreEqual(string.Empty, message, message);
+        }
+
+        private static IEnumerable<Type> LegacyScan(Type marker) =>
+            typeof(NoS0575PacketHandler).Assembly.GetTypes()
+                .Where(type => typeof(IPacketHandler).IsAssignableFrom(type) && marker.IsAssignableFrom(type))
+                // The old scan passed GetTypes() straight to Autofac, so it also picked up
+                // interfaces and abstract bases; only concrete classes were ever resolvable.
+                .Where(type => type is { IsClass: true, IsAbstract: false });
+    }
+}

--- a/test/NosCore.PacketHandlers.Tests/PacketHandlerRegistrationParityTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/PacketHandlerRegistrationParityTests.cs
@@ -14,9 +14,8 @@ using System.Linq;
 
 namespace NosCore.PacketHandlers.Tests
 {
-    // Guards the swap from the bootstraps' reflection scan to the lists emitted by
-    // NosCore.DiGenerator. LegacyScan is what WorldServerBootstrap and
-    // LoginServerBootstrap used to run against NosCore.PacketHandlers at startup.
+    // LegacyScan is the startup scan the generator replaced, kept as the oracle its
+    // output is diffed against.
     [TestClass]
     public class PacketHandlerRegistrationParityTests
     {
@@ -28,8 +27,8 @@ namespace NosCore.PacketHandlers.Tests
         public void GeneratedLoginHandlerListMatchesTheReflectionScan()
             => AssertMatches(LegacyScan(typeof(ILoginPacketHandler)), GeneratedPacketHandlers.LoginHandlerTypes);
 
-        // PacketType replaced a BaseType.GenericTypeArguments[0] walk that returned null
-        // - and silently dropped the handler - whenever the chain didn't match.
+        // The old walk returned null - silently dropping the handler - when the chain
+        // did not match.
         [TestMethod]
         public void EveryHandlerReportsThePacketItsBaseClassWasClosedOver()
         {
@@ -64,8 +63,8 @@ namespace NosCore.PacketHandlers.Tests
         private static IEnumerable<Type> LegacyScan(Type marker) =>
             typeof(NoS0575PacketHandler).Assembly.GetTypes()
                 .Where(type => typeof(IPacketHandler).IsAssignableFrom(type) && marker.IsAssignableFrom(type))
-                // The old scan passed GetTypes() straight to Autofac, so it also picked up
-                // interfaces and abstract bases; only concrete classes were ever resolvable.
+                // The old scan passed GetTypes() straight to Autofac, so it saw interfaces and
+                // abstract bases too; only concrete classes were ever resolvable.
                 .Where(type => type is { IsClass: true, IsAbstract: false });
     }
 }

--- a/tools/NosCore.DiGenerator/AnalyzerReleases.Shipped.md
+++ b/tools/NosCore.DiGenerator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/tools/NosCore.DiGenerator/AnalyzerReleases.Unshipped.md
+++ b/tools/NosCore.DiGenerator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,12 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+NOSDI001 | NosCore.DependencyInjection | Warning | ServiceRegistrationGenerator, ISingletonService marker has no effect
+NOSDI002 | NosCore.DependencyInjection | Warning | ServiceRegistrationGenerator, open generic service cannot be registered by convention
+NOSDI003 | NosCore.DependencyInjection | Error | PacketHandlerGenerator, two packet handlers claim the same packet
+NOSDI004 | NosCore.DependencyInjection | Warning | PacketHandlerGenerator, handled packet has no PacketHeader attribute
+NOSDI005 | NosCore.DependencyInjection | Warning | PacketHandlerGenerator, packet handler declares no server scope

--- a/tools/NosCore.DiGenerator/NosCore.DiGenerator.csproj
+++ b/tools/NosCore.DiGenerator/NosCore.DiGenerator.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="5.6.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+</Project>

--- a/tools/NosCore.DiGenerator/PacketHandlerGenerator.cs
+++ b/tools/NosCore.DiGenerator/PacketHandlerGenerator.cs
@@ -1,0 +1,307 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace NosCore.DiGenerator;
+
+// Emits the concrete world/login packet handler lists the server bootstraps used to
+// discover by scanning NosCore.PacketHandlers with reflection, and turns the two
+// failure modes that scan swallowed into build errors.
+[Generator]
+public class PacketHandlerGenerator : IIncrementalGenerator
+{
+    private const string PacketHandlerBase = "NosCore.GameObject.Infastructure.PacketHandler`1";
+    private const string WorldMarker = "NosCore.GameObject.Infastructure.IWorldPacketHandler";
+    private const string LoginMarker = "NosCore.GameObject.Infastructure.ILoginPacketHandler";
+    private const string PacketHeaderAttribute = "NosCore.Packets.Attributes.PacketHeaderAttribute";
+
+    private static readonly DiagnosticDescriptor DuplicateHandler = new(
+        "NOSDI003",
+        "Two packet handlers claim the same packet",
+        "'{0}' and '{1}' both handle {2} in the same server scope; only one would ever be dispatched",
+        "NosCore.DependencyInjection",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor MissingPacketHeader = new(
+        "NOSDI004",
+        "Handled packet has no PacketHeader attribute",
+        "'{0}' handles {1}, which carries no [PacketHeader]; the client can never address it",
+        "NosCore.DependencyInjection",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor UnscopedHandler = new(
+        "NOSDI005",
+        "Packet handler declares no server scope",
+        "'{0}' derives from PacketHandler<T> but implements neither IWorldPacketHandler nor ILoginPacketHandler, so no bootstrap registers it",
+        "NosCore.DependencyInjection",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Opt-in per project. Every assembly referencing NosCore.GameObject can see
+        // PacketHandler<T>, but only NosCore.PacketHandlers should own the generated
+        // bootstrap lists, so it sets NosCoreGeneratePacketHandlerLists in its csproj.
+        var enabled = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) =>
+            provider.GlobalOptions.TryGetValue(
+                "build_property.NosCoreGeneratePacketHandlerLists", out var value) &&
+            value.Equals("true", StringComparison.OrdinalIgnoreCase));
+
+        var handlers = context.CompilationProvider.Combine(enabled)
+            .Select(static (pair, _) => pair.Right ? Collect(pair.Left) : HandlerModel.Empty);
+
+        context.RegisterSourceOutput(handlers, static (spc, model) => Execute(model, spc));
+    }
+
+    private static HandlerModel Collect(Compilation compilation)
+    {
+        var baseType = compilation.GetTypeByMetadataName(PacketHandlerBase);
+        var worldMarker = compilation.GetTypeByMetadataName(WorldMarker);
+        var loginMarker = compilation.GetTypeByMetadataName(LoginMarker);
+        var headerAttribute = compilation.GetTypeByMetadataName(PacketHeaderAttribute);
+
+        if (baseType is null || worldMarker is null || loginMarker is null)
+        {
+            return HandlerModel.Empty;
+        }
+
+        var handlers = new List<Handler>();
+        var diagnostics = new List<DiagnosticInfo>();
+
+        foreach (var type in EnumerateTypes(compilation.Assembly.GlobalNamespace))
+        {
+            if (type.TypeKind != TypeKind.Class || type.IsAbstract || type.IsGenericType)
+            {
+                continue;
+            }
+
+            var packetType = FindHandledPacket(type, baseType);
+            if (packetType is null)
+            {
+                continue;
+            }
+
+            var isWorld = Implements(type, worldMarker);
+            var isLogin = Implements(type, loginMarker);
+
+            if (!isWorld && !isLogin)
+            {
+                diagnostics.Add(DiagnosticInfo.For(UnscopedHandler, type, type.ToDisplayString(), string.Empty));
+                continue;
+            }
+
+            if (headerAttribute is not null && !HasHeader(packetType, headerAttribute))
+            {
+                diagnostics.Add(DiagnosticInfo.For(MissingPacketHeader, type,
+                    type.ToDisplayString(), packetType.ToDisplayString()));
+            }
+
+            handlers.Add(new Handler(
+                Display(type),
+                Display(packetType),
+                packetType.ToDisplayString(),
+                isWorld,
+                isLogin,
+                type.Locations.FirstOrDefault(),
+                type.ToDisplayString()));
+        }
+
+        foreach (var scope in new[] { true, false })
+        {
+            var inScope = handlers.Where(h => scope ? h.IsWorld : h.IsLogin);
+
+            foreach (var clash in inScope.GroupBy(h => h.PacketDisplay).Where(g => g.Count() > 1))
+            {
+                var ordered = clash.OrderBy(h => h.HandlerDisplay, StringComparer.Ordinal).ToList();
+                diagnostics.Add(DiagnosticInfo.At(DuplicateHandler, ordered[1].Location,
+                    ordered[0].HandlerDisplay, ordered[1].HandlerDisplay, clash.Key));
+            }
+        }
+
+        handlers.Sort(static (a, b) => string.CompareOrdinal(a.HandlerType, b.HandlerType));
+
+        return new HandlerModel(handlers.ToImmutableArray(), diagnostics.ToImmutableArray());
+    }
+
+    private static INamedTypeSymbol? FindHandledPacket(INamedTypeSymbol type, INamedTypeSymbol baseType)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType &&
+                SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, baseType))
+            {
+                return current.TypeArguments.FirstOrDefault() as INamedTypeSymbol;
+            }
+        }
+
+        return null;
+    }
+
+    // PacketHeaderAttribute is inherited (CommandPacketHeaderAttribute derives from it),
+    // so walk the packet's base chain the way GetCustomAttribute(inherit: true) did.
+    private static bool HasHeader(INamedTypeSymbol packetType, INamedTypeSymbol headerAttribute)
+    {
+        for (var current = packetType; current is not null; current = current.BaseType)
+        {
+            foreach (var attribute in current.GetAttributes())
+            {
+                for (var attrType = attribute.AttributeClass; attrType is not null; attrType = attrType.BaseType)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(attrType, headerAttribute))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamespaceSymbol root)
+    {
+        foreach (var member in root.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol ns:
+                    foreach (var nested in EnumerateTypes(ns))
+                    {
+                        yield return nested;
+                    }
+
+                    break;
+                case INamedTypeSymbol type:
+                    yield return type;
+                    break;
+            }
+        }
+    }
+
+    private static bool Implements(INamedTypeSymbol type, INamedTypeSymbol iface)
+        => type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, iface));
+
+    private static string Display(ITypeSymbol symbol)
+        => symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+    private static void Execute(HandlerModel model, SourceProductionContext context)
+    {
+        foreach (var diagnostic in model.Diagnostics)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                diagnostic.Descriptor, diagnostic.Location, diagnostic.Args));
+        }
+
+        if (model.Handlers.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("//  __  _  __    __   ___ __  ___ ___");
+        sb.AppendLine("// |  \\| |/__\\ /' _/ / _//__\\| _ \\ __|");
+        sb.AppendLine("// | | ' | \\/ |`._`.| \\_| \\/ | v / _|");
+        sb.AppendLine("// |_|\\__|\\__/ |___/ \\__/\\__/|_|_\\___|");
+        sb.AppendLine("//");
+        sb.AppendLine("// <auto-generated/> by NosCore.DiGenerator. Do not edit.");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using System;");
+        sb.AppendLine();
+        sb.AppendLine("namespace NosCore.PacketHandlers.Generated");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static class GeneratedPacketHandlers");
+        sb.AppendLine("    {");
+
+        AppendTypeArray(sb, "WorldHandlerTypes", model.Handlers.Where(h => h.IsWorld));
+        sb.AppendLine();
+        AppendTypeArray(sb, "LoginHandlerTypes", model.Handlers.Where(h => h.IsLogin));
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        context.AddSource("GeneratedPacketHandlers.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+    }
+
+    private static void AppendTypeArray(StringBuilder sb, string name, IEnumerable<Handler> handlers)
+    {
+        sb.Append("        public static readonly Type[] ").Append(name).AppendLine(" =");
+        sb.AppendLine("        {");
+
+        foreach (var handler in handlers)
+        {
+            sb.Append("            typeof(").Append(handler.HandlerType).AppendLine("),");
+        }
+
+        sb.AppendLine("        };");
+    }
+
+    private readonly struct Handler
+    {
+        public Handler(string handlerType, string packetType, string packetDisplay, bool isWorld, bool isLogin,
+            Location? location, string handlerDisplay)
+        {
+            HandlerType = handlerType;
+            PacketType = packetType;
+            PacketDisplay = packetDisplay;
+            IsWorld = isWorld;
+            IsLogin = isLogin;
+            Location = location;
+            HandlerDisplay = handlerDisplay;
+        }
+
+        public string HandlerType { get; }
+        public string PacketType { get; }
+        public string PacketDisplay { get; }
+        public bool IsWorld { get; }
+        public bool IsLogin { get; }
+        public Location? Location { get; }
+        public string HandlerDisplay { get; }
+    }
+
+    private readonly struct DiagnosticInfo
+    {
+        private DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location, object?[] args)
+        {
+            Descriptor = descriptor;
+            Location = location;
+            Args = args;
+        }
+
+        public DiagnosticDescriptor Descriptor { get; }
+        public Location? Location { get; }
+        public object?[] Args { get; }
+
+        public static DiagnosticInfo For(DiagnosticDescriptor descriptor, INamedTypeSymbol symbol, params object?[] args)
+            => new(descriptor, symbol.Locations.FirstOrDefault(), args);
+
+        public static DiagnosticInfo At(DiagnosticDescriptor descriptor, Location? location, params object?[] args)
+            => new(descriptor, location, args);
+    }
+
+    private readonly struct HandlerModel
+    {
+        public HandlerModel(ImmutableArray<Handler> handlers, ImmutableArray<DiagnosticInfo> diagnostics)
+        {
+            Handlers = handlers;
+            Diagnostics = diagnostics;
+        }
+
+        public ImmutableArray<Handler> Handlers { get; }
+        public ImmutableArray<DiagnosticInfo> Diagnostics { get; }
+
+        public static HandlerModel Empty => new(ImmutableArray<Handler>.Empty, ImmutableArray<DiagnosticInfo>.Empty);
+    }
+}

--- a/tools/NosCore.DiGenerator/PacketHandlerGenerator.cs
+++ b/tools/NosCore.DiGenerator/PacketHandlerGenerator.cs
@@ -14,9 +14,6 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace NosCore.DiGenerator;
 
-// Emits the concrete world/login packet handler lists the server bootstraps used to
-// discover by scanning NosCore.PacketHandlers with reflection, and turns the two
-// failure modes that scan swallowed into build errors.
 [Generator]
 public class PacketHandlerGenerator : IIncrementalGenerator
 {
@@ -51,9 +48,8 @@ public class PacketHandlerGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // Opt-in per project. Every assembly referencing NosCore.GameObject can see
-        // PacketHandler<T>, but only NosCore.PacketHandlers should own the generated
-        // bootstrap lists, so it sets NosCoreGeneratePacketHandlerLists in its csproj.
+        // Only NosCore.PacketHandlers owns these lists, so it opts in with
+        // NosCoreGeneratePacketHandlerLists.
         var enabled = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) =>
             provider.GlobalOptions.TryGetValue(
                 "build_property.NosCoreGeneratePacketHandlerLists", out var value) &&
@@ -149,8 +145,8 @@ public class PacketHandlerGenerator : IIncrementalGenerator
         return null;
     }
 
-    // PacketHeaderAttribute is inherited (CommandPacketHeaderAttribute derives from it),
-    // so walk the packet's base chain the way GetCustomAttribute(inherit: true) did.
+    // PacketHeaderAttribute is inherited, so walk the base chain the way
+    // GetCustomAttribute(inherit: true) did.
     private static bool HasHeader(INamedTypeSymbol packetType, INamedTypeSymbol headerAttribute)
     {
         for (var current = packetType; current is not null; current = current.BaseType)

--- a/tools/NosCore.DiGenerator/ServiceRegistrationGenerator.cs
+++ b/tools/NosCore.DiGenerator/ServiceRegistrationGenerator.cs
@@ -1,0 +1,344 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace NosCore.DiGenerator;
+
+[Generator]
+public class ServiceRegistrationGenerator : IIncrementalGenerator
+{
+    private const string SingletonMarker = "NosCore.GameObject.Infastructure.ISingletonService";
+    private const string NrunEventHandler = "NosCore.GameObject.Messaging.Handlers.Nrun.INrunEventHandler";
+    private const string QuestTypeHandler = "NosCore.GameObject.Services.QuestService.IQuestTypeHandler";
+    private const string HubClientSuffix = "HubClient";
+
+    private static readonly string[] ConventionSuffixes =
+        { "Service", "Provider", "Resolver", "Calculator", "Catalog", "Queue", "Ai" };
+
+    private static readonly DiagnosticDescriptor DeadSingletonMarker = new(
+        "NOSDI001",
+        "ISingletonService marker has no effect",
+        "'{0}' implements ISingletonService but its name matches none of the registration suffixes ({1}), so it is never registered and the marker is dead",
+        "NosCore.DependencyInjection",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor UnregisterableOpenGeneric = new(
+        "NOSDI002",
+        "Open generic service cannot be registered by convention",
+        "'{0}' matches a registration suffix but is an unbound generic type; register it explicitly instead",
+        "NosCore.DependencyInjection",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var candidates = context.CompilationProvider.Select(static (compilation, _) => Collect(compilation));
+
+        context.RegisterSourceOutput(candidates, static (spc, model) => Execute(model, spc));
+    }
+
+    private static RegistrationModel Collect(Compilation compilation)
+    {
+        var singletonMarker = compilation.GetTypeByMetadataName(SingletonMarker);
+        if (singletonMarker is null)
+        {
+            return RegistrationModel.Empty;
+        }
+
+        // Both generators live in one analyzer assembly, so this runs for every project
+        // that references it - including ones that merely reference NosCore.GameObject
+        // and would resolve the marker from metadata. Only the assembly that declares
+        // the marker owns these registrations.
+        if (!SymbolEqualityComparer.Default.Equals(singletonMarker.ContainingAssembly, compilation.Assembly))
+        {
+            return RegistrationModel.Empty;
+        }
+
+        var nrunHandler = compilation.GetTypeByMetadataName(NrunEventHandler);
+        var questHandler = compilation.GetTypeByMetadataName(QuestTypeHandler);
+
+        var registrations = new List<Registration>();
+        var diagnostics = new List<DiagnosticInfo>();
+
+        foreach (var type in EnumerateTypes(compilation.Assembly.GlobalNamespace))
+        {
+            // Static classes are abstract+sealed in metadata, so IsAbstract already
+            // excludes them here exactly as it did in the runtime scan.
+            if (type.TypeKind != TypeKind.Class || type.IsAbstract)
+            {
+                continue;
+            }
+
+            // Reflection's Type.IsPublic is true only for top-level public types; a
+            // public nested type reports IsNestedPublic instead and was never picked up
+            // by the runtime scan. Mirror that exactly so the generated list matches.
+            var isTopLevelPublic = type.DeclaredAccessibility == Accessibility.Public &&
+                                   type.ContainingType is null;
+
+            var name = type.Name;
+            var isUnboundGeneric = type.IsGenericType;
+            var isSingleton = Implements(type, singletonMarker);
+            var matchesSuffix = ConventionSuffixes.Any(s => name.EndsWith(s, System.StringComparison.Ordinal));
+            var isHubClient = name.EndsWith(HubClientSuffix, System.StringComparison.Ordinal);
+
+            // The four runtime scans ran independently over every type, so a class could
+            // be picked up by more than one. Evaluate them independently here too rather
+            // than short-circuiting, or the generated list silently loses registrations.
+            if (isHubClient || matchesSuffix)
+            {
+                if (isUnboundGeneric)
+                {
+                    diagnostics.Add(DiagnosticInfo.For(UnregisterableOpenGeneric, type));
+                    continue;
+                }
+            }
+
+            // Hub clients are matched on name alone and registered as every interface
+            // they implement, including framework ones - the runtime scan applied no
+            // namespace filter and no visibility filter here, so neither do we.
+            if (isHubClient)
+            {
+                foreach (var iface in type.AllInterfaces)
+                {
+                    registrations.Add(new Registration(Display(iface), Display(type), Lifetime.Singleton));
+                }
+
+                registrations.Add(new Registration(Display(type), Display(type), Lifetime.Singleton));
+            }
+
+            if (!isTopLevelPublic)
+            {
+                continue;
+            }
+
+            if (nrunHandler is not null && Implements(type, nrunHandler))
+            {
+                registrations.Add(new Registration(Display(nrunHandler), Display(type), Lifetime.Transient));
+                registrations.Add(new Registration(Display(type), Display(type), Lifetime.Transient));
+            }
+
+            if (questHandler is not null && Implements(type, questHandler))
+            {
+                registrations.Add(new Registration(Display(questHandler), Display(type), Lifetime.Transient));
+                registrations.Add(new Registration(Display(type), Display(type), Lifetime.Transient));
+            }
+
+            if (!matchesSuffix)
+            {
+                if (isSingleton)
+                {
+                    diagnostics.Add(DiagnosticInfo.For(DeadSingletonMarker, type));
+                }
+
+                continue;
+            }
+
+            var lifetime = isSingleton ? Lifetime.Singleton : Lifetime.Transient;
+
+            foreach (var iface in type.AllInterfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(iface, singletonMarker) || IsSystemInterface(iface))
+                {
+                    continue;
+                }
+
+                registrations.Add(new Registration(Display(iface), Display(type), lifetime));
+            }
+
+            registrations.Add(new Registration(Display(type), Display(type), lifetime));
+        }
+
+        // Metadata order from Type.GetTypes() is not reproducible at compile time, so
+        // order deterministically instead. Where an interface has several
+        // implementations the last registration wins for GetRequiredService, which is
+        // why DependencyInjectionParityTests asserts the generated set matches the
+        // runtime scan as a set and flags multiply-implemented contracts.
+        registrations.Sort(static (a, b) =>
+        {
+            var byService = string.CompareOrdinal(a.ServiceType, b.ServiceType);
+            return byService != 0 ? byService : string.CompareOrdinal(a.ImplementationType, b.ImplementationType);
+        });
+
+        return new RegistrationModel(registrations.ToImmutableArray(), diagnostics.ToImmutableArray());
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamespaceSymbol root)
+    {
+        foreach (var member in root.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol ns:
+                    foreach (var nested in EnumerateTypes(ns))
+                    {
+                        yield return nested;
+                    }
+
+                    break;
+                case INamedTypeSymbol type:
+                    yield return type;
+                    break;
+            }
+        }
+    }
+
+    private static bool Implements(INamedTypeSymbol type, INamedTypeSymbol iface)
+        => type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, iface));
+
+    private static bool IsSystemInterface(INamedTypeSymbol iface)
+    {
+        var ns = iface.ContainingNamespace;
+        if (ns is null || ns.IsGlobalNamespace)
+        {
+            return false;
+        }
+
+        return ns.ToDisplayString().StartsWith("System", System.StringComparison.Ordinal);
+    }
+
+    private static string Display(ITypeSymbol symbol)
+        => symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+    private static void Execute(RegistrationModel model, SourceProductionContext context)
+    {
+        foreach (var diagnostic in model.Diagnostics)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                diagnostic.Descriptor,
+                diagnostic.Location,
+                diagnostic.TypeName,
+                string.Join(", ", ConventionSuffixes)));
+        }
+
+        if (model.Registrations.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("//  __  _  __    __   ___ __  ___ ___");
+        sb.AppendLine("// |  \\| |/__\\ /' _/ / _//__\\| _ \\ __|");
+        sb.AppendLine("// | | ' | \\/ |`._`.| \\_| \\/ | v / _|");
+        sb.AppendLine("// |_|\\__|\\__/ |___/ \\__/\\__/|_|_\\___|");
+        sb.AppendLine("//");
+        sb.AppendLine("// <auto-generated/> by NosCore.DiGenerator. Do not edit.");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using Microsoft.Extensions.DependencyInjection;");
+        sb.AppendLine();
+        sb.AppendLine("namespace NosCore.GameObject.Generated");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static class GeneratedServiceRegistrations");
+        sb.AppendLine("    {");
+        sb.AppendLine("        public static void AddGeneratedGameObjectServices(this IServiceCollection services)");
+        sb.AppendLine("        {");
+
+        foreach (var registration in model.Registrations)
+        {
+            var method = registration.Lifetime == Lifetime.Singleton ? "AddSingleton" : "AddTransient";
+            sb.Append("            services.").Append(method).Append('<')
+                .Append(registration.ServiceType);
+
+            if (registration.ServiceType != registration.ImplementationType)
+            {
+                sb.Append(", ").Append(registration.ImplementationType);
+            }
+
+            sb.AppendLine(">();");
+        }
+
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        // (serviceType, implementationType, lifetime) triples, exposed so");
+        sb.AppendLine("        // DependencyInjectionParityTests can diff this list against the");
+        sb.AppendLine("        // reflection scan it replaced.");
+        sb.AppendLine("        public static readonly (string ServiceType, string ImplementationType, ServiceLifetime Lifetime)[] Descriptors =");
+        sb.AppendLine("        {");
+
+        foreach (var registration in model.Registrations)
+        {
+            var lifetime = registration.Lifetime == Lifetime.Singleton
+                ? "ServiceLifetime.Singleton"
+                : "ServiceLifetime.Transient";
+            sb.Append("            (\"").Append(Strip(registration.ServiceType)).Append("\", \"")
+                .Append(Strip(registration.ImplementationType)).Append("\", ")
+                .Append(lifetime).AppendLine("),");
+        }
+
+        sb.AppendLine("        };");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        context.AddSource("GeneratedServiceRegistrations.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+    }
+
+    // Descriptors are compared against reflection-derived names in
+    // DependencyInjectionParityTests, so drop every 'global::' - including the ones
+    // inside type arguments of a constructed generic - rather than just the prefix.
+    private static string Strip(string fullyQualified)
+        => fullyQualified.Replace("global::", string.Empty);
+
+    private enum Lifetime
+    {
+        Transient,
+        Singleton
+    }
+
+    private readonly struct Registration
+    {
+        public Registration(string serviceType, string implementationType, Lifetime lifetime)
+        {
+            ServiceType = serviceType;
+            ImplementationType = implementationType;
+            Lifetime = lifetime;
+        }
+
+        public string ServiceType { get; }
+        public string ImplementationType { get; }
+        public Lifetime Lifetime { get; }
+    }
+
+    // Deliberately stores strings and a Location rather than the INamedTypeSymbol:
+    // symbols root the whole Compilation, and this value is cached by the incremental
+    // pipeline.
+    private readonly struct DiagnosticInfo
+    {
+        private DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location, string typeName)
+        {
+            Descriptor = descriptor;
+            Location = location;
+            TypeName = typeName;
+        }
+
+        public DiagnosticDescriptor Descriptor { get; }
+        public Location? Location { get; }
+        public string TypeName { get; }
+
+        public static DiagnosticInfo For(DiagnosticDescriptor descriptor, INamedTypeSymbol symbol)
+            => new(descriptor, symbol.Locations.FirstOrDefault(), symbol.ToDisplayString());
+    }
+
+    private readonly struct RegistrationModel
+    {
+        public RegistrationModel(ImmutableArray<Registration> registrations, ImmutableArray<DiagnosticInfo> diagnostics)
+        {
+            Registrations = registrations;
+            Diagnostics = diagnostics;
+        }
+
+        public ImmutableArray<Registration> Registrations { get; }
+        public ImmutableArray<DiagnosticInfo> Diagnostics { get; }
+
+        public static RegistrationModel Empty => new(ImmutableArray<Registration>.Empty, ImmutableArray<DiagnosticInfo>.Empty);
+    }
+}

--- a/tools/NosCore.DiGenerator/ServiceRegistrationGenerator.cs
+++ b/tools/NosCore.DiGenerator/ServiceRegistrationGenerator.cs
@@ -55,10 +55,8 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
             return RegistrationModel.Empty;
         }
 
-        // Both generators live in one analyzer assembly, so this runs for every project
-        // that references it - including ones that merely reference NosCore.GameObject
-        // and would resolve the marker from metadata. Only the assembly that declares
-        // the marker owns these registrations.
+        // Only the assembly declaring the marker owns these registrations; referencing
+        // projects would resolve it from metadata.
         if (!SymbolEqualityComparer.Default.Equals(singletonMarker.ContainingAssembly, compilation.Assembly))
         {
             return RegistrationModel.Empty;
@@ -72,16 +70,13 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
 
         foreach (var type in EnumerateTypes(compilation.Assembly.GlobalNamespace))
         {
-            // Static classes are abstract+sealed in metadata, so IsAbstract already
-            // excludes them here exactly as it did in the runtime scan.
             if (type.TypeKind != TypeKind.Class || type.IsAbstract)
             {
                 continue;
             }
 
-            // Reflection's Type.IsPublic is true only for top-level public types; a
-            // public nested type reports IsNestedPublic instead and was never picked up
-            // by the runtime scan. Mirror that exactly so the generated list matches.
+            // A public nested type reports IsNestedPublic, so the runtime scan never saw one.
+            // Mirror that.
             var isTopLevelPublic = type.DeclaredAccessibility == Accessibility.Public &&
                                    type.ContainingType is null;
 
@@ -91,9 +86,8 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
             var matchesSuffix = ConventionSuffixes.Any(s => name.EndsWith(s, System.StringComparison.Ordinal));
             var isHubClient = name.EndsWith(HubClientSuffix, System.StringComparison.Ordinal);
 
-            // The four runtime scans ran independently over every type, so a class could
-            // be picked up by more than one. Evaluate them independently here too rather
-            // than short-circuiting, or the generated list silently loses registrations.
+            // The four scans ran independently, so evaluate them independently rather than
+            // short-circuiting, or the list silently loses registrations.
             if (isHubClient || matchesSuffix)
             {
                 if (isUnboundGeneric)
@@ -103,9 +97,7 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
                 }
             }
 
-            // Hub clients are matched on name alone and registered as every interface
-            // they implement, including framework ones - the runtime scan applied no
-            // namespace filter and no visibility filter here, so neither do we.
+            // The runtime scan applied no namespace or visibility filter here, so neither do we.
             if (isHubClient)
             {
                 foreach (var iface in type.AllInterfaces)
@@ -158,11 +150,8 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
             registrations.Add(new Registration(Display(type), Display(type), lifetime));
         }
 
-        // Metadata order from Type.GetTypes() is not reproducible at compile time, so
-        // order deterministically instead. Where an interface has several
-        // implementations the last registration wins for GetRequiredService, which is
-        // why DependencyInjectionParityTests asserts the generated set matches the
-        // runtime scan as a set and flags multiply-implemented contracts.
+        // Metadata order is not reproducible at compile time, so order by name and let
+        // DependencyInjectionParityTests compare as a set.
         registrations.Sort(static (a, b) =>
         {
             var byService = string.CompareOrdinal(a.ServiceType, b.ServiceType);
@@ -282,9 +271,8 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
         context.AddSource("GeneratedServiceRegistrations.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
     }
 
-    // Descriptors are compared against reflection-derived names in
-    // DependencyInjectionParityTests, so drop every 'global::' - including the ones
-    // inside type arguments of a constructed generic - rather than just the prefix.
+    // Drop every 'global::', including inside type arguments, to match the
+    // reflection-derived names the parity test compares against.
     private static string Strip(string fullyQualified)
         => fullyQualified.Replace("global::", string.Empty);
 
@@ -308,9 +296,8 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
         public Lifetime Lifetime { get; }
     }
 
-    // Deliberately stores strings and a Location rather than the INamedTypeSymbol:
-    // symbols root the whole Compilation, and this value is cached by the incremental
-    // pipeline.
+    // Strings rather than INamedTypeSymbol: symbols root the whole Compilation and this
+    // is cached by the incremental pipeline.
     private readonly struct DiagnosticInfo
     {
         private DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location, string typeName)

--- a/tools/NosCore.DiGenerator/ServiceRegistrationGenerator.cs
+++ b/tools/NosCore.DiGenerator/ServiceRegistrationGenerator.cs
@@ -161,6 +161,17 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
         return new RegistrationModel(registrations.ToImmutableArray(), diagnostics.ToImmutableArray());
     }
 
+    // GetTypes() returned nested types too, so the hub-client scan - which applies no
+    // visibility filter - could pick one up.
+    private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamedTypeSymbol type)
+    {
+        yield return type;
+        foreach (var nested in type.GetTypeMembers().SelectMany(EnumerateTypes))
+        {
+            yield return nested;
+        }
+    }
+
     private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamespaceSymbol root)
     {
         foreach (var member in root.GetMembers())
@@ -175,7 +186,11 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
 
                     break;
                 case INamedTypeSymbol type:
-                    yield return type;
+                    foreach (var nested in EnumerateTypes(type))
+                    {
+                        yield return nested;
+                    }
+
                     break;
             }
         }


### PR DESCRIPTION
## What

Service registration and packet-handler discovery were both convention-based reflection scans executed at startup. Anything that missed the convention was skipped in silence:

- `WolverineDependencyRegistrar` matched on name suffixes (`Service|Provider|Resolver|Calculator|Catalog|Queue|Ai`). Name a class `MonsterBrain` and it was simply never registered.
- `PacketHandlerRegistry` read `handler.GetType().BaseType?.GenericTypeArguments[0]` and `continue`d on null, dropping the handler.
- Two handlers claiming the same packet: `if (!_handlersByPacketType.ContainsKey(type))` kept whichever the container yielded first.
- `WorldServerBootstrap` / `LoginServerBootstrap` each re-scanned `NosCore.PacketHandlers` with their own filter.

`tools/NosCore.DiGenerator` now applies the same rules at compile time.

## Generated

| Generator | Emits | Replaces |
|---|---|---|
| `ServiceRegistrationGenerator` | `AddGeneratedGameObjectServices()` — 140 explicit `AddSingleton`/`AddTransient` calls | the four reflection scans in `WolverineDependencyRegistrar` |
| `PacketHandlerGenerator` | `GeneratedPacketHandlers.WorldHandlerTypes` (112) / `LoginHandlerTypes` (2) | the scan in each server bootstrap |

MSDI and Autofac now consume one identical list, which removes the "registered on both sides → duplicate key" failure mode the registrar's own comments warn about.

## New build diagnostics

| ID | Severity | Catches |
|---|---|---|
| NOSDI001 | Warning | `ISingletonService` on a class matching no suffix — the marker was dead |
| NOSDI002 | Warning | open generic matched by convention but unregisterable |
| NOSDI003 | Error | two handlers claiming one packet in the same scope |
| NOSDI004 | Warning | handled packet with no `[PacketHeader]` |
| NOSDI005 | Warning | `PacketHandler<T>` implementing neither `IWorldPacketHandler` nor `ILoginPacketHandler` |

None fire on master today — they're guardrails, not fixes.

## How the swap is proven safe

Both replacements are guarded by parity tests that keep the **old reflection algorithm** as an oracle and diff the generated output against it:

- `DependencyInjectionParityTests` — generated descriptor list vs. the scan it replaced, as `(service, impl, lifetime)` triples.
- `PacketHandlerRegistrationParityTests` — generated world/login arrays vs. the bootstrap scans, plus a check that `PacketType` agrees with the base-class type argument for all 114 handlers.

`OnlyKnownContractsHaveMultipleImplementations` pins the fan-in set, because the generator orders by name where the old scan used metadata order. Three contracts have multiple implementations: `INrunEventHandler` and `IQuestTypeHandler` (resolved as `IEnumerable<T>`, so order is irrelevant) and `System.IAsyncDisposable`.

## Worth a look

`System.IAsyncDisposable` picking up 7 registrations is pre-existing and now visible: the `*HubClient` scan applies no namespace filter, unlike the suffix scan which excludes `System.*`. Nothing resolves it, so this PR preserves the behaviour rather than changing it — happy to drop it in a follow-up.

## Testing

- Full solution builds clean in Debug and Release.
- 1051 tests pass.
- `NosCore.Parser.Tests.EveryDeclaredEffectIsNamed` fails, but it fails identically on a clean `origin/master` checkout (verified in a scratch worktree) — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added generated registration for game services and packet handlers.
  - Added direct packet-type identification for more reliable handler registration.
  - Added validation for duplicate, incomplete, or incorrectly scoped packet handlers.

- **Bug Fixes**
  - Duplicate handlers are now reported explicitly instead of being silently ignored.
  - Login and world servers use consistent, prebuilt handler registrations.

- **Tests**
  - Added coverage confirming generated registrations match existing behavior and handler mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->