### PR TITLE
Drop the comment the assertions already make

### DIFF
--- a/test/NosCore.PacketHandlers.Tests/Miniland/MlEditPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Miniland/MlEditPacketHandlerTests.cs
@@ -208,9 +208,6 @@ namespace NosCore.PacketHandlers.Tests.Miniland
             var miniland = MinilandProvider.GetMiniland(Session.Character.CharacterId);
             Assert.AreEqual("Test Test", miniland.MinilandMessage);
             var lastpacket2 = (MlintroPacket?)Session.LastPackets.FirstOrDefault(s => s is MlintroPacket);
-
-            // The packet carries the message as typed; the "^" encoding is the serializer's,
-            // which is why MlintroPacket.Intro declares EscapeSpaces.
             Assert.AreEqual("Test Test", lastpacket2?.Intro);
             Assert.AreEqual("mlintro Test^Test", new Serializer(new[] { typeof(MlintroPacket) }).Serialize(lastpacket2!));
         }


### PR DESCRIPTION
Follow-up to #2339. The two asserts under it already say the packet carries the message as typed and that the caret appears on the wire, so the comment was restating them.

Paired with NosCoreIO/NosCore.Packets#502, which does the same on the serializer side — twelve blocks down to one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an outdated explanatory comment from a Miniland packet handler test.
  * No test behavior, assertions, or application functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->