### PR TITLE
perf: one awaited life loop per map instead of a 400ms timer per entity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,25 @@ and an approval table in its `DocumentationTest`. Do not hand-roll a lookup tabl
 
 `NosCore.Data` being data-only and `NosCore.GameObject` holding the logic is deliberate.
 
+### ECS layering
+
+The entity model is Arch components underneath, generated bundles on top — this split is
+the decided design, not a migration in flight:
+
+- **Components** (`Ecs/Components/`) own ALL entity state. A new piece of per-entity
+  state goes into a component (or a new component), never into a bundle body, a service
+  dictionary keyed by entity, or a static.
+- **Bundles** (`[ComponentBundle]` partial structs) are the generated facade the rest of
+  the code reads and writes. Hand-written bundle members are computed views only —
+  no backing fields.
+- **Extension methods** (`Ecs/Extensions/`) are the per-entity behaviour layer; they act
+  on one entity through its bundle.
+- **Systems** (`Ecs/Systems/`) are for iteration-heavy queries over many entities.
+  Prefer a system over LINQ across a bundle list when the call site runs per tick.
+- **Hot paths do not materialise bundle lists.** `MapInstance.Monsters`/`Npcs` allocate a
+  fresh `List` per access; anything called from the map life loop enumerates the backing
+  dictionaries or a system query instead.
+
 ### Deciding, in order
 
 1. A **wire shape** — field order, separator, sentinel? → `NosCore.Packets`, evidenced by a

--- a/src/NosCore.GameObject/Ecs/Components/NpcStateComponent.cs
+++ b/src/NosCore.GameObject/Ecs/Components/NpcStateComponent.cs
@@ -18,7 +18,6 @@ public record struct NpcStateComponent(
     ConcurrentDictionary<Entity, int> HitList,
     Shop? Shop,
     Dictionary<int, Shop>? Shops,
-    IDisposable? Life,
     Dictionary<Type, Subject<RequestData>> Requests,
     short? Dialog,
     bool IsDisabled

--- a/src/NosCore.GameObject/Ecs/Extensions/NonPlayableEntityExtension.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/NonPlayableEntityExtension.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -89,49 +89,31 @@ namespace NosCore.GameObject.Ecs.Extensions
             bundle.Shop = shops.Values.First();
         }
 
-        public static void StopLife(this INonPlayableEntity entity)
-        {
-            entity.Life?.Dispose();
-            entity.Life = null;
-        }
-
-        public static Task StartLifeAsync(this INonPlayableEntity entity, IHeuristic distanceCalculator, IClock clock, ILogger logger)
-            => entity.StartLifeAsync(monsterAi: null, distanceCalculator, clock, logger);
-
-        // Overload that lets the caller wire in the aggro-driven AI. When the AI is
-        // absent (or the entity has no aggro target this tick) we fall back to the
-        // original random-wander behaviour. Both monsters (targeting players) and
-        // NPCs (targeting hostile mobs) flow through the same TickAsync — the AI
+        // One AI step, driven by the owning map's life loop. When the AI is absent
+        // (or the entity has no aggro target this tick) we fall back to the original
+        // random-wander behaviour. Both monsters (targeting players) and NPCs
+        // (targeting hostile mobs) flow through the same TickAsync — the AI
         // implementation decides what counts as a target based on the entity's
         // race/hostility.
-        public static Task StartLifeAsync(this INonPlayableEntity entity, IMonsterAi? monsterAi, IHeuristic distanceCalculator, IClock clock, ILogger logger)
+        public static async Task TickLifeAsync(this INonPlayableEntity entity, IMonsterAi? monsterAi, IHeuristic distanceCalculator, IClock clock, ILogger logger)
         {
-            entity.Life?.Dispose();
-
-            async Task LifeAsync()
+            try
             {
-                try
+                var acted = false;
+                if (monsterAi != null)
                 {
-                    if (entity.MapInstance.IsSleeping) return;
-
-                    var acted = false;
-                    if (monsterAi != null)
-                    {
-                        acted = await monsterAi.TickAsync(entity);
-                    }
-
-                    if (!acted)
-                    {
-                        await entity.MoveAsync(distanceCalculator, clock);
-                    }
+                    acted = await monsterAi.TickAsync(entity);
                 }
-                catch (Exception e)
+
+                if (!acted)
                 {
-                    logger.LogError(e.Message, e);
+                    await entity.MoveAsync(distanceCalculator, clock);
                 }
             }
-            entity.Life = Observable.Interval(TimeSpan.FromMilliseconds(400)).Select(_ => LifeAsync()).Subscribe();
-            return Task.CompletedTask;
+            catch (Exception e)
+            {
+                logger.LogError(e.Message, e);
+            }
         }
 
         public static Task ShowDialogAsync(this INonPlayableEntity entity, RequestData requestData, long dialog)

