### PR TITLE
chore(tests): drop two comments from the equipment stats tests

### DIFF
--- a/test/NosCore.GameObject.Tests/Services/EquipmentService/EquipmentStatsServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/EquipmentService/EquipmentStatsServiceTests.cs
@@ -204,9 +204,6 @@ namespace NosCore.GameObject.Tests.Services.EquipmentService
         [TestMethod]
         public void AWeaponInTheBagCountsForNothing()
         {
-            // It was the clearest report of them all: "I attack with the sword but it uses the crossbow,
-            // which I am not even wearing". Only what is in the slots counts
-            // dell'equipaggiamento.
             var item = _items.Create(MainWeaponVnum, 1);
             _session.Character.InventoryService.AddItemToPocket(
                 InventoryItemInstance.Create(item, _session.Character.CharacterId),
@@ -214,12 +211,6 @@ namespace NosCore.GameObject.Tests.Services.EquipmentService
 
             Assert.AreEqual(EquipmentStats.None, _service.Resolve(_session.Character));
         }
-        // --- The effects declared by the pieces -----------------------------------------------
-        //
-        // A piece carries effects as well as numbers - "chance of poisoning", "defence increased
-        // by 25%". The parser already read them correctly from the official files and nobody ever
-        // looked at them again. The sibling codebase folds them in with GetStuffBuff.
-
         [TestMethod]
         public void AWornPieceCarriesItsDeclaredEffects()
         {


### PR DESCRIPTION
Follow-up to the equipment stats PR, applying the review note about comments to
what was already merged.

Both blocks say what the test names already say, and one had a stray Italian
word left in the middle of an English sentence.

### What was tested

`dotnet build`: 0 warnings. `dotnet test NosCore.sln`: green, except
`BCardVocabularyTests.EveryDeclaredEffectIsNamed`, which is marked
`[TestCategory("OPTIONAL-TEST")]`, fails on `master` too, and is untouched here.

### What was NOT tested

Nothing to play: comments only, no behaviour changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed outdated explanatory comments from equipment statistics tests.
  * No functional behavior or test coverage changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->