### PR TITLE
fix(compose): resolve port collisions, add healthchecks and startup ordering

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=noscore
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d noscore"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
     ports:
       - 5432:5432
     # PG17 cannot read a PG12 data directory. A dedicated path forces a clean
@@ -20,6 +25,8 @@ services:
   reverse-proxy:
     container_name: noscore-reverse-proxy
     image: noscoreio/noscore.reverseproxy:latest
+    profiles:
+      - proxy
     restart: unless-stopped
     ports:
       - 4000:4000
@@ -32,6 +39,9 @@ services:
 
   master:
     container_name: noscore-master
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       - PORT=5000
       - DB_HOST=db
@@ -40,10 +50,14 @@ services:
       context: ./
       dockerfile: deploy/Dockerfile-master
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:5000/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     ports:
       - 5000:5000
-    expose:
-      - 5432
     networks:
       - noscore-network
     volumes:
@@ -52,6 +66,11 @@ services:
 
   world:
     container_name: noscore-world
+    depends_on:
+      db:
+        condition: service_healthy
+      master:
+        condition: service_healthy
     environment:
       - WEBAPI_PORT=5001
       - WEBAPI_HOST=http://world
@@ -63,11 +82,16 @@ services:
       context: ./
       dockerfile: deploy/Dockerfile-world
     restart: unless-stopped
+    stop_grace_period: 60s
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 1337"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
     ports:
       - 5001:5001
       - 1337:1337
-    expose:
-      - 5432
     networks:
       - noscore-network
     volumes:
@@ -76,6 +100,11 @@ services:
 
   login:
     container_name: noscore-login
+    depends_on:
+      db:
+        condition: service_healthy
+      master:
+        condition: service_healthy
     environment:
       - LOGIN_PORT=4000
       - MASTER_HOST=http://master
@@ -85,10 +114,14 @@ services:
       context: ./
       dockerfile: deploy/Dockerfile-login
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 4000"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     ports:
       - 4000:4000
-    expose:
-      - 5432
     networks:
       - noscore-network
     volumes:


### PR DESCRIPTION
- **`docker compose up` was unstartable as written**: reverse-proxy publishes 4000 + 1337, colliding with login (4000) and world (1337). The proxy is now behind a `proxy` profile: `docker compose up` runs the direct stack; `docker compose --profile proxy up` includes the proxy (drop the login/world port mappings when fronting them with it).
- **db healthcheck** (`pg_isready`) + `depends_on: condition: service_healthy` on master/world/login — no more racing Postgres at boot.
- **master** gets an HTTP readiness check on `/health/ready`; **world/login** (no HTTP pipeline — plain `Host`, no Kestrel) get TCP checks on their game ports. If you'd rather have real `/health` endpoints on world/login it means hosting ASP.NET in those processes — happy to do that as a follow-up if wanted.
- **`stop_grace_period: 60s` on world** so the shutdown save (see the StopAsync PR) isn't SIGKILLed at the 10s docker default.
- Removed `expose: 5432` from the app containers (leftover; exposes nothing useful — the db owns 5432).

Validated with `docker compose config`.

Merge note: same file as #2341 (different hunks — build/volumes vs health/ordering); whichever lands second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)