--- a/src/NosCore.GameObject/Ecs/Interfaces/INonPlayableEntity.cs
+++ b/src/NosCore.GameObject/Ecs/Interfaces/INonPlayableEntity.cs
@@ -24,7 +24,6 @@ namespace NosCore.GameObject.Ecs.Interfaces
 
         Instant LastMove { get; set; }
 
-        IDisposable? Life { get; set; }
 
         new bool IsAlive { get; set; }
 

--- a/src/NosCore.GameObject/Ecs/MapWorld.cs
+++ b/src/NosCore.GameObject/Ecs/MapWorld.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -90,7 +90,7 @@ public class MapWorld : IDisposable
             new SpawnComponent(firstX, firstY, isMoving, isHostile),
             new EffectComponent(0, 0),
             new TimingComponent(now, now),
-            new NpcStateComponent(npcMonster, mapInstance, new SemaphoreSlim(1, 1), new ConcurrentDictionary<Entity, int>(), null, null, null, new Dictionary<Type, Subject<RequestData>>(), null, isDisabled),
+            new NpcStateComponent(npcMonster, mapInstance, new SemaphoreSlim(1, 1), new ConcurrentDictionary<Entity, int>(), null, null, new Dictionary<Type, Subject<RequestData>>(), null, isDisabled),
             new BuffStateComponent(new ConcurrentDictionary<short, BuffInstance>()),
             new AggroComponent(VisualType.Object, 0, 0, Instant.MinValue),
             new SkillCooldownComponent(new ConcurrentDictionary<short, Instant>())
@@ -129,7 +129,7 @@ public class MapWorld : IDisposable
             new SpawnComponent(firstX, firstY, isMoving, false),
             new EffectComponent(effect, effectDelay),
             new TimingComponent(now, now),
-            new NpcStateComponent(npcMonster, mapInstance, new SemaphoreSlim(1, 1), new ConcurrentDictionary<Entity, int>(), shop, null, null, new Dictionary<Type, Subject<RequestData>> { [typeof(NpcDialogRequestSubject)] = new() }, dialog, isDisabled),
+            new NpcStateComponent(npcMonster, mapInstance, new SemaphoreSlim(1, 1), new ConcurrentDictionary<Entity, int>(), shop, null, new Dictionary<Type, Subject<RequestData>> { [typeof(NpcDialogRequestSubject)] = new() }, dialog, isDisabled),
             new BuffStateComponent(new ConcurrentDictionary<short, BuffInstance>()),
             new AggroComponent(VisualType.Object, 0, 0, Instant.MinValue),
             new SkillCooldownComponent(new ConcurrentDictionary<short, Instant>())
@@ -157,7 +157,7 @@ public class MapWorld : IDisposable
             new EffectComponent(0, 0),
             new TimingComponent(now, now),
             new NpcStateComponent(mate.NpcMonster, mapInstance, new SemaphoreSlim(1, 1),
-                new ConcurrentDictionary<Entity, int>(), null, null, null,
+                new ConcurrentDictionary<Entity, int>(), null, null,
                 new Dictionary<Type, Subject<RequestData>>(), null, false),
             new BuffStateComponent(new ConcurrentDictionary<short, BuffInstance>()),
             new AggroComponent(VisualType.Object, 0, 0, Instant.MinValue),

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -35,6 +35,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 using System.Threading.Tasks;
 
 
@@ -150,9 +151,6 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
 
                 _isSleeping = true;
                 _isSleepingRequest = false;
-                Parallel.ForEach(Monsters.Where(s => s.Life != null), monster => NonPlayableEntityExtension.StopLife(monster));
-                Parallel.ForEach(Npcs.Where(s => s.Life != null), npc => NonPlayableEntityExtension.StopLife(npc));
-
                 return true;
             }
             set
