### PR TITLE
An offered item that left the inventory was duplicated

### DIFF
--- a/src/NosCore.GameObject/Services/ExchangeService/ExchangeService.cs
+++ b/src/NosCore.GameObject/Services/ExchangeService/ExchangeService.cs
@@ -11,6 +11,7 @@ using NosCore.Data.Enumerations.I18N;
 using NosCore.GameObject.Ecs.Extensions;
 using NosCore.GameObject.Ecs.Interfaces;
 using NosCore.GameObject.Networking.ClientSession;
+using NosCore.GameObject.Services.BroadcastService;
 using NosCore.GameObject.Services.InventoryService;
 using NosCore.GameObject.Services.ItemGenerationService;
 using NosCore.Packets.Enumerations;
@@ -28,7 +29,8 @@ namespace NosCore.GameObject.Services.ExchangeService
 {
     public class ExchangeService(IItemGenerationService itemBuilderService,
             IOptions<WorldConfiguration> worldConfiguration, ILogger<ExchangeService> logger, IExchangeRequestRegistry exchangeRegistry,
-            ILogLanguageLocalizer<LogLanguageKey> logLanguage, IGameLanguageLocalizer gameLanguageLocalizer)
+            ILogLanguageLocalizer<LogLanguageKey> logLanguage, IGameLanguageLocalizer gameLanguageLocalizer,
+            ISessionRegistry sessionRegistry)
         : IExchangeService
     {
         public void SetGold(long visualId, long gold, long bankGold)
@@ -204,10 +206,23 @@ namespace NosCore.GameObject.Services.ExchangeService
                 logger.LogError(logLanguage[LogLanguageKey.TRY_REMOVE_FAILED], data.Value);
             }
 
+            SetInExchange(data.Key, false);
+            SetInExchange(data.Value, false);
+
             return new ExcClosePacket
             {
                 Type = resultType
             };
+        }
+
+        // The lifecycle owns the flag. Set at the seven call sites instead, it was simply
+        // never set at all, which left every InExchangeOrShop guard inert.
+        private void SetInExchange(long visualId, bool value)
+        {
+            if (sessionRegistry.TryGetCharacter(c => c.VisualId == visualId, out var character))
+            {
+                character.InExchange = value;
+            }
         }
 
         public bool OpenExchange(long visualId, long targetVisualId)
@@ -222,6 +237,8 @@ namespace NosCore.GameObject.Services.ExchangeService
             exchangeRegistry.SetExchangeRequest(targetVisualId, visualId);
             exchangeRegistry.SetExchangeData(visualId, new ExchangeData());
             exchangeRegistry.SetExchangeData(targetVisualId, new ExchangeData());
+            SetInExchange(visualId, true);
+            SetInExchange(targetVisualId, true);
             return true;
         }
 
@@ -254,6 +271,21 @@ namespace NosCore.GameObject.Services.ExchangeService
                     var isFullTransfer = item.Value == item.Key.ItemInstance.Amount;
 
                     pendingTransfers.Add((originInventory, destInventory, item.Key, item.Value, targetId, sessionId, isFullTransfer));
+                }
+            }
+
+            // The offer captured these references when the item was put in the window. Confirm
+            // each is still there, at that amount, before anything is created: the destination
+            // item is built fresh, so a source that has since gone would duplicate it.
+            foreach (var transfer in pendingTransfers)
+            {
+                if (!transfer.OriginInventory.TryGetValue(transfer.OriginalItem.ItemInstanceId, out var live)
+                    || live.ItemInstance == null
+                    || live.ItemInstance.ItemVNum != transfer.OriginalItem.ItemInstance.ItemVNum
+                    || live.ItemInstance.Amount < transfer.Amount)
+                {
+                    logger.LogError(logLanguage[LogLanguageKey.INVALID_EXCHANGE]);
+                    return new List<KeyValuePair<long, IvnPacket>>();
                 }
             }
 

--- a/test/NosCore.GameObject.Tests/Services/ExchangeService/ExchangeServiceTests.cs
+++ b/test/NosCore.GameObject.Tests/Services/ExchangeService/ExchangeServiceTests.cs
@@ -56,7 +56,8 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
             };
 
             ItemProvider = new GameObject.Services.ItemGenerationService.ItemGenerationService(items, NullLoggerFactory.Instance, TestHelpers.Instance.LogLanguageLocalizer);
-            ExchangeProvider = new GameObject.Services.ExchangeService.ExchangeService(ItemProvider, WorldConfiguration, NullLogger<NosCore.GameObject.Services.ExchangeService.ExchangeService>.Instance, new ExchangeRequestRegistry(), TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer);
+            ExchangeProvider = new GameObject.Services.ExchangeService.ExchangeService(ItemProvider, WorldConfiguration, NullLogger<NosCore.GameObject.Services.ExchangeService.ExchangeService>.Instance, new ExchangeRequestRegistry(), TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer,
+                TestHelpers.Instance.SessionRegistry);
         }
 
         [TestMethod]
