### PR TITLE
feat: ship the parser as a docker image

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -91,6 +91,20 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+    - name: Build, tag, and push image Parser
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ./deploy/Dockerfile
+        target: parser
+        push: true
+        tags: |
+          noscoreio/noscore.parser:latest
+          noscoreio/noscore.parser:${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Build, tag, and push image WorldServer
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v7

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,7 +6,8 @@ COPY src/ src/
 RUN --mount=type=cache,target=/root/.nuget/packages \
     dotnet publish src/NosCore.MasterServer -c Release -o /out/master \
     && dotnet publish src/NosCore.LoginServer -c Release -o /out/login \
-    && dotnet publish src/NosCore.WorldServer -c Release -o /out/world
+    && dotnet publish src/NosCore.WorldServer -c Release -o /out/world \
+    && dotnet publish src/NosCore.Parser -c Release -o /out/parser
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.24-amd64 AS base
 
@@ -35,3 +36,9 @@ COPY --from=build /out/world .
 USER $APP_UID
 EXPOSE 1337 5001
 ENTRYPOINT ["dotnet", "NosCore.WorldServer.dll"]
+
+FROM base AS parser
+COPY --from=build /out/parser .
+USER $APP_UID
+ENTRYPOINT ["dotnet", "NosCore.Parser.dll"]
+CMD ["--folder", "/dats"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,25 @@ services:
     volumes:
       - ./configuration/:/app/configuration
 
+  parser:
+    container_name: noscore-parser
+    profiles:
+      - tools
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - DB_HOST=db
+    build:
+      context: ./
+      dockerfile: deploy/Dockerfile
+      target: parser
+    networks:
+      - noscore-network
+    volumes:
+      - ./configuration/:/app/configuration
+      - ./dats:/dats
+
 networks:
   noscore-network:
     driver: bridge


### PR DESCRIPTION
The missing "update" path from the parser-crash saga: fixes could land on master, but the parser ships in **no artifact** — DockerHub only carries the three servers, and there are no releases or tags — so an affected user had no way to receive #2360/#2361 short of building from source.

- `deploy/Dockerfile` gains a `parser` target (Release publish, same runtime base, non-root, `ENTRYPOINT dotnet NosCore.Parser.dll`, default `CMD --folder /dats`)
- CI pushes **`noscoreio/noscore.parser:latest`** + `:sha` on master, same pattern as the servers
- compose gains an on-demand service behind the `tools` profile: `docker compose --profile tools run --rm parser` — waits for db health, `DB_HOST=db`, mounts `./configuration` and `./dats`

## Verification (real image runs)

Built the target and ran the container against a throwaway Postgres: DI resolves (post-#2361), all migrations apply, and execution reaches `ImportPacketsAsync` — failing only on the deliberately empty `/dats` mount. `docker compose config` valid.

After merge, master CI publishes the first parser image — that's the artifact to hand the reporting user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a containerized Parser service for local and deployed environments.
  * The Parser can process data from the mounted `dats` directory and configuration files.
  * Added automated Docker image publishing for master-branch builds.
  * The Parser service waits for the database to become healthy before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->