@@ -193,7 +191,8 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
 
         public int XpRate { get; set; }
 
-        private IDisposable? Life { get; set; }
+        private CancellationTokenSource? _lifeCts;
+        private Task? _lifeLoop;
 
         public ISessionGroup Sessions { get; set; }
 
@@ -394,19 +393,59 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             };
         }
 
+        // One awaited loop per map replaces the per-entity 400ms timers: entity AI
+        // steps run sequentially inside the tick, so a slow tick delays the next one
+        // instead of overlapping it, and a sleeping map costs one early-out per tick
+        // instead of thousands of idle timers.
         public Task StartLifeAsync()
         {
-            async Task LifeAsync()
+            if (_lifeLoop != null)
             {
-                try
+                return Task.CompletedTask;
+            }
+
+            _lifeCts = new CancellationTokenSource();
+            _lifeLoop = RunLifeLoopAsync(_lifeCts.Token);
+            return Task.CompletedTask;
+        }
+
+        private async Task RunLifeLoopAsync(CancellationToken token)
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(400));
+            try
+            {
+                while (await timer.WaitForNextTickAsync(token))
                 {
+                    try
+                    {
+                        await TickLifeAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e.Message, e);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private async Task TickLifeAsync()
+        {
                     if (IsSleeping)
                     {
                         return;
                     }
 
-                    await Task.WhenAll(Monsters.Where(s => s.Life == null).Select(monster => monster.StartLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger)));
-                    await Task.WhenAll(Npcs.Where(s => s.Life == null).Select(npc => npc.StartLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger)));
+                    foreach (var monster in Monsters)
+                    {
+                        await monster.TickLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger);
+                    }
+                    foreach (var npc in Npcs)
+                    {
+                        await npc.TickLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger);
+                    }
 
                     // Buff expiration: drop any buff whose ExpiresAt is past. Done
                     // per-map so the tick rate matches the life loop (400ms) which is
@@ -446,14 +485,6 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                     }
 
                     await SweepPendingRespawnsAsync().ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(e.Message, e);
-                }
-            }
-            Life = Observable.Interval(TimeSpan.FromMilliseconds(400)).Select(_ => LifeAsync()).Subscribe();
-            return Task.CompletedTask;
         }
 
         // Registered by MonsterRespawnHandler when a monster dies. The map-level life
@@ -493,11 +524,10 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                 return;
             }
 
-            Parallel.ForEach(Monsters.Where(s => s.Life != null), monster => NonPlayableEntityExtension.StopLife(monster));
-            Parallel.ForEach(Npcs.Where(s => s.Life != null), npc => NonPlayableEntityExtension.StopLife(npc));
-
-            Life?.Dispose();
-            Life = null;
+            _lifeCts?.Cancel();
+            _lifeCts?.Dispose();
+            _lifeCts = null;
+            _lifeLoop = null;
             EcsWorld.Dispose();
         }
     }

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -438,11 +438,11 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                         return;
                     }
 
-                    foreach (var monster in Monsters)
+                    foreach (var (_, monster) in _monsters)
                     {
                         await monster.TickLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger);
                     }
-                    foreach (var npc in Npcs)
+                    foreach (var (_, npc) in _npcs)
                     {
                         await npc.TickLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger);
                     }
