### PR TITLE
docs: pin the ECS layering as the decided design; stop allocating bundle lists per tick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,25 @@ and an approval table in its `DocumentationTest`. Do not hand-roll a lookup tabl
 
 `NosCore.Data` being data-only and `NosCore.GameObject` holding the logic is deliberate.
 
+### ECS layering
+
+The entity model is Arch components underneath, generated bundles on top — this split is
+the decided design, not a migration in flight:
+
+- **Components** (`Ecs/Components/`) own ALL entity state. A new piece of per-entity
+  state goes into a component (or a new component), never into a bundle body, a service
+  dictionary keyed by entity, or a static.
+- **Bundles** (`[ComponentBundle]` partial structs) are the generated facade the rest of
+  the code reads and writes. Hand-written bundle members are computed views only —
+  no backing fields.
+- **Extension methods** (`Ecs/Extensions/`) are the per-entity behaviour layer; they act
+  on one entity through its bundle.
+- **Systems** (`Ecs/Systems/`) are for iteration-heavy queries over many entities.
+  Prefer a system over LINQ across a bundle list when the call site runs per tick.
+- **Hot paths do not materialise bundle lists.** `MapInstance.Monsters`/`Npcs` allocate a
+  fresh `List` per access; anything called from the map life loop enumerates the backing
+  dictionaries or a system query instead.
+
 ### Deciding, in order
 
 1. A **wire shape** — field order, separator, sentinel? → `NosCore.Packets`, evidenced by a

--- a/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
+++ b/src/NosCore.GameObject/Services/MapInstanceGenerationService/MapInstance.cs
@@ -438,11 +438,11 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                         return;
                     }
 
-                    foreach (var monster in Monsters)
+                    foreach (var (_, monster) in _monsters)
                     {
                         await monster.TickLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger);
                     }
-                    foreach (var npc in Npcs)
+                    foreach (var (_, npc) in _npcs)
                     {
                         await npc.TickLifeAsync(_monsterAi, _distanceCalculator, _clock, _logger);
                     }
@@ -452,8 +452,8 @@ namespace NosCore.GameObject.Services.MapInstanceGenerationService
                     // fine for buffs since their Duration is measured in deciseconds.
                     if (_buffService != null)
                     {
-                        foreach (var monster in Monsters) await _buffService.TickAsync(monster).ConfigureAwait(false);
-                        foreach (var npc in Npcs) await _buffService.TickAsync(npc).ConfigureAwait(false);
+                        foreach (var (_, monster) in _monsters) await _buffService.TickAsync(monster).ConfigureAwait(false);
+                        foreach (var (_, npc) in _npcs) await _buffService.TickAsync(npc).ConfigureAwait(false);
                         foreach (var session in _sessionRegistry.GetClientSessionsByMapInstance(MapInstanceId))
                         {
                             if (!session.HasPlayerEntity)


### PR DESCRIPTION
Architecture-review PR 6: "decide what the ECS is".

The review flagged the component/bundle hybrid as a half-migration risk. Reading the generator changed the verdict: bundles are **generated projections over real Arch components** — the design is coherent, it just wasn't written down, so nothing stopped the next feature from parking state in a bundle body, a keyed service dictionary, or a static.

- **CLAUDE.md gains an "ECS layering" section** pinning the roles: components own all state; bundles are the generated facade (hand-written members = computed views only); extension methods are per-entity behaviour; systems for iteration-heavy queries; hot paths never materialise bundle lists. This is the "declare the hybrid deliberate" option from the review — a full systems migration would rewrite working combat code for no player-visible gain.
- **The one hot-path violation is fixed**: the map life loop read `Monsters`/`Npcs`, which allocate a fresh `List` per access — 4 list snapshots per map per 400 ms tick. The tick now enumerates the backing dictionaries.

**Stacked on #2354** (base: `arch/map-tick-loop`) since it edits the same tick body — merge #2354 first, then retarget/rebase this onto master (one click).

Build clean; GameObject.Tests 535/535.

If you'd rather push further toward real systems (e.g. moving `MonsterAi` target scans into a query-based system), that's a follow-up we can scope separately — this PR deliberately locks in the current shape instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)