### PR TITLE
Take NosCore.Packets 21.1.0 and drop the manual mlintro escape

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
     <PackageVersion Include="NosCore.Analyzers" Version="2.0.0" />
     <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
-    <PackageVersion Include="NosCore.Packets" Version="21.0.0" />
+    <PackageVersion Include="NosCore.Packets" Version="21.1.0" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
     <PackageVersion Include="NosCore.Shared" Version="6.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />

--- a/src/NosCore.PacketHandlers/Miniland/MlobjPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Miniland/MlobjPacketHandler.cs
@@ -24,7 +24,7 @@ namespace NosCore.PacketHandlers.Miniland
             switch (mlEditPacket.Type)
             {
                 case 1:
-                    await clientSession.SendPacketAsync(new MlintroPacket { Intro = mlEditPacket.MinilandInfo!.Replace(' ', '^') });
+                    await clientSession.SendPacketAsync(new MlintroPacket { Intro = mlEditPacket.MinilandInfo });
                     miniland.MinilandMessage = mlEditPacket.MinilandInfo;
                     await clientSession.SendPacketAsync(new InfoiPacket
                     {

--- a/test/NosCore.PacketHandlers.Tests/Miniland/MlEditPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MlEditPacketHandlerTests.cs
@@ -4,6 +4,7 @@
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
 //
 
+using NosCore.Packets;
 using Mapster;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -207,7 +208,11 @@ namespace NosCore.PacketHandlers.Tests.Miniland
             var miniland = MinilandProvider.GetMiniland(Session.Character.CharacterId);
             Assert.AreEqual("Test Test", miniland.MinilandMessage);
             var lastpacket2 = (MlintroPacket?)Session.LastPackets.FirstOrDefault(s => s is MlintroPacket);
-            Assert.AreEqual("Test^Test", lastpacket2?.Intro);
+
+            // The packet carries the message as typed; the "^" encoding is the serializer's,
+            // which is why MlintroPacket.Intro declares EscapeSpaces.
+            Assert.AreEqual("Test Test", lastpacket2?.Intro);
+            Assert.AreEqual("mlintro Test^Test", new Serializer(new[] { typeof(MlintroPacket) }).Serialize(lastpacket2!));
         }
 
         private void InfoPacketShouldBeSent()


### PR DESCRIPTION
Consumer half of NosCoreIO/NosCore.Packets#499, released as 21.1.0.

## What the serializer now does

Spaces are encoded as `^` by the serializer in three cases, so callers stop doing it:

- any string that is **not** the last field — this was the original defect, a spaced value split its own field and shifted every field after it
- a string **nested in a sub-packet**, which has to escape the outer separator as well as its own; `pinit` mate names were going out as `10|Joyeux Mouton|0` and breaking the packet above
- a field that declares **`EscapeSpaces`**, for text the client wants encoded wherever it sits — `mlintro`, the miniland message on `mlinfobr`, the family message on `ginfo`

## What changes here

`MlobjPacketHandler` passes the message through as typed; `MlintroPacket.Intro` declares `EscapeSpaces`.

`MlEditPacketHandlerTests` asserted the caret on the packet object, which is no longer where it appears. It now checks the object carries the message as typed and pins `mlintro Test^Test` on the wire, so the escaping is still covered end to end rather than just deleted.

## What deliberately stays

`MinilandEntranceHandler` keeps its `Replace(' ', '^')`. It writes onto `MsgPacket`, and five other call sites send that same field unescaped — `"Your respawn location has been changed."` among them — so the field cannot declare `EscapeSpaces` without mangling them. Making this one serializer-owned would need a second class on the `msg` header with `AllowDuplicateHeader`, which is worse than one line in the handler.

## Fixed for free

`Miniland.GenerateMlinfobr()` sent `MinilandMessage` raw while `MinilandEntranceHandler` escaped the *same string* onto `msg` a few lines away, so a spaced miniland message rendered differently depending on which packet carried it. `EscapeSpaces` on `MlInfoBrPacket` settles that without a change here.

`GInfoPacket.FamilyMessage` gets the same treatment, which matters for #2283.

## Tests

Full solution builds against 21.1.0 after a cache clear. GameObject 532, PacketHandlers 410, Parser 139, Database 11, Core 10, WebApi 17 — all green under the CI filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Miniland introductory messages now preserve spaces as entered, ensuring displayed messages remain readable and accurate.
  * Message serialization continues to handle required formatting automatically without altering the text shown to players.

* **Tests**
  * Updated coverage verifies that miniland messages with spaces are transmitted and serialized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->