@@ -183,7 +184,8 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
             _sessionB = await TestHelpers.Instance.GenerateSessionAsync();
             _realExchange = new GameObject.Services.ExchangeService.ExchangeService(
                 ItemProvider!, WorldConfiguration!, NullLogger<NosCore.GameObject.Services.ExchangeService.ExchangeService>.Instance, new ExchangeRequestRegistry(),
-                TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer);
+                TestHelpers.Instance.LogLanguageLocalizer, TestHelpers.Instance.GameLanguageLocalizer,
+                TestHelpers.Instance.SessionRegistry);
             _realExchange.OpenExchange(_sessionA.Character.CharacterId, _sessionB.Character.VisualId);
         }
 
@@ -331,6 +333,31 @@ namespace NosCore.GameObject.Tests.Services.ExchangeService
             ExchangeProvider.AddItems(2, item2, 1);
             var itemList = ExchangeProvider.ProcessExchange(1, 2, inventory1, inventory2);
             Assert.IsTrue((itemList.Count(s => s.Key == 1) == 2) && (itemList.Count(s => s.Key == 2) == 2));
+        }
+
+        [TestMethod]
+        public void AnOfferedItemThatLeftTheInventoryDoesNotReachTheOtherSide()
+        {
+            IInventoryService giver =
+                new GameObject.Services.InventoryService.InventoryService(new List<ItemDto> { new Item { VNum = 1012, Type = NoscorePocketType.Main } },
+                    WorldConfiguration!, NullLogger<NosCore.GameObject.Services.InventoryService.InventoryService>.Instance);
+            IInventoryService receiver =
+                new GameObject.Services.InventoryService.InventoryService(new List<ItemDto> { new Item { VNum = 1012, Type = NoscorePocketType.Main } },
+                    WorldConfiguration!, NullLogger<NosCore.GameObject.Services.InventoryService.InventoryService>.Instance);
+
+            var offered = giver.AddItemToPocket(InventoryItemInstance.Create(ItemProvider!.Create(1012, 1), 0))!.First();
+
+            ExchangeProvider!.OpenExchange(1, 2);
+            ExchangeProvider.AddItems(1, offered, 1);
+
+            // The destination item is built fresh rather than moved, so dropping the offered
+            // item after putting it in the window used to hand over a second copy of it.
+            giver.Remove(offered.ItemInstanceId);
+
+            var itemList = ExchangeProvider.ProcessExchange(1, 2, giver, receiver);
+
+            Assert.AreEqual(0, itemList.Count, "a vanished offer must not transfer");
+            Assert.AreEqual(0, receiver.Count, "the receiver must not gain a duplicate");
         }
     }
 }


### PR DESCRIPTION
First of the two things from the audit. No new technology — the pieces were already here and simply not wired.

## The dupe

`PlayerStateComponent` declares `InShop` and `InExchange`, the ECS generates working setters for both, and **nothing in `src/` ever assigned either one**. They were permanently `false`, so five guards were inert:

| | what it was meant to stop |
|---|---|
| `WorldPacketHandlingStrategy:156` | the global `Scope.InTrade` gate |
| `RemovePacketHandler:25` | dropping an item mid-trade |
| `WearHandler:56` | equipping one |
| `BiPacketHandler:69` | destroying one |
| `VehicleHandler:41` | mounting |

That matters because `ProcessExchange` builds the destination item **fresh** rather than moving it, and `InventoryService : ConcurrentDictionary<Guid, …>`, so removing an item that has since gone returns `false` without complaint.

Offer an item → drop it → both confirm → the receiver gets a real item and the giver still has one.

## The fix

**The lifecycle owns the flag.** `OpenExchange` and `CloseExchange` set it for both parties, rather than each of the seven call sites remembering to — which is precisely how it came to never be set at all. `ExchangeService` takes `ISessionRegistry` to reach the two characters.

**Commit-time revalidation**, as defence in depth. `ProcessExchange` confirms every offer is still present at the offered amount before anything is created, so a trade whose subject vanished transfers nothing rather than half of it.

## Evidence

`AnOfferedItemThatLeftTheInventoryDoesNotReachTheOtherSide` offers an item, removes it from the giver, then processes. I removed the revalidation loop and re-ran: it fails with `a vanished offer must not transfer`, receiver count 1. With the fix, 0.

Solution builds. GameObject 538, PacketHandlers 413.

## Not in here

- The transfer still **recreates** rather than moves the instance. Moving it would make the dupe structurally impossible instead of guarded against; it is the right follow-up and a larger change. This is the only place in the codebase that recreates — warehouse and bazaar move instances.
- **`InShop` is still never set**, so the same five guards remain inert for player shops. Same fix, different lifecycle; kept separate so this one stays reviewable.
- There are still **no DB transactions anywhere** — no `BeginTransaction`, no `TransactionScope` — so a crash mid-exchange leaves it half-applied. Separate concern from the in-memory dupe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exchange participants are now correctly marked as being in an exchange while it is open.
  * Invalid or outdated item offers are rejected before transfers occur, preventing unintended item duplication or delivery.

* **Tests**
  * Added coverage for items removed from an inventory before exchange completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->