@@ -452,8 +452,8 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                     // fine for buffs since their Duration is measured in deciseconds.
                     if (_buffService != null)
                     {
-                        foreach (var monster in Monsters) await _buffService.TickAsync(monster).ConfigureAwait(false);
-                        foreach (var npc in Npcs) await _buffService.TickAsync(npc).ConfigureAwait(false);
+                        foreach (var (_, monster) in _monsters) await _buffService.TickAsync(monster).ConfigureAwait(false);
+                        foreach (var (_, npc) in _npcs) await _buffService.TickAsync(npc).ConfigureAwait(false);
                         foreach (var session in _sessionRegistry.GetClientSessionsByMapInstance(MapInstanceId))
                         {
                             if (!session.HasPlayerEntity)

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -191,6 +191,7 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
 
         public int XpRate { get; set; }
 
+        private readonly Lock _lifeLock = new();
         private CancellationTokenSource? _lifeCts;
         private Task? _lifeLoop;
 
@@ -399,13 +400,15 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
         // instead of thousands of idle timers.
         public Task StartLifeAsync()
         {
-            if (_lifeLoop != null)
+            lock (_lifeLock)
             {
-                return Task.CompletedTask;
+                if (_lifeLoop == null)
+                {
+                    _lifeCts = new CancellationTokenSource();
+                    _lifeLoop = RunLifeLoopAsync(_lifeCts.Token);
+                }
             }
 
-            _lifeCts = new CancellationTokenSource();
-            _lifeLoop = RunLifeLoopAsync(_lifeCts.Token);
             return Task.CompletedTask;
         }
 
@@ -525,6 +528,11 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
             }
 
             _lifeCts?.Cancel();
+
+            // The token only ends the wait between ticks. A tick already inside TickLifeAsync
+            // walks the entities of the world below, so it has to finish before the world goes.
+            _lifeLoop?.GetAwaiter().GetResult();
+
             _lifeCts?.Dispose();
             _lifeCts = null;
             _lifeLoop = null;

--- a/test/NosCore.GameObject.Tests/Services/BattleService/InflictedCardTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/BattleService/InflictedCardTests.cs
@@ -1,4 +1,4 @@
-﻿//  __  _  __    __   ___ __  ___ ___
+//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -72,7 +72,7 @@ namespace NosCore.GameObject.Tests.Services.BattleService
             new MonsterComponentBundle(
                 _world.World.Create(
                     new BuffStateComponent(new ConcurrentDictionary<short, BuffInstance>()),
-                    new NpcStateComponent(null!, null!, null!, null!, null, null, null, null!, null, false)),
+                    new NpcStateComponent(null!, null!, null!, null!, null, null, null!, null, false)),
                 _world);
 
         private void RollGives(int value) => _random.Setup(r => r.Next(0, 100)).Returns(value);


### PR DESCRIPTION
First of the architecture-review PRs: the tick model.

## Before

- Every monster/NPC: its own `Observable.Interval(400ms).Select(_ => LifeAsync()).Subscribe()` — **fire-and-forget**: when AI + pathfinding exceeded 400ms the next tick fired anyway and overlapped the same entity; thousands of timers stayed alive on sleeping maps just to early-out
- The map loop's only entity duty was (re)starting per-entity timers via the `Life == null` check
- Sleep transitions had to chase and dispose every entity timer (`Parallel.ForEach ... StopLife`), including from inside the `IsSleeping` **getter**

## After

- One `PeriodicTimer(400ms)` loop per map, properly awaited: entity AI steps run sequentially inside the map tick (`TickLifeAsync`), then buffs/regen/cooldowns/respawns as before. A slow tick delays the next one instead of overlapping — load becomes visible as tick latency rather than silent concurrency
- A sleeping map costs one early-out per tick; no timers to stop or restart
- `NpcStateComponent.Life`, `INonPlayableEntity.Life`, `StartLifeAsync`/`StopLife` all deleted — the loop owns the cadence
- `Dispose` cancels the loop's CTS

## Behavior preserved

- Movement cadence unchanged: `MoveAsync` keeps its internal randomized 400–3200 ms gate, so mobs don't move in lockstep
- Dead entities: `MonsterAi.TickAsync` and `MoveAsync` both early-out on `!IsAlive` (verified); respawns stay map-swept
- Sleep/wake semantics identical (same `IsSleeping` state machine, minus the timer chasing)

## Verification

- Full solution build clean; GameObject.Tests and PacketHandlers.Tests pass
- Manual checks to run from `documentation/manual-test-plan.md` (client): **Monsters → Respawn timing** (all three boxes), plus eyeballing that mobs still wander at their usual cadence on a busy map and that a map left empty for 30s goes quiet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC and monster life-cycle updates with centralized map-level processing.
  * Preserved periodic entity updates while improving cancellation and cleanup behavior.
  * Maintained sleeping-map handling and exception logging during updates.

* **Refactor**
  * Simplified entity state by removing obsolete life-cycle tracking.
  * Consolidated AI and random-wander processing into a single per-tick update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->