### PR TITLE
fix: register ScriptedInstanceDto's DAO - the InstanceDto name filter ate it

### DIFF
--- a/src/NosCore.Parser/ParserBootstrap.cs
+++ b/src/NosCore.Parser/ParserBootstrap.cs
@@ -36,6 +36,23 @@ namespace NosCore.Parser
         private const string Title = "NosCore - Parser";
         private const string ConsoleText = "PARSER - NosCoreIO";
 
+        // ItemInstance DTOs are the only exclusion: they get the dedicated
+        // IDao<IItemInstanceDto?, Guid> registration. A name-based filter here once
+        // swallowed ScriptedInstanceDto too and left its DAO unresolvable.
+        public static IEnumerable<Type> RegistrableDtoTypes()
+        {
+            var entityNames = typeof(Account).Assembly.GetTypes()
+                .Where(t => t is { IsClass: true, IsPublic: true })
+                .Select(t => t.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return typeof(IStaticDto).Assembly.GetTypes()
+                .Where(p => typeof(IDto).IsAssignableFrom(p)
+                    && !typeof(IItemInstanceDto).IsAssignableFrom(p)
+                    && p.IsClass
+                    && p.Name.EndsWith("Dto")
+                    && entityNames.Contains(p.Name[..^3]));
+        }
+
         public static void RegisterDatabaseObject<TDto, TDb, TPk>(ContainerBuilder containerBuilder, bool isStatic)
         where TDb : class where TPk : struct
         {
@@ -75,23 +92,20 @@ namespace NosCore.Parser
             var assemblyDto = typeof(IStaticDto).Assembly.GetTypes();
             var assemblyDb = typeof(Account).Assembly.GetTypes();
 
-            assemblyDto.Where(p =>
-                    typeof(IDto).IsAssignableFrom(p) && !p.Name.Contains("InstanceDto") && p.IsClass)
-                .ToList()
-                .ForEach(t =>
-                {
-                    var type = assemblyDb.First(tgo =>
-                        string.Compare(t.Name, $"{tgo.Name}Dto", StringComparison.OrdinalIgnoreCase) == 0);
-                    var optionsBuilder = new DbContextOptionsBuilder<NosCoreContext>().UseInMemoryDatabase(
-                        Guid.NewGuid().ToString());
-                    var typepk = type.GetProperties()
-                        .Where(s => new NosCoreContext(optionsBuilder.Options).Model.FindEntityType(type)?
-                            .FindPrimaryKey()?.Properties.Select(x => x.Name)
-                            .Contains(s.Name) ?? false
-                        ).ToArray()[0];
-                    registerDatabaseObject?.MakeGenericMethod(t, type, typepk.PropertyType).Invoke(null,
-                        new[] { containerBuilder, (object)typeof(IStaticDto).IsAssignableFrom(t) });
-                });
+            foreach (var t in RegistrableDtoTypes())
+            {
+                var type = assemblyDb.First(tgo =>
+                    string.Compare(t.Name, $"{tgo.Name}Dto", StringComparison.OrdinalIgnoreCase) == 0);
+                var optionsBuilder = new DbContextOptionsBuilder<NosCoreContext>().UseInMemoryDatabase(
+                    Guid.NewGuid().ToString());
+                var typepk = type.GetProperties()
+                    .Where(s => new NosCoreContext(optionsBuilder.Options).Model.FindEntityType(type)?
+                        .FindPrimaryKey()?.Properties.Select(x => x.Name)
+                        .Contains(s.Name) ?? false
+                    ).ToArray()[0];
+                registerDatabaseObject?.MakeGenericMethod(t, type, typepk.PropertyType).Invoke(null,
+                    new[] { containerBuilder, (object)typeof(IStaticDto).IsAssignableFrom(t) });
+            }
 
             containerBuilder.RegisterType<Dao<ItemInstance, IItemInstanceDto?, Guid>>().As<IDao<IItemInstanceDto?, Guid>>()
                 .SingleInstance();

--- a/test/NosCore.Parser.Tests/ParserDaoContractTests.cs
+++ b/test/NosCore.Parser.Tests/ParserDaoContractTests.cs
@@ -12,6 +12,7 @@ using NosCore.Data.StaticEntities;
 using NosCore.Database;
 using NosCore.Database.Entities;
 using NosCore.Parser.Parsers;
+using NosCore.Parser;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,6 +36,7 @@ namespace NosCore.Parser.Tests
                 .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
             var model = context.Model;
 
+            var registrable = ParserBootstrap.RegistrableDtoTypes().ToHashSet();
             var mismatches = new List<string>();
             foreach (var parser in typeof(CardParser).Assembly.GetTypes()
                 .Where(t => t is { IsClass: true, IsAbstract: false, IsGenericType: false } && t.Name.EndsWith("Parser")))
@@ -60,6 +62,12 @@ namespace NosCore.Parser.Tests
                     if (!entities.TryGetValue(entityName, out var entityType))
                     {
                         mismatches.Add($"{parser.Name}: no entity found for {dtoType.Name}");
+                        continue;
+                    }
+
+                    if (!registrable.Contains(dtoType))
+                    {
+                        mismatches.Add($"{parser.Name}: {dtoType.Name} is not registered by ParserBootstrap");
                         continue;
                     }
 


### PR DESCRIPTION
Completes the parser startup fix: #2360 was merged before this second commit reached its branch, so master still crashes on `ScriptedInstanceParser` (the second screenshot the reporting user sent).

- The DAO registration filter excluded anything named `*InstanceDto*` to keep item instances out — which also swallowed **Scripted**InstanceDto, leaving its DAO unregistered and `ScriptedInstanceParser` unresolvable
- The filter is now type-based (`IItemInstanceDto` only, entity-paired) via `ParserBootstrap.RegistrableDtoTypes()`, and `ParserDaoContractTests` additionally asserts every parser's DAO parameter maps to a registered DTO

Verified before the branch split: parser starts against a fresh database, applies all 15 migrations (71 tables) and reaches dat parsing. Parser.Tests 140/140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic registration of data transfer types by matching them with their corresponding database entities.
  * Prevented item-instance types from being registered through the general process while preserving their dedicated handling.
  * Updated parser validation to accurately check registered types and avoid incorrect primary-key validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->