### PR TITLE
fix(npc): the monster info card carries the monster's name

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
     <PackageVersion Include="NosCore.Analyzers" Version="2.0.0" />
     <PackageVersion Include="NosCore.Dao" Version="5.0.0" />
     <PackageVersion Include="NosCore.Networking" Version="8.0.0" />
-    <PackageVersion Include="NosCore.Packets" Version="21.1.1" />
+    <PackageVersion Include="NosCore.Packets" Version="21.1.2" />
     <PackageVersion Include="NosCore.PathFinder" Version="2.1.0" />
     <PackageVersion Include="NosCore.Shared" Version="6.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />

--- a/src/NosCore.GameObject/Ecs/Extensions/NpcInfoExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/NpcInfoExtensions.cs
@@ -1,4 +1,4 @@
-//  __  _  __    __   ___ __  ___ ___
+﻿//  __  _  __    __   ___ __  ___ ___
 // |  \| |/__\ /' _/ / _//__\| _ \ __|
 // | | ' | \/ |`._`.| \_| \/ | v / _|
 // |_|\__|\__/ |___/ \__/\__/|_|_\___|
@@ -41,9 +41,7 @@ public static class NpcInfoExtensions
             DarkResistance = npc.DarkResistance,
             MaxHp = npc.MaxHp,
             MaxMp = npc.MaxMp,
-            // The serializer escapes a string field against the separator that follows it, and
-            // nothing follows this one, so the spaces have to go before it is handed over.
-            Name = npc.Name[language].Replace(' ', '^'),
+            Name = npc.Name[language],
         };
     }
 

--- a/src/NosCore.GameObject/Ecs/Extensions/NpcInfoExtensions.cs
+++ b/src/NosCore.GameObject/Ecs/Extensions/NpcInfoExtensions.cs
@@ -13,15 +13,6 @@ namespace NosCore.GameObject.Ecs.Extensions;
 
 public static class NpcInfoExtensions
 {
-    // Builds the e_info response for a req_info 5 (NPC) or req_info 6 (monster/mate).
-    // OpenNos's NpcMonster.GenerateEInfo AND Mate.GenerateEInfo both emit:
-    //   `e_info 10 <vnum> <level> <element> <attackClass> <elementRate> <atkUp>
-    //    <dmgMin> <dmgMax> <concentrate> <critChance> <critRate> <defUp> <closeDef>
-    //    <defDodge> <distDef> <distDodge> <magicDef> <fire> <water> <light> <dark>
-    //    <maxHp> <maxMp> -1 <name>`
-    // — the leading 10 is the format discriminator and the trailing -1 is a constant
-    // the client expects before the name field. Without either, the client can't align
-    // fields and falls back to defaults (Level=0, HP=100/100) in the target info card.
     public static EInfoNpcMonsterPacket GenerateNpcInfo(this NpcMonsterDto npc, RegionType language)
     {
         return new EInfoNpcMonsterPacket
@@ -50,6 +41,9 @@ public static class NpcInfoExtensions
             DarkResistance = npc.DarkResistance,
             MaxHp = npc.MaxHp,
             MaxMp = npc.MaxMp,
+            // The serializer escapes a string field against the separator that follows it, and
+            // nothing follows this one, so the spaces have to go before it is handed over.
+            Name = npc.Name[language].Replace(' ', '^'),
         };
     }
 

--- a/test/NosCore.GameObject.Tests/Ecs/Extensions/NpcInfoLineTests.cs
+++ b/test/NosCore.GameObject.Tests/Ecs/Extensions/NpcInfoLineTests.cs
@@ -1,0 +1,60 @@
+//  __  _  __    __   ___ __  ___ ___
+// |  \| |/__\ /' _/ / _//__\| _ \ __|
+// | | ' | \/ |`._`.| \_| \/ | v / _|
+// |_|\__|\__/ |___/ \__/\__/|_|_\___|
+//
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NosCore.Data.Dto;
+using NosCore.Data.StaticEntities;
+using NosCore.GameObject.Ecs.Extensions;
+using NosCore.Packets.Interfaces;
+using NosCore.Shared.Enumerations;
+using NosCore.Packets;
+
+namespace NosCore.GameObject.Tests.Ecs.Extensions
+{
+    [TestClass]
+    public class NpcInfoLineTests
+    {
+        private static readonly Serializer Wire = new(typeof(IPacket).Assembly.GetTypes()
+            .Where(p => p.GetInterfaces().Contains(typeof(IPacket)) && p.IsClass && !p.IsAbstract)
+            .ToList());
+
+        private static NpcMonsterDto Cuby()
+        {
+            var name = new I18NString
+            {
+                [RegionType.EN] = "Mother Cuby",
+                [RegionType.FR] = "Cuby Mere"
+            };
+
+            return new NpcMonsterDto
+            {
+                NpcMonsterVNum = 303,
+                Level = 35,
+                MaxHp = 1360,
+                MaxMp = 630,
+                Name = name
+            };
+        }
+
+        [TestMethod]
+        public void TheLineEndsWithThePortraitAndTheName()
+        {
+            var line = Wire.Serialize(new[] { (IPacket)Cuby().GenerateNpcInfo(RegionType.EN) }).TrimEnd();
+
+            Assert.IsTrue(line.EndsWith("-1 Mother^Cuby"), line);
+            Assert.AreEqual(26, line.Split(' ').Length - 1, line);
+        }
+
+        [TestMethod]
+        public void TheNameIsTheReadersLanguage()
+        {
+            var line = Wire.Serialize(new[] { (IPacket)Cuby().GenerateNpcInfo(RegionType.FR) }).TrimEnd();
+
+            Assert.IsTrue(line.EndsWith("-1 Cuby^Mere"), line);
+        }
+    }
+}


### PR DESCRIPTION
`GenerateNpcInfo` never assigns `Name`, so the field serialises as `-` and the
client draws a dash where the monster's name belongs. It compares field 25
against `@` and falls back when it does not match.

`Unknown` already defaults to `-1` in the packet class, so the rest of the line
was correct: `... 1360 630 -1 -`. The name is the only missing piece.

The `Replace(' ', '^')` is deliberate and meant to be deleted. `Name` is the
last field of the packet, and a last field is only escaped when it declares
`EscapeSpaces`. `EInfoNpcMonsterPacket.Name` does not, so the escaping has to
happen before the value is handed to the serialiser. Adding the flag belongs in
NosCore.Packets; once it ships, this line goes away. It matters in practice:
929 of the 1109 monster-info lines in a real capture carry a name with a space
in it, across 630 distinct names.

### What was tested

- A unit test on the **serialised** line, not on the object: it asserts the tail
  reads `-1 <name>` and that a spaced name arrives escaped. Written red first -
  without the assignment it fails on the dash.
- `dotnet build`: 0 warnings. `dotnet test NosCore.sln`: green, except
  `BCardVocabularyTests.EveryDeclaredEffectIsNamed`, which is marked
  `[TestCategory("OPTIONAL-TEST")]`, fails on `master` too, and is untouched by
  this branch.

### What was NOT tested

Not played. The NosCore servers are not started here, so there is no screenshot
of the info card. The client-side behaviour above is read from the client
binary, not observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NPC information packets now correctly preserve localized names, including names containing spaces.
  * English and French NPC names are serialized with the appropriate localization.

* **Tests**
  * Added coverage for NPC packet formatting, field counts, portrait data, and localized names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->