### PR TITLE
CLAUDE.md: the serializer owns the wire format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ noise to the line. Do not add it; the calls still in the tree are not a preceden
 **Keep semantic types.** Do not flatten a `bool` or an enum to a number because the wire
 value happens to be `0` or `1`; the serializer handles the conversion.
 
+**The serializer owns the wire format.** Never massage a value to fit it: no
+`Replace(' ', '^')` before assigning a field, no manual padding, no hand-built separator. A
+field that needs escaping says so on the packet property - `EscapeSpaces` for the one that
+ends the line - so the fix belongs in `NosCore.Packets` and ships as a version bump. A
+`Replace` here to make a packet come out right is a defect, including as a stopgap while
+the package catches up.
+
 **Ship only what is wired.** No placeholder enums, handlers or UI for behaviour that does
 not exist yet. A data file listing a field is not a reason to expose it.
 


### PR DESCRIPTION
## What

One rule under **Code conventions**, next to *Keep semantic types* — the same class of mistake, one level further along:

> **The serializer owns the wire format.** Never massage a value to fit it: no `Replace(' ', '^')` before assigning a field, no manual padding, no hand-built separator. A field that needs escaping says so on the packet property — `EscapeSpaces` for the one that ends the line — so the fix belongs in `NosCore.Packets` and ships as a version bump. A `Replace` here to make a packet come out right is a defect, including as a stopgap while the package catches up.

## Why

`GInfoPacket`, `MlInfoBrPacket` and `MlintroPacket` already declare `EscapeSpaces` for a last field that carries a value rather than free text. `EInfoNpcMonsterPacket.Name` did not, and #2365 was about to ship `Replace(' ', '^')` at the call site to compensate — knowingly, with a comment saying the flag belonged in the package. That shortcut is easy to reach for because it works, and it leaves the wire knowledge in two repos.

The packet side is fixed in NosCoreIO/NosCore.Packets#509, released as 21.1.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified code conventions for preserving serializer-owned wire formats.
  * Documented that escaping and formatting fixes should be addressed in the packet serialization layer rather than through manual value manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->