### PR TITLE
A bazaar listing could be sold twice across channels

### DIFF
--- a/src/NosCore.GameObject/Services/BazaarService/BazaarService.cs
+++ b/src/NosCore.GameObject/Services/BazaarService/BazaarService.cs
@@ -6,6 +6,8 @@
 
 using Json.More;
 using NodaTime;
+using NosCore.Core.Concurrency;
+using System.Collections.Concurrent;
 using NodaTime.Serialization.SystemTextJson;
 using NosCore.Dao.Interfaces;
 using NosCore.Data.Dto;
@@ -26,6 +28,13 @@ namespace NosCore.GameObject.Services.BazaarService
             IDao<IItemInstanceDto?, Guid> itemInstanceDao, IClock clock)
         : IBazaarService
     {
+        // Channels reach these through BazaarHub, and SignalR dispatches calls concurrently, so
+        // read-check-write on a listing is a lost update waiting to happen. One lock per listing
+        // rather than one for the bazaar, so unrelated trades still run in parallel.
+        private static readonly ConcurrentDictionary<long, AsyncLock> Claims = new();
+
+        private static AsyncLock ClaimLock(long id) => Claims.GetOrAdd(id, _ => new AsyncLock());
+
         public List<BazaarLink> GetBazaar(long id, byte? index, byte? pageSize, BazaarListType? typeFilter,
             byte? subTypeFilter, byte? levelFilter, byte? rareFilter, byte? upgradeFilter, long? sellerFilter)
         {
@@ -154,6 +163,7 @@ namespace NosCore.GameObject.Services.BazaarService
 
         public async Task<bool> DeleteBazaarAsync(long id, short count, string requestCharacterName, long? requestCharacterId = null)
         {
+            using var claim = await ClaimLock(id).AcquireAsync();
             var bzlink = bazaarRegistry.GetById(id);
             if (bzlink == null)
             {
@@ -243,6 +253,7 @@ namespace NosCore.GameObject.Services.BazaarService
 
         public async Task<BazaarLink?> ModifyBazaarAsync(long id, Json.Patch.JsonPatch bzMod)
         {
+            using var claim = await ClaimLock(id).AcquireAsync();
             var item = bazaarRegistry.GetById(id);
             if ((item?.BazaarItem == null) || (item.BazaarItem?.Amount != item.ItemInstance?.Amount))
             {

--- a/src/NosCore.PacketHandlers/Bazaar/CBuyPacketHandler.cs
+++ b/src/NosCore.PacketHandlers/Bazaar/CBuyPacketHandler.cs
@@ -55,21 +55,25 @@ namespace NosCore.PacketHandlers.Bazaar
                 {
                     if (clientSession.Character.Gold >= price)
                     {
-                        clientSession.Character.Gold -= price;
-                        await clientSession.SendPacketAsync(clientSession.Character.GenerateGold());
-
-                        var itemInstance = await itemInstanceDao.FirstOrDefaultAsync(s => s!.Id == bz.ItemInstance.Id);
-                        var item = itemProvider.Convert(itemInstance!);
-                        item.Id = Guid.NewGuid();
-                        var newInv =
-                            clientSession.Character.InventoryService.AddItemToPocket(
-                                InventoryItemInstance.Create(item, clientSession.Character.CharacterId));
-                        await clientSession.SendPacketAsync(newInv!.GeneratePocketChange());
-
+                        // Claim the listing before anything is paid for or created. The listing
+                        // is shared across channels, so two buyers can both pass the checks
+                        // above; only one can win this call, and the loser must leave with
+                        // neither the gold gone nor an item made.
                         var remove = await bazaarHttpClient.DeleteBazaarAsync(packet.BazaarId, packet.Amount,
                             clientSession.Character.Name);
                         if (remove)
                         {
+                            clientSession.Character.Gold -= price;
+                            await clientSession.SendPacketAsync(clientSession.Character.GenerateGold());
+
+                            var itemInstance = await itemInstanceDao.FirstOrDefaultAsync(s => s!.Id == bz.ItemInstance.Id);
+                            var item = itemProvider.Convert(itemInstance!);
+                            item.Id = Guid.NewGuid();
+                            var newInv =
+                                clientSession.Character.InventoryService.AddItemToPocket(
+                                    InventoryItemInstance.Create(item, clientSession.Character.CharacterId));
+                            await clientSession.SendPacketAsync(newInv!.GeneratePocketChange());
+
                             await clientSession.HandlePacketsAsync(new[] { new CBListPacket { Index = 0, ItemVNumFilter = new List<short>() } });
                             await clientSession.SendPacketAsync(new RCBuyPacket(bz.SellerName!)
                             {
@@ -95,7 +99,14 @@ namespace NosCore.PacketHandlers.Bazaar
                             return;
                         }
 
-                        logger.LogError(logLanguage[LogLanguageKey.BAZAAR_BUY_ERROR]);
+                        // Someone else took it first, most likely from another channel.
+                        logger.LogInformation(logLanguage[LogLanguageKey.BAZAAR_BUY_ERROR]);
+                        await clientSession.SendPacketAsync(new ModaliPacket
+                        {
+                            Type = 1,
+                            Message = Game18NConstString.OfferUpdated
+                        });
+                        await clientSession.HandlePacketsAsync(new[] { new CBListPacket { Index = 0, ItemVNumFilter = new List<short>() } });
                     }
                     else
                     {

--- a/test/NosCore.PacketHandlers.Tests/Bazaar/CBuyPacketHandlerTests.cs
+++ b/test/NosCore.PacketHandlers.Tests/Bazaar/CBuyPacketHandlerTests.cs
@@ -302,5 +302,22 @@ namespace NosCore.PacketHandlers.Tests.Bazaar
             var packet = (ModaliPacket?)Session.LastPackets.FirstOrDefault(s => s is ModaliPacket);
             Assert.IsTrue(packet?.Message == Game18NConstString.InsufficientGoldAvailable);
         }
+    
+        [TestMethod]
+        public async Task LosingTheRaceForAListingCostsNeitherGoldNorMakesAnItem()
+        {
+            // The listing lives on the master server and every channel reads it, so two buyers
+            // can both pass the price and amount checks. Only one wins the claim.
+            Session.Character.Gold = 500;
+            BazaarHttpClient!
+                .Setup(b => b.DeleteBazaarAsync(It.IsAny<long>(), It.IsAny<short>(), It.IsAny<string>(), It.IsAny<long?>()))
+                .ReturnsAsync(false);
+
+            await CbuyPacketHandler!.ExecuteAsync(new CBuyPacket { BazaarId = 0, Amount = 1, Price = 50 }, Session);
+
+            Assert.AreEqual(500, Session.Character.Gold, "the loser must keep their gold");
+            Assert.AreEqual(0, Session.Character.InventoryService.Count, "the loser must not receive an item");
+        }
+
     }
 }


### PR DESCRIPTION
Second of the two from the audit, and the one where the cross-channel and duplication concerns meet. Follows #2370, which fixed the same ordering mistake one layer in.

## The defect

`CBuyPacketHandler` delivered before it claimed:

1. `GetBazaar` — read the listing
2. deduct gold, **create the item, add it to the buyer's inventory**
3. `DeleteBazaarAsync` — only now claim it
4. on failure: `LogError(BAZAAR_BUY_ERROR)` and return, **no rollback**

The listing lives on the master server and every channel reads it, so two buyers on different channels both pass the price and amount checks at step 1 and both receive an item at step 2. Only one claim wins. The loser keeps the item *and* has paid for it — one listing, two items in the world.

The claim was not safe either. `DeleteBazaarAsync` and `ModifyBazaarAsync` read, check and write a listing with nothing serialising them, and SignalR dispatches hub calls concurrently, so even the claim could lose an update.

## The change

**Reserve, then fulfil.** The claim runs first and nothing is paid for or created unless it wins. The losing buyer keeps their gold, receives no item, and is told the offer changed — the old path left them staring at nothing while a line went into the log.

**A lock per listing id** on the master side, using the `AsyncLock` already in `NosCore.Core`. Per listing rather than per bazaar, so unrelated trades still run in parallel.

## Evidence

`LosingTheRaceForAListingCostsNeitherGoldNorMakesAnItem` makes the claim fail and asserts the buyer keeps their gold and gains nothing. I restored the old ordering and re-ran it: fails. With the fix: passes.

The happy path was already covered by `BuyingItemShouldSucceed`, so I dropped the duplicate I had written rather than add a second one.

Solution builds. PacketHandlers 414, GameObject 538.

## Still open from the audit

- **`InShop` is never assigned**, so the five `InExchangeOrShop` guards remain inert for player shops. Same shape as #2370, separate lifecycle.
- The exchange still **recreates** rather than moves the item instance; moving it would make that dupe structurally impossible instead of guarded.
- No DB transactions anywhere, so a crash mid-trade still half-applies.
- `PubSubHub.SendMessageAsync` fans out to `Clients.Others` — every channel receives every message and filters locally. Fine at this scale; there is no addressing to tighten later without changing the contract.
- `MasterClientList` is in-memory, so a master restart drops all subscriber state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bazaar purchase reliability when multiple buyers attempt to purchase the same listing.
  * Prevented duplicate purchases, incorrect gold deductions, and unintended item delivery.
  * Displays an updated-offer message and refreshes listings when an item is no longer available.
* **Tests**
  * Added coverage to verify that unsuccessful purchase attempts do not deduct gold or add items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->