### PR TITLE
fix: save sessions in StopAsync instead of ProcessExit

### DIFF
--- a/src/NosCore.Data/Enumerations/I18N/LanguageKey.cs
+++ b/src/NosCore.Data/Enumerations/I18N/LanguageKey.cs
@@ -114,7 +114,6 @@ namespace NosCore.Data.Enumerations.I18N
         SHOPITEMS_LOADED,
         SHOPS_LOADED,
         CONNECTION_LOST,
-        CHANNEL_WILL_EXIT,
         CANT_MOVE_ITEM_IN_SHOP,
         VISUALENTITY_DOES_NOT_EXIST,
         ALREADY_EXCHANGE,

--- a/src/NosCore.Data/Resource/LocalizedResources.Designer.cs
+++ b/src/NosCore.Data/Resource/LocalizedResources.Designer.cs
@@ -214,15 +214,6 @@ namespace NosCore.Data.Resource {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The channel will exit in brief moments..
-        /// </summary>
-        public static string CHANNEL_WILL_EXIT {
-            get {
-                return ResourceManager.GetString("CHANNEL_WILL_EXIT", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Client connected, SessionId: {0}.
         /// </summary>
         public static string CLIENT_ARRIVED {

--- a/src/NosCore.Data/Resource/LocalizedResources.de.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.de.resx
@@ -184,9 +184,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Channel</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>Der Kanal wird gleich schließen.</value>
-  </data>
   <data name="CHUNK_FORMAT_INVALID" xml:space="preserve">
     <value>Das Chunkformat ist falsch.</value>
   </data>

--- a/src/NosCore.Data/Resource/LocalizedResources.es.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.es.resx
@@ -156,9 +156,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Canal</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>El canal se cerrarÃ¡ en breves momentos.</value>
-  </data>
   <data name="CLIENT_ARRIVED" xml:space="preserve">
     <value>Cliente ha llegado con SessionId = {0}</value>
   </data>

--- a/src/NosCore.Data/Resource/LocalizedResources.fr.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.fr.resx
@@ -408,9 +408,6 @@
   <data name="VISUALTYPE_UNKNOWN" xml:space="preserve">
     <value>Type Visuel inconnu.</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>Fermeture du serveur dans {0} secondes.</value>
-  </data>
   <data name="CONNECTION_LOST" xml:space="preserve">
     <value>La connexion au serveur a été perdue.</value>
   </data>

--- a/src/NosCore.Data/Resource/LocalizedResources.it.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.it.resx
@@ -183,9 +183,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Canale</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>Il canale chiuderà per un momento breve.</value>
-  </data>
   <data name="CHUNK_FORMAT_INVALID" xml:space="preserve">
     <value>Formato blocco non valido.</value>
   </data>

--- a/src/NosCore.Data/Resource/LocalizedResources.pl.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.pl.resx
@@ -156,9 +156,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Kanał</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>Kanał zamknie się w krótkim czasie.</value>
-  </data>
   <data name="CLIENT_ARRIVED" xml:space="preserve">
     <value>Klient podłączony. SessionId: {0}</value>
   </data>

--- a/src/NosCore.Data/Resource/LocalizedResources.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.resx
@@ -157,9 +157,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Channel</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>The channel will exit in brief moments.</value>
-  </data>
   <data name="CLIENT_ARRIVED" xml:space="preserve">
     <value>Client connected, SessionId: {0}</value>
   </data>

--- a/src/NosCore.Data/Resource/LocalizedResources.ru.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.ru.resx
@@ -190,9 +190,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Канал</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>Работа канала скоро будет завершена.</value>
-  </data>
   <data name="CLIENT_ARRIVED" xml:space="preserve">
     <value>Клиент прибыл на сервер, SessionId: {0}</value>
     <comment>Проверить контекст, возможно, нужно использователь "Пользователь"</comment>

--- a/src/NosCore.Data/Resource/LocalizedResources.tr.resx
+++ b/src/NosCore.Data/Resource/LocalizedResources.tr.resx
@@ -156,9 +156,6 @@
   <data name="CHANNEL" xml:space="preserve">
     <value>Kanal</value>
   </data>
-  <data name="CHANNEL_WILL_EXIT" xml:space="preserve">
-    <value>Bu kanal bir kaç saniye içinde kapatılacak.</value>
-  </data>
   <data name="CLIENT_ARRIVED" xml:space="preserve">
     <value>İstemci bağlandı, ID {0}</value>
   </data>

--- a/src/NosCore.WorldServer/WorldServer.cs
+++ b/src/NosCore.WorldServer/WorldServer.cs
@@ -38,13 +38,6 @@ namespace NosCore.WorldServer
             Broadcaster.Initialize(sessionGroupFactory);
             await mapInstanceGeneratorService.InitializeAsync();
             logger.LogInformation(logLanguage[LogLanguageKey.SUCCESSFULLY_LOADED]);
-            AppDomain.CurrentDomain.ProcessExit += (_, _) =>
-            {
-                logger.LogInformation(logLanguage[LogLanguageKey.SAVING_ALL]);
-                Task.WhenAll(sessionRegistry.GetSessions().Select(saveService.SaveAsync)).GetAwaiter().GetResult();
-                logger.LogInformation(logLanguage[LogLanguageKey.CHANNEL_WILL_EXIT], 30);
-                Thread.Sleep(30000);
-            };
 
             ConsoleTitle.Append($@" - Port : {worldConfiguration.Value.Port}");
             var connectTask = Policy
@@ -56,6 +49,13 @@ namespace NosCore.WorldServer
                             timeSpan.TotalSeconds)
                 ).ExecuteAsync(() => channelHubClient.Bind(channel));
             await Task.WhenAny(connectTask, networkManager.RunServerAsync());
+        }
+
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation(logLanguage[LogLanguageKey.SAVING_ALL]);
+            await Task.WhenAll(sessionRegistry.GetSessions().Select(saveService.SaveAsync));
+            await base.StopAsync(cancellationToken);
         }
     }
 }

--- a/src/NosCore.WorldServer/WorldServerBootstrap.cs
+++ b/src/NosCore.WorldServer/WorldServerBootstrap.cs
@@ -273,6 +273,7 @@ namespace NosCore.WorldServer
                     NosCore.GameObject.Messaging.WolverineDependencyRegistrar.RegisterDependencies(services);
 
                     services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
+                    services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(60));
                     services.AddHostedService<WorldServer>();
                     services.AddHostedService(sp => new RecurringMessagePublisher<SaveAllSessionsMessage>(
                         sp.GetRequiredService<IMessageBus>(),


### PR DESCRIPTION
## Problem

Session saving on shutdown lived in an `AppDomain.ProcessExit` handler:

- `ProcessExit` fires **after** the Generic Host's graceful-shutdown window, not inside it
- the save blocked with `.GetAwaiter().GetResult()`
- `Thread.Sleep(30000)` then held the handler open, while `docker stop` SIGKILLs after 10s by default — so in containers the process died mid-handler and saves raced process death

## Change

- Save moved to `WorldServer.StopAsync` — runs on SIGTERM/Ctrl+C inside the host's shutdown window, properly awaited, then defers to `base.StopAsync`
- `HostOptions.ShutdownTimeout` set to 60s so a slow save of many sessions isn't cut off at the 30s default
- `ProcessExit` handler and the 30s sleep removed (the sleep delayed every exit including clean local ones; the "channel will exit in 30s" grace belongs to a maintenance flow, not process shutdown)

The compose-side `stop_grace_period: 60s` for the world container is in the compose PR.

`dotnet build src/NosCore.WorldServer`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)